### PR TITLE
New strategic icons behavior

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1331,7 +1331,8 @@ bool CGame::Draw() {
 
 	{
 		SCOPED_TIMER("Draw::Screen");
-		unitDrawer->DrawUnitIconsScreenArray();
+		if (unitDrawer->useScreenIcons)
+			unitDrawer->DrawUnitIconsScreen();
 
 		eventHandler.DrawScreenEffects();
 

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1331,6 +1331,7 @@ bool CGame::Draw() {
 
 	{
 		SCOPED_TIMER("Draw::Screen");
+		unitDrawer->DrawUnitIconsScreenArray();
 
 		eventHandler.DrawScreenEffects();
 

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -2734,20 +2734,34 @@ public:
 	}
 };
 
-class IconScaleActionExecutor : public IUnsyncedActionExecutor {
+class IconsAsUIActionExecutor : public IUnsyncedActionExecutor {
 public:
-	IconScaleActionExecutor() : IUnsyncedActionExecutor("IconScale",
-			"Set the multiplier for the size of the unit icons") {}
+	IconsAsUIActionExecutor() : IUnsyncedActionExecutor("IconsAsUI", "Set whether unit icons are drawn as an UI element (true) or old LOD-like style (false, default).") {
+	}
 
 	bool Execute(const UnsyncedAction& action) const final {
+		InverseOrSetBool(unitDrawer->useScreenIcons, action.GetArgs());
+		configHandler->Set("UnitIconsAsUI", unitDrawer->useScreenIcons ? 1 : 0);
+		LogSystemStatus("Draw unit icons as UI: ", unitDrawer->useScreenIcons);
+		return true;
+	}
+};
+
+class IconScaleActionExecutor : public IUnsyncedActionExecutor {
+public:
+	IconScaleActionExecutor() : IUnsyncedActionExecutor("IconScaleUI",
+			"Set the multiplier for the size of the UI unit icons") {}
+
+	bool Execute(const UnsyncedAction& action) const final
+	{
 		if (!action.GetArgs().empty()) {
 			const float iconScale = (float) atof(action.GetArgs().c_str());
-			unitDrawer->SetUnitIconScale(iconScale);
-			configHandler->Set("UnitIconScale", iconScale);
-			LOG("Set UnitIconScale to %f", iconScale);
-		} else {
-			LOG_L(L_WARNING, "/%s: wrong syntax", GetCommand().c_str());
+			unitDrawer->SetUnitIconScaleUI(iconScale);
+			configHandler->Set("UnitIconScaleUI", iconScale);
+			LOG("Set UnitIconScaleUI to %f", iconScale);
 		}
+		else
+			LOG("UnitIconScaleUI is %f", unitDrawer->GetUnitIconScaleUI());
 
 		return true;
 	}
@@ -2758,15 +2772,17 @@ public:
 	IconFadeStartActionExecutor() : IUnsyncedActionExecutor("IconFadeStart",
 			"Set the distance where unit icons became completely opaque at") {}
 
-	bool Execute(const UnsyncedAction& action) const final {
-		if (!action.GetArgs().empty()) {
+	bool Execute(const UnsyncedAction& action) const final
+	{
+		if (!action.GetArgs().empty())
+		{
 			const float iconFadeStart = (float) atof(action.GetArgs().c_str());
 			unitDrawer->SetUnitIconFadeStart(iconFadeStart);
 			configHandler->Set("UnitIconFadeStart", iconFadeStart);
 			LOG("Set UnitIconFadeStart to %f", iconFadeStart);
-		} else {
-			LOG_L(L_WARNING, "/%s: wrong syntax", GetCommand().c_str());
 		}
+		else
+			LOG("UnitIconFadeStart is %f", unitDrawer->GetUnitIconFadeStart());
 
 		return true;
 	}
@@ -2777,15 +2793,17 @@ public:
 	IconFadeVanishActionExecutor() : IUnsyncedActionExecutor("IconFadeVanish",
 			"Set the distance where unit icons fade out at") {}
 
-	bool Execute(const UnsyncedAction& action) const final {
-		if (!action.GetArgs().empty()) {
+	bool Execute(const UnsyncedAction& action) const final
+	{
+		if (!action.GetArgs().empty())
+		{
 			const float iconFadeVanish = (float) atof(action.GetArgs().c_str());
 			unitDrawer->SetUnitIconFadeVanish(iconFadeVanish);
 			configHandler->Set("UnitIconFadeVanish", iconFadeVanish);
 			LOG("Set UnitIconFadeVanish to %f", iconFadeVanish);
-		} else {
-			LOG_L(L_WARNING, "/%s: wrong syntax", GetCommand().c_str());
 		}
+		else
+			LOG("UnitIconFadeVanish is %f", unitDrawer->GetUnitIconFadeVanish());
 
 		return true;
 	}
@@ -3554,6 +3572,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<BufferTextActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<InputTextGeoActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DistIconActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<IconsAsUIActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<IconScaleActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<IconFadeStartActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<IconFadeVanishActionExecutor>());

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -2734,6 +2734,64 @@ public:
 	}
 };
 
+class IconScaleActionExecutor : public IUnsyncedActionExecutor {
+public:
+	IconScaleActionExecutor() : IUnsyncedActionExecutor("IconScale",
+			"Set the multiplier for the size of the unit icons") {}
+
+	bool Execute(const UnsyncedAction& action) const final {
+		if (!action.GetArgs().empty()) {
+			const float iconScale = (float) atof(action.GetArgs().c_str());
+			unitDrawer->SetUnitIconScale(iconScale);
+			configHandler->Set("UnitIconScale", iconScale);
+			LOG("Set UnitIconScale to %f", iconScale);
+		} else {
+			LOG_L(L_WARNING, "/%s: wrong syntax", GetCommand().c_str());
+		}
+
+		return true;
+	}
+};
+
+class IconFadeStartActionExecutor : public IUnsyncedActionExecutor {
+public:
+	IconFadeStartActionExecutor() : IUnsyncedActionExecutor("IconFadeStart",
+			"Set the distance where unit icons became completely opaque at") {}
+
+	bool Execute(const UnsyncedAction& action) const final {
+		if (!action.GetArgs().empty()) {
+			const float iconFadeStart = (float) atof(action.GetArgs().c_str());
+			unitDrawer->SetUnitIconFadeStart(iconFadeStart);
+			configHandler->Set("UnitIconFadeStart", iconFadeStart);
+			LOG("Set UnitIconFadeStart to %f", iconFadeStart);
+		} else {
+			LOG_L(L_WARNING, "/%s: wrong syntax", GetCommand().c_str());
+		}
+
+		return true;
+	}
+};
+
+class IconFadeVanishActionExecutor : public IUnsyncedActionExecutor {
+public:
+	IconFadeVanishActionExecutor() : IUnsyncedActionExecutor("IconFadeVanish",
+			"Set the distance where unit icons fade out at") {}
+
+	bool Execute(const UnsyncedAction& action) const final {
+		if (!action.GetArgs().empty()) {
+			const float iconFadeVanish = (float) atof(action.GetArgs().c_str());
+			unitDrawer->SetUnitIconFadeVanish(iconFadeVanish);
+			configHandler->Set("UnitIconFadeVanish", iconFadeVanish);
+			LOG("Set UnitIconFadeVanish to %f", iconFadeVanish);
+		} else {
+			LOG_L(L_WARNING, "/%s: wrong syntax", GetCommand().c_str());
+		}
+
+		return true;
+	}
+};
+
+
 class DistDrawActionExecutor : public IUnsyncedActionExecutor {
 public:
 	DistDrawActionExecutor() : IUnsyncedActionExecutor("DistDraw",
@@ -3496,6 +3554,9 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<BufferTextActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<InputTextGeoActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DistIconActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<IconScaleActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<IconFadeStartActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<IconFadeVanishActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DistDrawActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<LODScaleActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<AirMeshActionExecutor>());

--- a/rts/Rendering/UnitDrawer.cpp
+++ b/rts/Rendering/UnitDrawer.cpp
@@ -588,6 +588,8 @@ void CUnitDrawer::DrawUnitIconsScreen()
 				continue;
 			if (unit->IsInVoid())
 				continue;
+			if (unit->health <= 0 || unit->beingBuilt)
+				continue;
 			
 			const unsigned short closBits = (unit->losStatus[gu->myAllyTeam] & (LOS_INLOS                  ));
 			const unsigned short plosBits = (unit->losStatus[gu->myAllyTeam] & (LOS_PREVLOS | LOS_CONTRADAR));
@@ -751,6 +753,8 @@ void CUnitDrawer::DrawIconScreenArray(const CUnit* unit, bool useDefaultIcon, CV
 	const float dist = fastmath::sqrt_builtin(camera->GetPos().SqDistance(pos));
 
 	pos = camera->CalcWindowCoordinates(pos);
+	if (pos.z < 0)
+		return;
 	
 	// use white for selected units
 	const uint8_t* srcColor = unit->isSelected? color4::white: teamHandler.Team(unit->team)->color;

--- a/rts/Rendering/UnitDrawer.h
+++ b/rts/Rendering/UnitDrawer.h
@@ -205,7 +205,8 @@ public:
 
 private:
 	/// Returns true if the given unit should be drawn as icon in the current frame.
-	bool DrawAsIcon(CUnit* unit, const float sqUnitCamDist) const;
+	//bool DrawAsIcon(const CUnit* unit, const float sqUnitCamDist) const;
+	bool DrawAsIcon(CUnit* unit) const;
 
 	bool CanDrawOpaqueUnit(const CUnit* unit, bool drawReflection, bool drawRefraction) const;
 	bool CanDrawOpaqueUnitShadow(const CUnit* unit) const;

--- a/rts/Rendering/UnitDrawer.h
+++ b/rts/Rendering/UnitDrawer.h
@@ -144,15 +144,13 @@ public:
 		unitIconDist = dist;
 		iconLength = unitIconDist * unitIconDist * 750.0f;
 	}
-	static void SetUnitIconScale(float scale) {
-		iconScale = std::clamp(scale, 0.5f, 2.0f);
-	}
-	static void SetUnitIconFadeStart(float scale) {
-		iconFadeStart = std::clamp(scale, 1.0f, 10000.0f);
-	}
-	static void SetUnitIconFadeVanish(float scale) {
-		iconFadeVanish = std::clamp(scale, 1.0f, 10000.0f);
-	}
+
+	static float GetUnitIconScaleUI() { return iconScale; }
+	static float GetUnitIconFadeStart() { return iconFadeStart; }
+	static float GetUnitIconFadeVanish() { return iconFadeVanish; }
+	static void SetUnitIconScaleUI(float scale) { iconScale = std::clamp(scale, 0.5f, 2.0f); }
+	static void SetUnitIconFadeStart(float scale) { iconFadeStart = std::clamp(scale, 1.0f, 10000.0f); }
+	static void SetUnitIconFadeVanish(float scale) { iconFadeVanish = std::clamp(scale, 1.0f, 10000.0f); }
 
 	bool ShowUnitBuildSquare(const BuildInfo& buildInfo);
 	bool ShowUnitBuildSquare(const BuildInfo& buildInfo, const std::vector<Command>& commands);
@@ -205,8 +203,8 @@ public:
 
 private:
 	/// Returns true if the given unit should be drawn as icon in the current frame.
-	//bool DrawAsIcon(const CUnit* unit, const float sqUnitCamDist) const;
-	bool DrawAsIcon(CUnit* unit) const;
+	bool DrawAsIcon(const CUnit* unit, const float sqUnitCamDist) const;
+	bool DrawAsIconScreen(CUnit* unit) const;
 
 	bool CanDrawOpaqueUnit(const CUnit* unit, bool drawReflection, bool drawRefraction) const;
 	bool CanDrawOpaqueUnitShadow(const CUnit* unit) const;
@@ -229,12 +227,13 @@ private:
 
 public:
 	void DrawUnitIcons();
-	void DrawUnitIconsScreenArray();
+	void DrawUnitIconsScreen();
 	void DrawUnitMiniMapIcon(const CUnit* unit, CVertexArray* va) const;
 	void UpdateUnitDefMiniMapIcons(const UnitDef* ud);
 private:
 	void UpdateUnitMiniMapIcon(const CUnit* unit, bool forced, bool killed);
 	void UpdateUnitIconState(CUnit* unit);
+	void UpdateUnitIconStateScreen(CUnit* unit);
 
 	static void DrawIcon(CUnit* unit, bool asRadarBlip);
 	static void DrawIconScreenArray(const CUnit* unit, bool asRadarBlip, CVertexArray* va);
@@ -273,6 +272,7 @@ public:
 	float unitIconDist;
 	float iconLength;
 	float sqCamDistToGroundForIcons;
+	bool useScreenIcons = false;
 
 	// .x := regular unit alpha
 	// .y := ghosted unit alpha (out of radar)
@@ -287,12 +287,14 @@ private:
 
 	bool advShading;
 
+	bool useDistToGroundForIcons;
+
+	// "icons as UI" fields
 	static constexpr float iconSizeMult = 1 / 128.0f;
 	static float iconSizeBase;
 	static float iconScale;
 	static float iconFadeStart;
 	static float iconFadeVanish;
-	bool useDistToGroundForIcons;
 
 private:
 	typedef void (*DrawModelFunc)(const CUnit*, bool);

--- a/rts/Rendering/UnitDrawer.h
+++ b/rts/Rendering/UnitDrawer.h
@@ -144,6 +144,15 @@ public:
 		unitIconDist = dist;
 		iconLength = unitIconDist * unitIconDist * 750.0f;
 	}
+	static void SetUnitIconScale(float scale) {
+		iconScale = std::clamp(scale, 0.5f, 2.0f);
+	}
+	static void SetUnitIconFadeStart(float scale) {
+		iconFadeStart = std::clamp(scale, 1.0f, 10000.0f);
+	}
+	static void SetUnitIconFadeVanish(float scale) {
+		iconFadeVanish = std::clamp(scale, 1.0f, 10000.0f);
+	}
 
 	bool ShowUnitBuildSquare(const BuildInfo& buildInfo);
 	bool ShowUnitBuildSquare(const BuildInfo& buildInfo, const std::vector<Command>& commands);
@@ -196,7 +205,7 @@ public:
 
 private:
 	/// Returns true if the given unit should be drawn as icon in the current frame.
-	bool DrawAsIcon(const CUnit* unit, const float sqUnitCamDist) const;
+	bool DrawAsIcon(CUnit* unit, const float sqUnitCamDist) const;
 
 	bool CanDrawOpaqueUnit(const CUnit* unit, bool drawReflection, bool drawRefraction) const;
 	bool CanDrawOpaqueUnitShadow(const CUnit* unit) const;
@@ -219,6 +228,7 @@ private:
 
 public:
 	void DrawUnitIcons();
+	void DrawUnitIconsScreenArray();
 	void DrawUnitMiniMapIcon(const CUnit* unit, CVertexArray* va) const;
 	void UpdateUnitDefMiniMapIcons(const UnitDef* ud);
 private:
@@ -226,6 +236,7 @@ private:
 	void UpdateUnitIconState(CUnit* unit);
 
 	static void DrawIcon(CUnit* unit, bool asRadarBlip);
+	static void DrawIconScreenArray(const CUnit* unit, bool asRadarBlip, CVertexArray* va);
 	static void UpdateUnitDrawPos(CUnit* unit);
 
 public:
@@ -275,6 +286,11 @@ private:
 
 	bool advShading;
 
+	static constexpr float iconSizeMult = 1 / 128.0f;
+	static float iconSizeBase;
+	static float iconScale;
+	static float iconFadeStart;
+	static float iconFadeVanish;
 	bool useDistToGroundForIcons;
 
 private:

--- a/rts/Rendering/WorldDrawer.cpp
+++ b/rts/Rendering/WorldDrawer.cpp
@@ -390,6 +390,12 @@ void CWorldDrawer::DrawMiscObjects() const
 		}
 	}
 
+	// either draw from here, or make {Dyn,Bump}Water use blending
+	// pro: icons are drawn only once per frame, not every pass
+	// con: looks somewhat worse for underwater / obscured icons
+	if (!unitDrawer->useScreenIcons)
+		unitDrawer->DrawUnitIcons();
+
 	lineDrawer.DrawAll();
 	cursorIcons.Draw();
 

--- a/rts/Rendering/WorldDrawer.cpp
+++ b/rts/Rendering/WorldDrawer.cpp
@@ -390,11 +390,6 @@ void CWorldDrawer::DrawMiscObjects() const
 		}
 	}
 
-	// either draw from here, or make {Dyn,Bump}Water use blending
-	// pro: icons are drawn only once per frame, not every pass
-	// con: looks somewhat worse for underwater / obscured icons
-	unitDrawer->DrawUnitIcons();
-
 	lineDrawer.DrawAll();
 	cursorIcons.Draw();
 


### PR DESCRIPTION
Transition from solid unit to icon is much more smooth and fluent now. Different stages of the transition are all configurable.
There are 3 new configuration entries: UnitIconScale, UnitIconFadeStart and UnitIconFadeVanish, with handling "/setting x" commands.
