### PR TITLE
Fix depth check for non-fac seaplane buildability

### DIFF
--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -1365,8 +1365,7 @@ bool CGameHelper::CheckTerrainConstraints(
 			maxDepth = unitDef->maxWaterDepth;
 		} else {
 			// submerging or floating aircraft
-			maxDepth *= unitDef->canSubmerge;
-			maxDepth *= (1 - unitDef->floatOnWater);
+			maxDepth *= (unitDef->canSubmerge || unitDef->floatOnWater);
 		}
 	}
 


### PR DESCRIPTION
This is about placing standalone units, like from ZK strider hub.
See ZK Athena for an example of current broken behaviour (has `floater` but is not buildable on water).
ZeroK-RTS/Zero-K#4014

Before the patch:
 * neither `canSubmerge` nor `floater`: NOT buildable on water
 * just `canSubmerge`, but not `floater`: buildable on water
 * just `floater`, but not `canSubmerge`: NOT buildable on water
 * both `floater` and `canSubmerge`: NOT buildable on water

After the patch:
 * neither `canSubmerge` nor `floater`: NOT buildable on water
 * just `canSubmerge`, but not `floater`: buildable on water
 * just `floater`, but not `canSubmerge`: buildable on water
 * both `floater` and `canSubmerge`: buildable on water