### PR TITLE
Archives: don't warn for empty server checksum

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -17,6 +17,9 @@ Maps:
 		- causticsResolution  (75.0)
 		- causticsStrength    (0.08)
 
+Misc:
+ - don't warn for archive checksum mismatch if server's checksum is zero
+
 -- 105.0 --------------------------------------------------------
 Sim:
  - allow resurrecting indestructable features

--- a/rts/System/FileSystem/ArchiveScanner.cpp
+++ b/rts/System/FileSystem/ArchiveScanner.cpp
@@ -1435,12 +1435,17 @@ sha512::raw_digest CArchiveScanner::GetArchiveCompleteChecksumBytes(const std::s
 	return checksum;
 }
 
-
+static constexpr sha512::raw_digest EMPTY_DIGEST = {0x80, }; // 1000...000 hex
 void CArchiveScanner::CheckArchive(
 	const std::string& name,
 	const sha512::raw_digest& serverChecksum,
 	      sha512::raw_digest& clientChecksum
 ) {
+	/* Dedicated servers often don't actually have the content,
+	 * but this is fine as they just relay traffic - don't warn. */
+	if (serverChecksum == EMPTY_DIGEST)
+		return;
+
 	if ((clientChecksum = GetArchiveCompleteChecksumBytes(name)) == serverChecksum)
 		return;
 


### PR DESCRIPTION
Dedicated server often doesn't have the content,
but this is fine since it just relays messages.