### PR TITLE
Fix amdHack that was broken by 149ea5c9476dc78cc6d05fafc5d3527c0e59997a

### DIFF
--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -392,7 +392,6 @@ void CProjectileDrawer::ViewResize()
 bool CProjectileDrawer::CheckSoftenExt()
 {
 	static bool result =
-		(!(globalRendering->amdHacks && Platform::GetOSFamilyStr() == "Linux")) &&
 		FBO::IsSupported() &&
 		GLEW_EXT_framebuffer_blit &&
 		globalRendering->haveGLSL; //eval once

--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -741,8 +741,8 @@ void CGlobalRendering::SetGLSupportFlags()
 	//TODO figure out if needed
 	if (globalRendering->amdHacks) {
 		supportDepthBufferBits[3] = false; //32
-		supportDepthBufferBits[2] = false; //24
-		supportDepthBufferBestBits = 16;
+		supportDepthBufferBits[1] = false; //16
+		supportDepthBufferBestBits = 24;
 	}
 }
 


### PR DESCRIPTION
Apparently 24-bit depth is the magic value for amdgpu.
https://github.com/beyond-all-reason/spring/issues/8