### PR TITLE
'AI above all' load order

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1897,18 +1897,6 @@ bool CGame::IsSimLagging(float maxLatency) const
 }
 
 
-void CGame::Reload()
-{
-	if (saveFileHandler != nullptr) {
-		// This reloads heightmap, triggers Load call-in, etc.
-		// Inside the Load call-in, Lua can ensure old units are wiped before new ones are placed.
-		saveFileHandler->LoadGame();
-		saveFileHandler->LoadAIData();
-	} else {
-		LOG_L(L_WARNING, "[Game::%s] can only reload the game when it has been started from a savegame", __func__);
-	}
-}
-
 void CGame::Save(std::string&& fileName, std::string&& saveArgs)
 {
 	globalSaveFileData.name = std::move(fileName);

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -429,19 +429,8 @@ void CGame::Load(const std::string& mapFileName)
 		}
 	}
 
-	if (!forcedQuit) {
-		try {
-			LOG("[Game::%s][7] globalQuit=%d forcedQuit=%d", __func__, globalQuit.load(), forcedQuit);
-
-			LoadSkirmishAIs();
-		} catch (const content_error& e) {
-			LOG_L(L_WARNING, "[Game::%s][7] forced quit with exception \"%s\"", __func__, e.what());
-			forcedQuit = true;
-		}
-	}
-
 	try {
-		LOG("[Game::%s][8] globalQuit=%d forcedQuit=%d", __func__, globalQuit.load(), forcedQuit);
+		LOG("[Game::%s][7] globalQuit=%d forcedQuit=%d", __func__, globalQuit.load(), forcedQuit);
 
 		if (!globalQuit && saveFileHandler != nullptr) {
 			loadscreen->SetLoadMessage("Loading Saved Game");
@@ -461,8 +450,22 @@ void CGame::Load(const std::string& mapFileName)
 			CLIENT_NETLOG(gu->myPlayerNum, LOG_LEVEL_INFO, msgBuf);
 		}
 	} catch (const content_error& e) {
-		LOG_L(L_WARNING, "[Game::%s][8] forced quit with exception \"%s\"", __func__, e.what());
+		LOG_L(L_WARNING, "[Game::%s][7] forced quit with exception \"%s\"", __func__, e.what());
 		forcedQuit = true;
+	}
+
+	if (!forcedQuit) {
+		try {
+			LOG("[Game::%s][8] globalQuit=%d forcedQuit=%d", __func__, globalQuit.load(), forcedQuit);
+
+			LoadSkirmishAIs();
+			if (saveFileHandler != nullptr) {
+				saveFileHandler->LoadAIData();
+			}
+		} catch (const content_error& e) {
+			LOG_L(L_WARNING, "[Game::%s][8] forced quit with exception \"%s\"", __func__, e.what());
+			forcedQuit = true;
+		}
 	}
 
 	Watchdog::DeregisterThread(WDT_LOAD);
@@ -1900,6 +1903,7 @@ void CGame::Reload()
 		// This reloads heightmap, triggers Load call-in, etc.
 		// Inside the Load call-in, Lua can ensure old units are wiped before new ones are placed.
 		saveFileHandler->LoadGame();
+		saveFileHandler->LoadAIData();
 	} else {
 		LOG_L(L_WARNING, "[Game::%s] can only reload the game when it has been started from a savegame", __func__);
 	}

--- a/rts/Game/Game.h
+++ b/rts/Game/Game.h
@@ -99,7 +99,6 @@ public:
 
 	void ParseInputTextGeometry(const std::string& geo);
 
-	void Reload();
 	void Save(std::string&& fileName, std::string&& saveArgs);
 
 	void ResizeEvent() override;

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -3285,19 +3285,6 @@ private:
 
 
 
-class ReloadGameActionExecutor : public IUnsyncedActionExecutor {
-public:
-	ReloadGameActionExecutor() : IUnsyncedActionExecutor("ReloadGame", "Restarts the game with the initially provided start-script") {
-	}
-
-	bool Execute(const UnsyncedAction& action) const final {
-		game->Reload();
-		return true;
-	}
-};
-
-
-
 class ReloadShadersActionExecutor : public IUnsyncedActionExecutor {
 public:
 	ReloadShadersActionExecutor() : IUnsyncedActionExecutor("ReloadShaders", "Reloads all engine shaders") {
@@ -3761,7 +3748,6 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<DumpStateActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SaveActionExecutor>(true));
 	AddActionExecutor(AllocActionExecutor<SaveActionExecutor>(false));
-	AddActionExecutor(AllocActionExecutor<ReloadGameActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<ReloadShadersActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<ReloadTexturesActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DebugInfoActionExecutor>());

--- a/rts/System/LoadSave/CregLoadSaveHandler.h
+++ b/rts/System/LoadSave/CregLoadSaveHandler.h
@@ -15,6 +15,7 @@ public:
 
 	bool LoadGameStartInfo(const std::string& path) override;
 	void LoadGame() override;
+	void LoadAIData() override;
 	void SaveGame(const std::string& path) override;
 
 protected:

--- a/rts/System/LoadSave/LoadSaveHandler.h
+++ b/rts/System/LoadSave/LoadSaveHandler.h
@@ -34,6 +34,7 @@ public:
 	/// load scriptText and (for creg saves) {map,mod}Name needed to fire up the engine
 	virtual bool LoadGameStartInfo(const std::string& file) = 0;
 	virtual void LoadGame() = 0;
+	virtual void LoadAIData() = 0;
 
 	void SaveInfo(const std::string& _mapName, const std::string& _modName) {
 		mapName = _mapName;
@@ -54,6 +55,7 @@ public:
 	void SaveGame(const std::string& file) override {}
 	bool LoadGameStartInfo(const std::string& file) override { return false; }
 	void LoadGame() override {}
+	void LoadAIData() override {}
 };
 
 

--- a/rts/System/LoadSave/LuaLoadSaveHandler.cpp
+++ b/rts/System/LoadSave/LuaLoadSaveHandler.cpp
@@ -196,7 +196,6 @@ void CLuaLoadSaveHandler::LoadGame()
 	ENTER_SYNCED_CODE();
 
 	LoadEventClients();
-	LoadAIData();
 	LoadHeightmap();
 
 	LEAVE_SYNCED_CODE();
@@ -212,6 +211,8 @@ void CLuaLoadSaveHandler::LoadEventClients()
 
 void CLuaLoadSaveHandler::LoadAIData()
 {
+	ENTER_SYNCED_CODE();
+
 	for (const auto& ai: skirmishAIHandler.GetAllSkirmishAIs()) {
 		const std::string aiSection = FILE_AIDATA + IntToString(ai.first, ".%i");
 		const std::string aiDataFile = LoadEntireFile(aiSection);
@@ -220,6 +221,8 @@ void CLuaLoadSaveHandler::LoadAIData()
 
 		eoh->Load(&aiData, ai.first);
 	}
+
+	LEAVE_SYNCED_CODE();
 }
 
 

--- a/rts/System/LoadSave/LuaLoadSaveHandler.h
+++ b/rts/System/LoadSave/LuaLoadSaveHandler.h
@@ -22,6 +22,7 @@ public:
 	void SaveGame(const std::string& file) override;
 	bool LoadGameStartInfo(const std::string& file) override;
 	void LoadGame() override;
+	void LoadAIData() override;
 
 protected:
 	void SaveEventClients(); // Lua
@@ -30,7 +31,6 @@ protected:
 	void SaveHeightmap();
 	void SaveEntireFile(const char* file, const char* what, const void* data, int size, bool throwOnError = false);
 	void LoadEventClients();
-	void LoadAIData();
 	void LoadHeightmap();
 	std::string LoadEntireFile(const std::string& file);
 

--- a/rts/System/creg/Serializer.cpp
+++ b/rts/System/creg/Serializer.cpp
@@ -98,7 +98,6 @@ void ReadVarSizeUInt(std::istream* stream, T* buf)
 	*buf = val;
 }
 
-
 template<typename T>
 void WriteVarSizeUInt(std::ostream* stream, T val)
 {
@@ -112,6 +111,16 @@ void WriteVarSizeUInt(std::ostream* stream, T val)
 
 		stream->write((char*)&a, sizeof(char));
 	} while (v > 0);
+}
+
+void creg::ReadUInt(std::istream* stream, std::uint64_t* buf)
+{
+	ReadVarSizeUInt(stream, buf);
+}
+
+void creg::WriteUInt(std::ostream* stream, uint64_t val)
+{
+	WriteVarSizeUInt(stream, val);
 }
 
 //-------------------------------------------------------------------------

--- a/rts/System/creg/Serializer.h
+++ b/rts/System/creg/Serializer.h
@@ -188,6 +188,10 @@ namespace creg {
 		void LoadPackage(std::istream* s, void*& root, Class*& rootCls);
 	};
 
+
+void ReadUInt(std::istream* stream, std::uint64_t* buf);
+void WriteUInt(std::ostream* stream, uint64_t val);
+
 }
 
 #endif //USING_CREG


### PR DESCRIPTION
Geo spot is a Feature.
Features are loaded on `CGame::LoadLua(false, <any>)` that happens after EVENT_LOAD for AI, thus AI can't see crucial economy places on savegame load. Though it's technically possible to delay AI routines till 1st executed frame and lag it, i don't see why should it.