### PR TITLE
Fix to https://github.com/beyond-all-reason/spring/issues/74

### DIFF
--- a/rts/Sim/Projectiles/WeaponProjectiles/BeamLaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/BeamLaserProjectile.cpp
@@ -85,7 +85,7 @@ void CBeamLaserProjectile::Update()
 			edgeColEnd[i]   *= decay;
 		}
 
-		explGenHandler.GenExplosion(cegID, startPos + ((targetPos - startPos) / ttl), (targetPos - startPos), 0.0f, flaresize, 0.0f, NULL, NULL);
+		explGenHandler.GenExplosion(cegID, startPos + ((targetPos - startPos) / ttl), (targetPos - startPos), 0.0f, flaresize, 0.0f, owner(), nullptr);
 	}
 
 	UpdateInterception();

--- a/rts/Sim/Projectiles/WeaponProjectiles/EmgProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/EmgProjectile.cpp
@@ -49,7 +49,7 @@ void CEmgProjectile::Update()
 		intensity -= 0.1f;
 		intensity = std::max(intensity, 0.0f);
 	} else {
-		explGenHandler.GenExplosion(cegID, pos, speed, ttl, intensity, 0.0f, nullptr, nullptr);
+		explGenHandler.GenExplosion(cegID, pos, speed, ttl, intensity, 0.0f, owner(), nullptr);
 	}
 
 	UpdateGroundBounce();

--- a/rts/Sim/Projectiles/WeaponProjectiles/ExplosiveProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/ExplosiveProjectile.cpp
@@ -49,7 +49,7 @@ void CExplosiveProjectile::Update()
 		Collision();
 	} else {
 		if (ttl > 0)
-			explGenHandler.GenExplosion(cegID, pos, speed, ttl, damages->damageAreaOfEffect, 0.0f, nullptr, nullptr);
+			explGenHandler.GenExplosion(cegID, pos, speed, ttl, damages->damageAreaOfEffect, 0.0f, owner(), nullptr);
 	}
 
 	curTime += invttl;

--- a/rts/Sim/Projectiles/WeaponProjectiles/FireBallProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FireBallProjectile.cpp
@@ -131,7 +131,7 @@ void CFireBallProjectile::TickSparks()
 		i++;
 	}
 
-	explGenHandler.GenExplosion(cegID, pos, speed, ttl, (numSparks > 0)? sparks[0].size: 0.0f, 0.0f, nullptr, nullptr);
+	explGenHandler.GenExplosion(cegID, pos, speed, ttl, (numSparks > 0)? sparks[0].size: 0.0f, 0.0f, owner(), nullptr);
 }
 
 

--- a/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
@@ -67,7 +67,7 @@ void CFlameProjectile::Update()
 	checkCol &= (curTime <= physLife);
 	deleteMe |= (curTime >= 1.0f);
 
-	explGenHandler.GenExplosion(cegID, pos, speed, curTime, 0.0f, 0.0f, nullptr, nullptr);
+	explGenHandler.GenExplosion(cegID, pos, speed, curTime, 0.0f, 0.0f, owner(), nullptr);
 }
 
 void CFlameProjectile::Draw(CVertexArray* va)

--- a/rts/Sim/Projectiles/WeaponProjectiles/LargeBeamLaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LargeBeamLaserProjectile.cpp
@@ -80,7 +80,7 @@ void CLargeBeamLaserProjectile::Update()
 			edgeColStart[i] = (unsigned char) (edgeColStart[i] * decay);
 		}
 
-		explGenHandler.GenExplosion(cegID, startPos + ((targetPos - startPos) / ttl), (targetPos - startPos), 0.0f, flaresize, 0.0f, NULL, NULL);
+		explGenHandler.GenExplosion(cegID, startPos + ((targetPos - startPos) / ttl), (targetPos - startPos), 0.0f, flaresize, 0.0f, owner(), nullptr);
 	}
 
 	UpdateInterception();

--- a/rts/Sim/Projectiles/WeaponProjectiles/LaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LaserProjectile.cpp
@@ -76,7 +76,7 @@ void CLaserProjectile::Update()
 
 void CLaserProjectile::UpdateIntensity() {
 	if (ttl > 0) {
-		explGenHandler.GenExplosion(cegID, pos, speed, ttl, intensity, 0.0f, NULL, NULL);
+		explGenHandler.GenExplosion(cegID, pos, speed, ttl, intensity, 0.0f, owner(), nullptr);
 		return;
 	}
 

--- a/rts/Sim/Projectiles/WeaponProjectiles/LightningProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LightningProjectile.cpp
@@ -44,7 +44,7 @@ void CLightningProjectile::Update()
 	if (--ttl <= 0) {
 		deleteMe = true;
 	} else {
-		explGenHandler.GenExplosion(cegID, startPos + ((targetPos - startPos) / ttl), (targetPos - startPos), 0.0f, displacements[0], 0.0f, NULL, NULL);
+		explGenHandler.GenExplosion(cegID, startPos + ((targetPos - startPos) / ttl), (targetPos - startPos), 0.0f, displacements[0], 0.0f, owner(), nullptr);
 	}
 
 	for (size_t d = 1; d < displacements_size; ++d) {

--- a/rts/Sim/Projectiles/WeaponProjectiles/MissileProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/MissileProjectile.cpp
@@ -186,7 +186,7 @@ void CMissileProjectile::Update()
 			SetDirectionAndSpeed(dir, speed.w);
 		}
 
-		explGenHandler.GenExplosion(cegID, pos, dir, ttl, damages->damageAreaOfEffect, 0.0f, NULL, NULL);
+		explGenHandler.GenExplosion(cegID, pos, dir, ttl, damages->damageAreaOfEffect, 0.0f, owner(), nullptr);
 	} else {
 		if (weaponDef->selfExplode) {
 			Collision();

--- a/rts/Sim/Projectiles/WeaponProjectiles/StarburstProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/StarburstProjectile.cpp
@@ -141,7 +141,7 @@ void CStarburstProjectile::Update()
 	}
 
 	if (ttl > 0)
-		explGenHandler.GenExplosion(cegID, pos, dir, ttl, damages->damageAreaOfEffect, 0.0f, nullptr, nullptr);
+		explGenHandler.GenExplosion(cegID, pos, dir, ttl, damages->damageAreaOfEffect, 0.0f, owner(), nullptr);
 
 	UpdateTracerPart();
 	UpdateSmokeTrail();

--- a/rts/Sim/Projectiles/WeaponProjectiles/TorpedoProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/TorpedoProjectile.cpp
@@ -126,7 +126,7 @@ void CTorpedoProjectile::Update()
 				CWorldObject::SetVelocity(targetHitVel);
 			}
 
-			explGenHandler.GenExplosion(cegID, pos, speed, ttl, damages->damageAreaOfEffect, 0.0f, nullptr, nullptr);
+			explGenHandler.GenExplosion(cegID, pos, speed, ttl, damages->damageAreaOfEffect, 0.0f, owner(), nullptr);
 		} else {
 			if (!luaMoveCtrl) {
 				// must update dir and speed.w here


### PR DESCRIPTION
Added owner() instead of nullptr in most explGenHandler.GenExplosion calls, such that CEGs inherit teamID of calling projectile and therefore are visible as allied

Partially fixes https://github.com/beyond-all-reason/spring/issues/74