### PR TITLE
Tarnished knight mt path requests

### DIFF
--- a/rts/Sim/CMakeLists.txt
+++ b/rts/Sim/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(engineSim STATIC
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/QTPFS/PathCache.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/QTPFS/PathSearch.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/QTPFS/PathManager.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Path/TKPFS/PathingState.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/TKPFS/PathEstimator.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/TKPFS/PathHeatMap.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/TKPFS/PathManager.cpp"

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -635,7 +635,7 @@ void CGroundMoveType::StartMoving(float3 moveGoalPos, float moveGoalRadius) {
 	// units passing intermediate waypoints will TYPICALLY not cause any
 	// script->{Start,Stop}Moving calls now (even when turnInPlace=true)
 	// unless they come to a full stop first
-	ReRequestPath(false);
+	ReRequestPath(true);
 
 	if (owner->team == gu->myTeam)
 		Channels::General->PlayRandomSample(owner->unitDef->sounds.activate, owner);

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -92,7 +92,7 @@ public:
 	const float3& GetGroundNormal(const float3&) const;
 	float GetGroundHeight(const float3&) const;
 
-	void DelayedReRequestPath() { if (wantRepath) { ReRequestPath(true); } }
+	void DelayedReRequestPath() { if (wantRepath) { DoReRequestPath(); } }
 
 private:
 	float3 GetObstacleAvoidanceDir(const float3& desiredDir);
@@ -112,6 +112,7 @@ private:
 	void SetNextWayPoint();
 	bool CanSetNextWayPoint();
 	void ReRequestPath(bool forceRequest);
+	void DoReRequestPath();
 
 	void StartEngine(bool callScript);
 	void StopEngine(bool callScript, bool hardStop = false);
@@ -213,7 +214,6 @@ private:
 
 	bool atGoal = false;
 	bool atEndOfPath = false;
-	bool wantRepath = false;
 
 	bool reversing = false;
 	bool idling = false;

--- a/rts/Sim/MoveTypes/MoveType.h
+++ b/rts/Sim/MoveTypes/MoveType.h
@@ -13,6 +13,13 @@
 
 class CUnit;
 
+// Note bit patterns
+enum PathRequestType {
+	PATH_REQUEST_NONE = 0,
+	PATH_REQUEST_DELAYED = 1,
+	PATH_REQUEST_IMMEDIATE = 2,
+};
+
 class AMoveType : public CObject
 {
 	CR_DECLARE(AMoveType)
@@ -81,6 +88,7 @@ public:
 	float CalcScriptMoveRate(float speed, float nsteps) const { return Clamp(math::floor((speed / maxSpeed) * nsteps), 0.0f, nsteps - 1.0f); }
 	float CalcStaticTurnRadius() const;
 
+	virtual PathRequestType WantsReRequestPath() const { return wantRepath; }
 	virtual void DelayedReRequestPath() {}
 
 public:
@@ -107,6 +115,8 @@ protected:
 
 	bool useHeading = true;
 	bool useWantedSpeed[2] = {true, true};  // if false, SelUnitsAI will not (re)set wanted-speed for {[0] := individual, [1] := formation} orders
+
+	PathRequestType wantRepath = PATH_REQUEST_NONE;
 };
 
 #endif // MOVETYPE_H

--- a/rts/Sim/Path/TKPFS/PathEstimator.cpp
+++ b/rts/Sim/Path/TKPFS/PathEstimator.cpp
@@ -35,9 +35,6 @@
 
 namespace TKPFS {
 
-CONFIG(int, PathingThreadCount).defaultValue(0).safemodeValue(1).minimumValue(0);
-CONFIG(int, MaxPathCostsMemoryFootPrint).defaultValue(512).minimumValue(64).description("Maximum memusage (in MByte) of multithreaded pathcache generator at loading time.");
-
 PCMemPool pcMemPool;
 PEMemPool peMemPool;
 

--- a/rts/Sim/Path/TKPFS/PathManager.h
+++ b/rts/Sim/Path/TKPFS/PathManager.h
@@ -23,6 +23,7 @@ struct MoveDef;
 namespace TKPFS {
 class CPathEstimator;
 class PathHeatMap;
+class PathingState;
 
 class CPathManager: public IPathManager {
 public:
@@ -233,6 +234,8 @@ private:
 	CPathFinder* maxResPFs;
 
 	std::vector<IPathFinder*> pathFinders;
+
+	PathingState* pathingStates;
 };
 
 }

--- a/rts/Sim/Path/TKPFS/PathingState.cpp
+++ b/rts/Sim/Path/TKPFS/PathingState.cpp
@@ -1,0 +1,9 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "PathingState.h"
+
+namespace TKPFS {
+
+
+
+}

--- a/rts/Sim/Path/TKPFS/PathingState.h
+++ b/rts/Sim/Path/TKPFS/PathingState.h
@@ -1,0 +1,18 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef TKPFS_PATHINGSTATESYSTEM_H
+#define TKPFS_PATHINGSTATESYSTEM_H
+
+namespace TKPFS {
+
+class PathingState {
+public:
+
+    void Init() {};
+
+    void Terminate() {};
+};
+
+}
+
+#endif


### PR DESCRIPTION
Corrected temp checksum calculation so that it doesn't create a false negative at match start.

User and AI commands to units may result in pathing request that have to be processed immediately (not by SlowUpdate) - I have updated the MT Reqs to support this.

Improved utilization of workthreads for pathing requests, which significantly improves their performance.

Note: work has begun on splitting out code/data shared between Estimators in a PathingState class. This is ongoing effort.