### PR TITLE
Area-reclaim: always ignore wrecks being rezzed

### DIFF
--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -1019,7 +1019,7 @@ void CBuilderCAI::ExecuteReclaim(Command& c)
 
 			if (feature != nullptr) {
 				bool featureBeingResurrected = IsFeatureBeingResurrected(feature->id, owner);
-				featureBeingResurrected &= (c.IsInternalOrder()) && !(c.GetOpts() & CONTROL_KEY);
+				featureBeingResurrected &= c.IsInternalOrder();
 
 				if (featureBeingResurrected || !ReclaimObject(feature)) {
 					StopMoveAndFinishCommand();
@@ -1582,7 +1582,7 @@ int CBuilderCAI::FindReclaimTarget(const float3& pos, float radius, unsigned cha
 				if (!owner->unitDef->canmove && !IsInBuildRange(f))
 					continue;
 
-				if (!(cmdopt & CONTROL_KEY) && IsFeatureBeingResurrected(f->id, owner))
+				if (IsFeatureBeingResurrected(f->id, owner))
 					continue;
 
 				metal |= (recSpecial && !metal && f->defResources.metal > 0.0f);


### PR DESCRIPTION
The CTRL modifier used to make area-reclaim eat up wrecks being rezzed.
But it is also (still) used to eat wrecks that aren't autoreclaimed in general.
Ideally these two would not be tied, but the META and META+CTRL modifiers
are already in use for other stuff. Rez seems usually preferable in major games
so maybe not leaving the option to absent-mindedly create a conflict is good.
You can still reclaim a wreck being rezzed by consciously giving a single-target command.