### PR TITLE
Allow fallback for commands with different args

### DIFF
--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -471,7 +471,7 @@ bool CKeyBindings::Bind(const std::string& keystr, const std::string& line)
 		// check if the command is already found to the given keyset
 		bool found = false;
 		for (const Action& act: al) {
-			if (act.command == action.command) {
+			if (act.command == action.command && act.extra == action.extra) {
 				found = true;
 				break;
 			}


### PR DESCRIPTION
This change allows for commands on a same keyset to fallback when different arguments are present, e.g.:

```
bind Shift+z enqueueunit armck 5
bind Shift+z enqueueunit corck 5
```

Currently the engine deduplicates by command instead.