### PR TITLE
[ALT 2] Remove inconsequential firestarter weapondef tag limit

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -6,6 +6,8 @@ Spring changelog
 
 Lua:
  - allow empty argument for Spring.GetKeyBindings to return all keybindings
+ - `firestarter` weapon tag no longer capped at 10000 in defs (which
+   becomes 100 in Lua after rescale). Now uncapped.
 Maps:
  - New bumpwater params, most of these were just hard-coded values:
     - waveOffsetFactor    (0.0)

--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -133,7 +133,7 @@ WEAPONTAG(float, metalcost).externalName("metalPerShot").defaultValue(0.0f);
 WEAPONTAG(float, energycost).externalName("energyPerShot").defaultValue(0.0f);
 
 // Other Properties
-WEAPONTAG(float, fireStarter).defaultValue(0.0f).minimumValue(0.0f).maximumValue(100.0f).scaleValue(0.01f)
+WEAPONTAG(float, fireStarter).defaultValue(0.0f).minimumValue(0.0f).scaleValue(0.01f) // max value that makes engine sense is 100%, but Lua gadgets may make use of higher ones
 	.description("The percentage chance of the weapon setting fire to static map features on impact.");
 WEAPONTAG(bool, paralyzer).defaultValue(false).description("Is the weapon a paralyzer? If true the weapon only stuns enemy units and does not cause damage in the form of lost hit-points.");
 WEAPONTAG(int, paralyzeTime,  damages.paralyzeDamageTime).defaultValue(10).minimumValue(0).description("Determines the maximum length of time in seconds that the target will be paralyzed. The timer is restarted every time the target is hit by the weapon. Cannot be less than 0.");


### PR DESCRIPTION
See #153 (tldr: the value is mistakenly capped at 10000%, so high we might as well not have a cap).

This is the alternative that just removes the limit. I slightly dislike it because I think it is cleaner for Lua gadgets to make their own customparam, which they can populate with the firestarter tag in unitdefs_post before it gets capped if they want to tie the two values together, but maybe somebody likes the lazy approach.