### PR TITLE
Fix build-position snapping

### DIFF
--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -580,9 +580,9 @@ void CBuilderCAI::ExecuteBuildCmd(Command& c)
 		}
 
 		#if 1
-		// snap build-position to multiples of SQUARE_SIZE plus a half-square offset (4, 12, 20, ...)
-		bi.pos.x = math::floor(c.GetParam(0) / SQUARE_SIZE + 0.5f) * SQUARE_SIZE;
-		bi.pos.z = math::floor(c.GetParam(2) / SQUARE_SIZE + 0.5f) * SQUARE_SIZE;
+		// snap build-position to multiples of SQUARE_SIZE
+		bi.pos.x = math::floor(c.GetParam(0) / SQUARE_SIZE) * SQUARE_SIZE;
+		bi.pos.z = math::floor(c.GetParam(2) / SQUARE_SIZE) * SQUARE_SIZE;
 		#endif
 
 		CFeature* f = nullptr;


### PR DESCRIPTION
BuildTest and Build positions are different.
![screen00007_1](https://user-images.githubusercontent.com/514675/123518861-8d692b00-d6b0-11eb-8af2-4b62aa93ebc2.jpg)
This may cause stuck constructor:
![screen00008_1](https://user-images.githubusercontent.com/514675/123518913-d4572080-d6b0-11eb-991f-6bfe27d3aacc.jpg)
```
-- known geo spot on Supreme Crossing V1
local bposx = 1100.000000
local bposz = 5860.000000
Spring.GiveOrderToUnit(unitID, -buildingDefID, { bposx, bposy, bposz, 0 }, {})
```
<= code will result in pictures above if geo spot position is not snapped to grid first.

PS. Frankly i'm not sure snapping at this place required at all: TestUnitBuildSquare is doing own snapping and Pos2BuildPos has own.
Hence `#if 1` => `#if 0` could be better