### PR TITLE
Some minor changes to icons

### DIFF
--- a/rts/Rendering/UnitDrawer.h
+++ b/rts/Rendering/UnitDrawer.h
@@ -236,7 +236,7 @@ private:
 	void UpdateUnitIconStateScreen(CUnit* unit);
 
 	static void DrawIcon(CUnit* unit, bool asRadarBlip);
-	static void DrawIconScreenArray(const CUnit* unit, bool asRadarBlip, const float dist, CVertexArray* va);
+	static void DrawIconScreenArray(const CUnit* unit, const icon::CIconData* icon, bool asRadarBlip, const float dist, CVertexArray* va);
 	static void UpdateUnitDrawPos(CUnit* unit);
 
 public:
@@ -296,6 +296,7 @@ private:
 	static float iconScale;
 	static float iconFadeStart;
 	static float iconFadeVanish;
+	static float iconZoomDist;
 
 private:
 	typedef void (*DrawModelFunc)(const CUnit*, bool);


### PR DESCRIPTION
- UnitIconsHideWithUI defaults to False;
- Always render unit models when icons are hidden;
- Show icons for ghosted buildings (scouted but no radar);
- Don't hide unit's model until icon is fully opaque;
- Some optimizations.