### PR TITLE
NameUnitDefContains -> IdMatches causes MSVC compiler to freak out at…

### DIFF
--- a/rts/Game/UI/SelectionKeyHandler.cpp
+++ b/rts/Game/UI/SelectionKeyHandler.cpp
@@ -169,7 +169,7 @@ namespace {
 		},
 	)
 
-	DECLARE_FILTER_EX(NameUnitDefContain, 1, unit->unitDef->name.find(name) != std::string::npos,
+	DECLARE_FILTER_EX(IdMatches, 1, unit->unitDef->name.compare(name) == 0,
 		std::string name;
 		void SetParam(int index, const std::string& value) override {
 			name = value;


### PR DESCRIPTION
… an unchanged line :/


Error (active)	E0274	improperly terminated macro invocation	engine-headless	N:\engine_source\spring\rts\Game\UI\SelectionKeyHandler.cpp	141