### PR TITLE
Update BARbarIAn. Build with custom profiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,8 @@ jobs:
           cd spring
           git fetch --tags --all
           git clone https://github.com/${GITHUB_REPOSITORY_OWNER}/mingwlibs64.git mingwlibs64
+          cd AI/Skirmish/BARb
+          git clone -b profile --single-branch https://github.com/${GITHUB_REPOSITORY_OWNER}/BARbarIAn.git profile
 
       - name: Clone Repository and Dependencies (windows-32)
         if: steps.cache.outputs.cache-hit != 'true' && matrix.config.os == 'windows-32'
@@ -194,6 +196,8 @@ jobs:
           cd spring
           git fetch --tags --all
           git clone https://github.com/spring/mingwlibs.git mingwlibs
+          cd AI/Skirmish/BARb
+          git clone -b profile --single-branch https://github.com/${GITHUB_REPOSITORY_OWNER}/BARbarIAn.git profile
 
       - name: Clone Repository and Dependencies (linux-64)
         if: steps.cache.outputs.cache-hit != 'true' && matrix.config.os == 'linux-64'
@@ -205,6 +209,8 @@ jobs:
           git fetch --tags --all
           UBUNTU_VER=$(echo ${{ matrix.config.runs-on }} | cut -d'-' -f2)
           git clone https://github.com/${GITHUB_REPOSITORY_OWNER}/spring-static-libs.git -b $UBUNTU_VER spring-static-libs
+          cd AI/Skirmish/BARb
+          git clone -b profile --single-branch https://github.com/${GITHUB_REPOSITORY_OWNER}/BARbarIAn.git profile
 
       - name: Create Build Folders
         run: |
@@ -395,6 +401,12 @@ jobs:
           mkdir -p ./bin-dir/AI/Skirmish/BARb/stable/
           cp -R ./AI/Skirmish/BARb/data/* ./bin-dir/AI/Skirmish/BARb/stable/
           cp -R ../AI/Skirmish/BARb/data/* ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ./AI/Skirmish/BARb/profile/AIOptions.lua ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ../AI/Skirmish/BARb/profile/AIOptions.lua ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ./AI/Skirmish/BARb/profile/config/ ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ../AI/Skirmish/BARb/profile/config/ ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ./AI/Skirmish/BARb/profile/script/ ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ../AI/Skirmish/BARb/profile/script/ ./bin-dir/AI/Skirmish/BARb/stable/
         working-directory: ${{ github.workspace }}/spring/build-${{ matrix.config.os }}
         shell: bash
 
@@ -435,6 +447,12 @@ jobs:
           mkdir -p ./bin-dir/AI/Skirmish/BARb/stable/
           cp -R ./AI/Skirmish/BARb/data/* ./bin-dir/AI/Skirmish/BARb/stable/
           cp -R ../AI/Skirmish/BARb/data/* ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ./AI/Skirmish/BARb/profile/AIOptions.lua ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ../AI/Skirmish/BARb/profile/AIOptions.lua ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ./AI/Skirmish/BARb/profile/config/ ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ../AI/Skirmish/BARb/profile/config/ ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ./AI/Skirmish/BARb/profile/script/ ./bin-dir/AI/Skirmish/BARb/stable/
+          cp -R ../AI/Skirmish/BARb/profile/script/ ./bin-dir/AI/Skirmish/BARb/stable/
         working-directory: ${{ github.workspace }}/spring/build-${{ matrix.config.os }}
         shell: bash
 


### PR DESCRIPTION
Description:
1) Clone additional beyond-all-reason/BARbarIAn.git repository inside BARb folder during "clone" stage.
2) Replace BARb's config files with those from beyond-all-reason/BARbarIAn.git (branch = profile) during "Fill Portable Directory" stage.

Is changing  .github/workflows/build.yml enough to apply additional build steps?
Is such approach acceptable?