### PR TITLE
Updated map triangulation

### DIFF
--- a/rts/Map/SMF/ROAM/Patch.cpp
+++ b/rts/Map/SMF/ROAM/Patch.cpp
@@ -382,9 +382,42 @@ void Patch::RecursRender(const TriTreeNode* tri, const int2 left, const int2 rig
 	if (tri->IsDummy())
 		return;
 	if (tri->IsLeaf()) {
-		indices.push_back(apex.x  + apex.y  * (PATCH_SIZE + 1));
-		indices.push_back(left.x  + left.y  * (PATCH_SIZE + 1));
-		indices.push_back(right.x + right.y * (PATCH_SIZE + 1));
+		const int apexIndex = apex.x + apex.y * (PATCH_SIZE + 1);
+		const int leftIndex = left.x + left.y * (PATCH_SIZE + 1);
+		const int rightIndex = right.x + right.y * (PATCH_SIZE + 1);
+
+		// Rotate the triangles if their hypotenuse becomes shorter
+		if (!tri->BaseNeighbor->IsDummy() && (tri->BaseNeighbor->BaseNeighbor == tri)) {
+			const int2 baseNeighborApex = left + right - apex;
+
+			if (baseNeighborApex.x >= 0 && baseNeighborApex.y >= 0 && baseNeighborApex.x < PATCH_SIZE + 1 && baseNeighborApex.y < PATCH_SIZE + 1) {
+				const float apexHeight = vertices[apexIndex * 3 + 1];
+				const float leftHeight = vertices[leftIndex * 3 + 1];
+				const float rightHeight = vertices[rightIndex * 3 + 1];
+
+				float heightDiff = leftHeight - rightHeight;
+				if (heightDiff < 0)
+					heightDiff = -heightDiff;
+
+				const int baseNeighborApexIndex = baseNeighborApex.x + baseNeighborApex.y * (PATCH_SIZE + 1);
+				const float baseNeighborApexHeight = vertices[baseNeighborApexIndex * 3 + 1];
+
+				float heightDiff2 = apexHeight - baseNeighborApexHeight;
+				if (heightDiff2 < 0)
+					heightDiff2 = -heightDiff2;
+
+				if (heightDiff2 < heightDiff - 0.0001f) {
+					indices.push_back(apexIndex);
+					indices.push_back(leftIndex);
+					indices.push_back(baseNeighborApexIndex);
+					return;
+				}
+			}
+		}
+
+		indices.push_back(apexIndex);
+		indices.push_back(leftIndex);
+		indices.push_back(rightIndex);
 		return;
 	}
 

--- a/rts/Map/SMF/ROAM/Patch.cpp
+++ b/rts/Map/SMF/ROAM/Patch.cpp
@@ -395,16 +395,12 @@ void Patch::RecursRender(const TriTreeNode* tri, const int2 left, const int2 rig
 				const float leftHeight = vertices[leftIndex * 3 + 1];
 				const float rightHeight = vertices[rightIndex * 3 + 1];
 
-				float heightDiff = leftHeight - rightHeight;
-				if (heightDiff < 0)
-					heightDiff = -heightDiff;
+				float heightDiff = std::abs(leftHeight - rightHeight);
 
 				const int baseNeighborApexIndex = baseNeighborApex.x + baseNeighborApex.y * (PATCH_SIZE + 1);
 				const float baseNeighborApexHeight = vertices[baseNeighborApexIndex * 3 + 1];
 
-				float heightDiff2 = apexHeight - baseNeighborApexHeight;
-				if (heightDiff2 < 0)
-					heightDiff2 = -heightDiff2;
+				float heightDiff2 = std::abs(apexHeight - baseNeighborApexHeight);
 
 				if (heightDiff2 < heightDiff - 0.0001f) {
 					indices.push_back(apexIndex);


### PR DESCRIPTION
Rotate the triangles in a square if their hypotenuse becomes shorter.
Fixes or lessens the issues with stretched triangles at sharp edges.
![before](https://user-images.githubusercontent.com/2300731/161399536-239ba24a-0cda-4f0a-bdb7-bc5929477570.jpg)
![after](https://user-images.githubusercontent.com/2300731/161399540-9e1600a2-d181-4811-9df5-594313aa3fb5.jpg)
