### PR TITLE
[AI] Savegame: aiInst.PostLoad() after load event

### DIFF
--- a/rts/ExternalAI/EngineOutHandler.h
+++ b/rts/ExternalAI/EngineOutHandler.h
@@ -82,7 +82,8 @@ public:
 
 
 	// Skirmish AI stuff
-	void CreateSkirmishAI(const uint8_t skirmishAIId);
+	void CreateSkirmishAI(const uint8_t skirmishAIId, bool savedGame);
+	void PostLoadSkirmishAI(const uint8_t skirmishAIId);
 	/**
 	 * Sets a local Skirmish AI to block events.
 	 * Do not call this if you want to kill a local AI, but use

--- a/rts/ExternalAI/Interface/AISEvents.h
+++ b/rts/ExternalAI/Interface/AISEvents.h
@@ -98,6 +98,7 @@ const int NUM_EVENTS = 28;
 struct SInitEvent {
 	int skirmishAIId;
 	const struct SSkirmishAICallback* callback;
+	bool savedGame;
 }; //$ EVENT_INIT
 
 /**

--- a/rts/ExternalAI/SkirmishAIHandler.cpp
+++ b/rts/ExternalAI/SkirmishAIHandler.cpp
@@ -186,7 +186,7 @@ bool CSkirmishAIHandler::RemoveSkirmishAI(const size_t skirmishAIId) {
 }
 
 
-void CSkirmishAIHandler::CreateLocalSkirmishAI(const size_t skirmishAIId) {
+void CSkirmishAIHandler::CreateLocalSkirmishAI(const size_t skirmishAIId, bool savedGame) {
 	SkirmishAIData* aiData = GetSkirmishAI(skirmishAIId);
 
 	// fail, if a local AI is already in line for this team
@@ -198,7 +198,14 @@ void CSkirmishAIHandler::CreateLocalSkirmishAI(const size_t skirmishAIId) {
 	localTeamAIs[aiData->team].isLuaAI = (aiData->isLuaAI = IsLuaAI(*aiData));
 
 	// create instantly
-	eoh->CreateSkirmishAI(skirmishAIId);
+	eoh->CreateSkirmishAI(skirmishAIId, savedGame);
+}
+
+void CSkirmishAIHandler::PostLoadSkirmishAI(const size_t skirmishAIId) {
+	if (HasLocalKillFlag(skirmishAIId) || GetSkirmishAI(skirmishAIId)->isLuaAI)
+		return;
+
+	eoh->PostLoadSkirmishAI(skirmishAIId);
 }
 
 void CSkirmishAIHandler::NetCreateLocalSkirmishAI(const SkirmishAIData& aiData) {

--- a/rts/ExternalAI/SkirmishAIHandler.h
+++ b/rts/ExternalAI/SkirmishAIHandler.h
@@ -114,7 +114,8 @@ public:
 	 * @param skirmishAIId Skirmish AI index
 	 * @see EngineOutHandler::CreateSkirmishAI()
 	 */
-	void CreateLocalSkirmishAI(const size_t skirmishAIId);
+	void CreateLocalSkirmishAI(const size_t skirmishAIId, bool savedGame);
+	void PostLoadSkirmishAI(const size_t skirmishAIId);
 	/**
 	 * Starts the synced initialization process of a locally running Skirmish AI.
 	 * Stores detailed info locally and sends synced stuff in a message

--- a/rts/ExternalAI/SkirmishAIWrapper.h
+++ b/rts/ExternalAI/SkirmishAIWrapper.h
@@ -32,16 +32,7 @@ public:
 	CSkirmishAIWrapper& operator = (CSkirmishAIWrapper&& w) = delete;
 
 	void Serialize(creg::ISerializer* s) {}
-	void PostLoad() {
-		#if 0
-		// EngineOutHandler invokes PostLoad directly since
-		// it does not (de)serialize AI's, less error-prone
-		CreateCallback();
-		InitLibrary(true);
-		#else
-		SendUnitEvents();
-		#endif
-	}
+	void PostLoad() { SendUnitEvents(); }
 
 
 	void PreInit(int aiID);
@@ -52,7 +43,7 @@ public:
 	 * Initialize the AI instance.
 	 * This calls the native init() method, the InitAIEvent is sent afterwards.
 	 */
-	void Init();
+	void Init(bool savedGame);
 	void Kill();
 
 	/// @see SReleaseEvent in Interface/AISEvents.h
@@ -106,11 +97,13 @@ public:
 
 	bool Active() const { return (skirmishAIId != -1); }
 
+	bool IsLoadSupported() const;
+
 private:
-	bool InitLibrary(bool postLoad);
+	bool InitLibrary();
 	void CreateCallback();
 
-	void SendInitEvent();
+	void SendInitEvent(bool savedGame);
 	void SendUnitEvents();
 
 	/**

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -1234,7 +1234,7 @@ void CGame::ClientReadNet()
 
 					if (playerNum == gu->myPlayerNum) {
 						LOG("[Game::%s] local skirmish AI being created for team %i ...", __func__, aiTeamNum);
-						eoh->CreateSkirmishAI(aiNum);
+						eoh->CreateSkirmishAI(aiNum, false);
 					}
 				} catch (const netcode::UnpackPacketException& ex) {
 					LOG_L(L_ERROR, "[Game::%s][NETMSG_AI_CREATED] exception \"%s\"", __func__, ex.what());
@@ -1278,7 +1278,7 @@ void CGame::ClientReadNet()
 					if (oldState == SKIRMAISTATE_RELOADING) {
 						if (isLocal) {
 							LOG("[Game::%s] %s skirmish AI \"%s\" being created for team %i", __func__, types[true], aiData->name.c_str(), aiTeamId);
-							eoh->CreateSkirmishAI(aiNum);
+							eoh->CreateSkirmishAI(aiNum, false);
 						}
 					} else {
 						// this could be done in the above function as well, team has no controller left now


### PR DESCRIPTION
Draft. Requires BARb update.

Actions on savegame load.
* Original:
1) For each AI:
  1.1) CreateAI, EVENT_INIT for specific AI.
  1.2) SendUnitEvents (UnitFinished, and for enemies: UnitEnteredLos/Radar) to AI.
2) Load AI data, EVENT_LOAD for each AI.

* Proposed:
1) CreateAIs, EVENT_INIT for each AI.
2) Load AI data, EVENT_LOAD for each AI.
3) SendUnitEvents to AI if loadSupported != "yes".

* Alternative:
1) For each AI:
  1.1) CreateAI, EVENT_INIT for specific AI.
  1.2) Load AI data, EVENT_LOAD for specific AI.
  1.3) SendUnitEvents to specific AI if loadSupported != "yes".

But "alternative" requires modification of AI save procedure and understanding why it saves GetAllSkirmishAIs() instead of only local AIs (for possible future multiplayer save/load?).