### PR TITLE
Disable Engine Tree drawer by default

### DIFF
--- a/rts/Rendering/Env/ITreeDrawer.cpp
+++ b/rts/Rendering/Env/ITreeDrawer.cpp
@@ -29,7 +29,7 @@ ITreeDrawer* treeDrawer = nullptr;
 
 
 ITreeDrawer::ITreeDrawer(): CEventClient("[ITreeDrawer]", 314444, false)
-	, drawTrees(true)
+	, drawTrees(false)
 	, wireFrameMode(false)
 {
 	eventHandler.AddClient(this);


### PR DESCRIPTION
Since we override the featuredefs (in engine distro!) of engine trees, there is no way of actually triggering this rendering path. 
Oddly enough, leaving it on still shows about 0.1%-0.3% cpu load in /debug. (Draw::World::Foliage)
This setting cannot be adjusted with springsettings.cfg, only the action executor /drawtrees can control this.  

Tested toggling /drawtrees on the map 'duck', which has a single engine tree in the eye of the duck. This engine tree is correctly swapped to the featuredef'd tree from engine, and toggling has no effect, outside making that small cpu load go away.