### PR TITLE
Fixed intermittent issue with building at high places

### DIFF
--- a/rts/Map/ReadMap.cpp
+++ b/rts/Map/ReadMap.cpp
@@ -548,27 +548,30 @@ void CReadMap::UpdateHeightMapSynced(const SRectangle& hgtMapRect, bool initiali
 
 void CReadMap::UpdateHeightBounds(int syncFrame)
 {
-	if (!updateHeightBounds)
-		return;
-
 	SCOPED_TIMER("ReadMap::UpdateHeightBounds");
 
 	constexpr int PACING_PERIOD = GAME_SPEED; //tune if needed
 	int dataChunk = syncFrame % PACING_PERIOD;
 
-	const int idxBeg = (dataChunk + 0) * mapDims.mapxp1 * mapDims.mapyp1 / PACING_PERIOD;
-	const int idxEnd = (dataChunk + 1) * mapDims.mapxp1 * mapDims.mapyp1 / PACING_PERIOD;
-	const int indCnt = idxEnd - idxBeg;
+	if (dataChunk == 0) {
+		processingHeightBounds = updateHeightBounds;
+		updateHeightBounds = false;
+	}
+
+	if (!processingHeightBounds)
+		return;
 
 	if (dataChunk == 0) {
-		if (syncFrame > 0) {
+		if (syncFrame > 0)
 			currHeightBounds = tempHeightBounds;
-			updateHeightBounds = false;
-		}
 
 		tempHeightBounds.x = std::numeric_limits<float>::max();
 		tempHeightBounds.y = std::numeric_limits<float>::lowest();
 	}
+
+	const int idxBeg = (dataChunk + 0) * mapDims.mapxp1 * mapDims.mapyp1 / PACING_PERIOD;
+	const int idxEnd = (dataChunk + 1) * mapDims.mapxp1 * mapDims.mapyp1 / PACING_PERIOD;
+	const int indCnt = idxEnd - idxBeg;
 
 #if 1
 	using SIMDVfloat = xsimd::simd_type<float>;

--- a/rts/Map/ReadMap.h
+++ b/rts/Map/ReadMap.h
@@ -275,6 +275,7 @@ private:
 
 	unsigned int mapChecksum = 0;
 
+	bool processingHeightBounds = false;
 	bool updateHeightBounds = false;
 
 	float2 initHeightBounds; //< initial minimum- and maximum-height (before any deformations)


### PR DESCRIPTION
The problem was that building a structure could trigger a mid-cycle limits sweep of the height map which could miss the true high/low points on a map. This change checks for map changes at the start of a limit sweep to ensure that the whole map is checked for high/low points and not just a part of the map. This change will also detect if the map changes during a sweep and issue a following sweep, just in case the height map change occurred in a part of the map we had already checked in the current sweep.