### PR TITLE
Allow empty argument to GetKeyBindings instead

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -5,7 +5,7 @@ Spring changelog
 -- 106.0 --------------------------------------------------------
 
 Lua:
- - add Spring.GetAllKeyBindings with optional string argument to match command
+ - allow empty argument for Spring.GetKeyBindings to return all keybindings
 
 
 -- 105.0 --------------------------------------------------------

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -305,7 +305,7 @@ void CKeyBindings::Kill()
 
 
 /******************************************************************************/
-const CKeyBindings::ActionList& CKeyBindings::GetActionList(const std::string& matcher) const
+const CKeyBindings::ActionList& CKeyBindings::GetActionList() const
 {
 	static ActionList merged; //FIXME switch to thread_local (?)
 	const ActionList* alPtr;
@@ -313,11 +313,7 @@ const CKeyBindings::ActionList& CKeyBindings::GetActionList(const std::string& m
 	for (const auto& p: bindings) {
 		const ActionList& al = p.second;
 
-		if (matcher.empty()) {
-			merged.insert(merged.end(), al.begin(), al.end());
-		} else {
-			std::copy_if(al.begin(), al.end(), std::back_inserter(merged), [matcher](Action a){ return a.command.rfind(matcher, 0) == 0; } );
-		}
+		merged.insert(merged.end(), al.begin(), al.end());
 	}
 
 	alPtr = &merged;

--- a/rts/Game/UI/KeyBindings.h
+++ b/rts/Game/UI/KeyBindings.h
@@ -27,7 +27,7 @@ class CKeyBindings : public CommandReceiver
 		bool Save(const std::string& filename) const;
 		void Print() const;
 
-		const ActionList& GetActionList(const std::string& matcher) const;
+		const ActionList& GetActionList() const;
 		const ActionList& GetActionList(const CKeySet& ks) const;
 		const ActionList& GetActionList(const CKeyChain& kc) const;
 		const HotkeyList& GetHotkeys(const std::string& action) const;

--- a/rts/Lua/LuaIntro.cpp
+++ b/rts/Lua/LuaIntro.cpp
@@ -247,7 +247,6 @@ bool CLuaIntro::LoadUnsyncedReadFunctions(lua_State* L)
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyCode);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeySymbol);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyBindings);
-	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetAllKeyBindings);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetActionHotKeys);
 
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetLogSections);

--- a/rts/Lua/LuaMenu.cpp
+++ b/rts/Lua/LuaMenu.cpp
@@ -293,7 +293,6 @@ bool CLuaMenu::LoadUnsyncedReadFunctions(lua_State* L)
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyCode);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeySymbol);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyBindings);
-	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetAllKeyBindings);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetActionHotKeys);
 
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetLogSections);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -207,7 +207,6 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetKeyCode);
 	REGISTER_LUA_CFUNC(GetKeySymbol);
 	REGISTER_LUA_CFUNC(GetKeyBindings);
-	REGISTER_LUA_CFUNC(GetAllKeyBindings);
 	REGISTER_LUA_CFUNC(GetActionHotKeys);
 
 	REGISTER_LUA_CFUNC(GetLastMessagePositions);
@@ -2239,33 +2238,21 @@ int LuaUnsyncedRead::GetKeySymbol(lua_State* L)
 	return 2;
 }
 
-int LuaUnsyncedRead::GetAllKeyBindings(lua_State* L)
-{
-	const CKeyBindings::ActionList& actions = keyBindings.GetActionList(luaL_optstring(L, 1, ""));
-
-	int i = 1;
-	lua_newtable(L);
-	for (const Action& action: actions) {
-		lua_newtable(L);
-			lua_pushsstring(L, action.command);
-			lua_pushsstring(L, action.extra);
-			lua_rawset(L, -3);
-			LuaPushNamedString(L, "command",   action.command);
-			LuaPushNamedString(L, "extra",     action.extra);
-			LuaPushNamedString(L, "boundWith", action.boundWith);
-		lua_rawseti(L, -2, i++);
-	}
-	return 1;
-}
-
 int LuaUnsyncedRead::GetKeyBindings(lua_State* L)
 {
-	CKeySet ks;
+	CKeyBindings::ActionList actions;
+	const std::string& argument = luaL_optstring(L, 1, "");
 
-	if (!ks.Parse(luaL_checksstring(L, 1)))
-		return 0;
+	if (argument.empty()) {
+		actions = keyBindings.GetActionList();
+	} else {
+		CKeySet ks;
 
-	const CKeyBindings::ActionList& actions = keyBindings.GetActionList(ks);
+		if (!ks.Parse(luaL_checksstring(L, 1)))
+			return 0;
+
+		actions = keyBindings.GetActionList(ks);
+	}
 
 	int i = 1;
 	lua_newtable(L);

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -140,7 +140,6 @@ class LuaUnsyncedRead {
 		static int GetKeyCode(lua_State* L);
 		static int GetKeySymbol(lua_State* L);
 		static int GetKeyBindings(lua_State* L);
-		static int GetAllKeyBindings(lua_State* L);
 		static int GetActionHotKeys(lua_State* L);
 
 		static int GetGroupList(lua_State* L);


### PR DESCRIPTION
Keep the API concise, the prefix matching is not essential for perf for
the use cases it would use anyways. Keybinding check would be done at
sparse callins or initialization