### PR TITLE
Move Preload event after lua is initialized.

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -437,6 +437,11 @@ void CGame::Load(const std::string& mapFileName)
 			loadscreen->SetLoadMessage("Loading Saved Game");
 			saveFileHandler->LoadGame();
 			LoadLua(false, true);
+		} else {
+			ENTER_SYNCED_CODE();
+			eventHandler.GamePreload();
+			eventHandler.CollectGarbage(true);
+			LEAVE_SYNCED_CODE();
 		}
 
 		{
@@ -794,13 +799,6 @@ void CGame::LoadSkirmishAIs()
 
 void CGame::LoadFinalize()
 {
-	if (saveFileHandler == nullptr) {
-		ENTER_SYNCED_CODE();
-		eventHandler.GamePreload();
-		eventHandler.CollectGarbage(true);
-		LEAVE_SYNCED_CODE();
-	}
-
 	{
 		loadscreen->SetLoadMessage("[" + std::string(__func__) + "] finalizing PFS");
 

--- a/rts/Map/ReadMap.cpp
+++ b/rts/Map/ReadMap.cpp
@@ -373,7 +373,7 @@ void CReadMap::Initialize()
 		sharedSlopeMaps[1] = &slopeMap[0];
 	}
 
-	mapChecksum = CalcHeightmapChecksum();
+	InitHeightBounds();
 
 	syncedHeightMapDigests.clear();
 	unsyncedHeightMapDigests.clear();
@@ -386,8 +386,7 @@ void CReadMap::Initialize()
 	// UpdateDraw(true);
 }
 
-
-unsigned int CReadMap::CalcHeightmapChecksum()
+void CReadMap::InitHeightBounds()
 {
 	const float* heightmap = GetCornerHeightMapSynced();
 
@@ -407,12 +406,24 @@ unsigned int CReadMap::CalcHeightmapChecksum()
 		checksum = HsiehHash(&heightmap[i], sizeof(heightmap[i]), checksum);
 	}
 
-	checksum = HsiehHash(mapInfo->map.name.c_str(), mapInfo->map.name.size(), checksum);
+	mapChecksum = HsiehHash(mapInfo->map.name.c_str(), mapInfo->map.name.size(), checksum);
 
 	currHeightBounds.x = initHeightBounds.x;
 	currHeightBounds.y = initHeightBounds.y;
+}
 
-	return checksum;
+
+unsigned int CReadMap::CalcHeightmapChecksum()
+{
+	const float* heightmap = GetCornerHeightMapSynced();
+
+	unsigned int checksum = 0;
+
+	for (int i = 0; i < (mapDims.mapxp1 * mapDims.mapyp1); ++i) {
+		checksum = HsiehHash(&heightmap[i], sizeof(heightmap[i]), checksum);
+	}
+
+	return HsiehHash(mapInfo->map.name.c_str(), mapInfo->map.name.size(), checksum);
 }
 
 

--- a/rts/Map/ReadMap.h
+++ b/rts/Map/ReadMap.h
@@ -209,6 +209,7 @@ public:
 	unsigned int CalcTypemapChecksum();
 
 private:
+	void InitHeightBounds();
 	void UpdateHeightBounds(int syncFrame);
 
 	void UpdateCenterHeightmap(const SRectangle& rect, bool initialize);


### PR DESCRIPTION
Also fix height bounds changing if CalcHeightmapChecksum is called.
Note that this is a behaviour change - original height will now be the
height of the map in the file, and not the height in the beginning of the
game.