### PR TITLE
Remove mouse centering

### DIFF
--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -691,10 +691,6 @@ void CMouseHandler::ShowMouse()
 	// (by switching between default cursor and later the real one, e.g. `attack`)
 	// instead update state and cursor at the same time
 	ToggleHwCursor(hardwareCursor);
-
-	// force a warp back to center
-	mouseInput->SetPos(globalRendering->GetScreenCenter());
-	mouseInput->WarpPos(mouseInput->GetPos());
 }
 
 void CMouseHandler::HideMouse()

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -81,10 +81,6 @@ CMouseHandler::CMouseHandler()
 {
 	const int2 screenCenter = globalRendering->GetScreenCenter();
 
-	// initially center the cursor
-	mouseInput->SetPos(screenCenter);
-	mouseInput->WarpPos(screenCenter);
-
 	dir = GetCursorCameraDir(lastx = screenCenter.x, lasty = screenCenter.y);
 
 


### PR DESCRIPTION
Currently there are two instances of mouse centering on start, this PR removes both.