### PR TITLE
Add Spring.GetAllKeyBindings

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -2,6 +2,12 @@ Spring changelog
 (since 85.0 a "!" prefix indicates backward compatibility broke)
 (numbers in brackets normally mean the mantis ticket ID)
 
+-- 106.0 --------------------------------------------------------
+
+Lua:
+ - add Spring.GetAllKeyBindings with optional string argument to match command
+
+
 -- 105.0 --------------------------------------------------------
 Sim:
  - allow resurrecting indestructable features

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -305,6 +305,25 @@ void CKeyBindings::Kill()
 
 
 /******************************************************************************/
+const CKeyBindings::ActionList& CKeyBindings::GetActionList(const std::string& matcher) const
+{
+	static ActionList merged; //FIXME switch to thread_local (?)
+	const ActionList* alPtr;
+
+	for (const auto& p: bindings) {
+		const ActionList& al = p.second;
+
+		if (matcher.empty()) {
+			merged.insert(merged.end(), al.begin(), al.end());
+		} else {
+			std::copy_if(al.begin(), al.end(), std::back_inserter(merged), [matcher](Action a){ return a.command.rfind(matcher, 0) == 0; } );
+		}
+	}
+
+	alPtr = &merged;
+
+	return *alPtr;
+}
 
 const CKeyBindings::ActionList& CKeyBindings::GetActionList(const CKeySet& ks) const
 {

--- a/rts/Game/UI/KeyBindings.h
+++ b/rts/Game/UI/KeyBindings.h
@@ -27,6 +27,7 @@ class CKeyBindings : public CommandReceiver
 		bool Save(const std::string& filename) const;
 		void Print() const;
 
+		const ActionList& GetActionList(const std::string& matcher) const;
 		const ActionList& GetActionList(const CKeySet& ks) const;
 		const ActionList& GetActionList(const CKeyChain& kc) const;
 		const HotkeyList& GetHotkeys(const std::string& action) const;

--- a/rts/Lua/LuaIntro.cpp
+++ b/rts/Lua/LuaIntro.cpp
@@ -247,6 +247,7 @@ bool CLuaIntro::LoadUnsyncedReadFunctions(lua_State* L)
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyCode);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeySymbol);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyBindings);
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetAllKeyBindings);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetActionHotKeys);
 
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetLogSections);

--- a/rts/Lua/LuaMenu.cpp
+++ b/rts/Lua/LuaMenu.cpp
@@ -293,6 +293,7 @@ bool CLuaMenu::LoadUnsyncedReadFunctions(lua_State* L)
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyCode);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeySymbol);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyBindings);
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetAllKeyBindings);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetActionHotKeys);
 
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetLogSections);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -207,6 +207,7 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetKeyCode);
 	REGISTER_LUA_CFUNC(GetKeySymbol);
 	REGISTER_LUA_CFUNC(GetKeyBindings);
+	REGISTER_LUA_CFUNC(GetAllKeyBindings);
 	REGISTER_LUA_CFUNC(GetActionHotKeys);
 
 	REGISTER_LUA_CFUNC(GetLastMessagePositions);
@@ -2238,6 +2239,24 @@ int LuaUnsyncedRead::GetKeySymbol(lua_State* L)
 	return 2;
 }
 
+int LuaUnsyncedRead::GetAllKeyBindings(lua_State* L)
+{
+	const CKeyBindings::ActionList& actions = keyBindings.GetActionList(luaL_optstring(L, 1, ""));
+
+	int i = 1;
+	lua_newtable(L);
+	for (const Action& action: actions) {
+		lua_newtable(L);
+			lua_pushsstring(L, action.command);
+			lua_pushsstring(L, action.extra);
+			lua_rawset(L, -3);
+			LuaPushNamedString(L, "command",   action.command);
+			LuaPushNamedString(L, "extra",     action.extra);
+			LuaPushNamedString(L, "boundWith", action.boundWith);
+		lua_rawseti(L, -2, i++);
+	}
+	return 1;
+}
 
 int LuaUnsyncedRead::GetKeyBindings(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -140,6 +140,7 @@ class LuaUnsyncedRead {
 		static int GetKeyCode(lua_State* L);
 		static int GetKeySymbol(lua_State* L);
 		static int GetKeyBindings(lua_State* L);
+		static int GetAllKeyBindings(lua_State* L);
 		static int GetActionHotKeys(lua_State* L);
 
 		static int GetGroupList(lua_State* L);


### PR DESCRIPTION
With optional command prefix matcher argument

Before, the only way lua could read keybindings with full action data
was via GetKeyBindings, that requires a keyset argument.

This exposes all keybindings with full action data with an optional
argument to match on command prefix.