### PR TITLE
setspeed command to set game speed directly

### DIFF
--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -1775,7 +1775,7 @@ public:
 class SetGamespeedActionExecutor : public IUnsyncedActionExecutor {
 public:
 	SetGamespeedActionExecutor() : IUnsyncedActionExecutor(
-		"GameSpeed",
+		"SetSpeed",
 		"Set the simulation speed to any positive value, bounded my minimum and maximum game speed settings."
 	) {}
 

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -1772,7 +1772,26 @@ public:
 	}
 };
 
+class SetGamespeedActionExecutor : public IUnsyncedActionExecutor {
+public:
+	SetGamespeedActionExecutor() : IUnsyncedActionExecutor(
+		"GameSpeed",
+		"Set the simulation speed, bounded my minimum and maximum game speed settings."
+	) {}
 
+	bool Execute(const UnsyncedAction& action) const final {
+		if ((action.GetArgs()).empty())
+			return false;
+
+		float minSpeed = gs->minUserSped;
+		float maxSpeed = gs->maxUserSped;
+		float speed = atof((action.GetArgs()).c_str());
+		speed = Clamp(speed, minSpeed, maxSpeed)
+
+		clientNet->Send(CBaseNetProtocol::Get().SendUserSpeed(gu->myPlayerNum, speed);
+		return true;
+	}
+};
 
 class ControlUnitActionExecutor : public IUnsyncedActionExecutor {
 public:

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -1783,12 +1783,9 @@ public:
 		if ((action.GetArgs()).empty())
 			return false;
 
-		float minSpeed = gs->minUserSped;
-		float maxSpeed = gs->maxUserSped;
 		float speed = atof((action.GetArgs()).c_str());
-		speed = Clamp(speed, minSpeed, maxSpeed)
 
-		clientNet->Send(CBaseNetProtocol::Get().SendUserSpeed(gu->myPlayerNum, speed);
+		clientNet->Send(CBaseNetProtocol::Get().SendUserSpeed(gu->myPlayerNum, speed));
 		return true;
 	}
 };

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -1776,7 +1776,7 @@ class SetGamespeedActionExecutor : public IUnsyncedActionExecutor {
 public:
 	SetGamespeedActionExecutor() : IUnsyncedActionExecutor(
 		"GameSpeed",
-		"Set the simulation speed, bounded my minimum and maximum game speed settings."
+		"Set the simulation speed to any positive value, bounded my minimum and maximum game speed settings."
 	) {}
 
 	bool Execute(const UnsyncedAction& action) const final {
@@ -1784,6 +1784,10 @@ public:
 			return false;
 
 		float speed = atof((action.GetArgs()).c_str());
+
+		// atof converts non-float strings to 0.0, can be ignored
+		if (speed <= 0.0)
+			return false;
 
 		clientNet->Send(CBaseNetProtocol::Get().SendUserSpeed(gu->myPlayerNum, speed));
 		return true;
@@ -3674,6 +3678,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<FeatureDrawDistActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SpeedUpActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SlowDownActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<SetGamespeedActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<ControlUnitActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<ShowStandardActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<ShowElevationActionExecutor>());


### PR DESCRIPTION
Added `setspeed` command to allow directly changing the game speed, rather than having to repeatedly send `speedup` and `slowdown` commands.

Chose `setspeed` because the other commands refer to "speed" and not "gamespeed": `setminspeed`, `setmaxspeed`.

`/setspeed n` where n is ignored if negative, zero, or not a number (`atof` coerces invalid values to 0.0), and is clamped to minimum and maximum game speeds.