### PR TITLE
Enable manually setting JPEG screenshot quality

### DIFF
--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -2084,7 +2084,16 @@ public:
 	}
 
 	bool Execute(const UnsyncedAction& action) const final {
-		TakeScreenshot(action.GetArgs());
+		auto args = _local_strSpaceTokenize(action.GetArgs());
+
+		if (args.size() == 0) {
+			TakeScreenshot("", 80);
+		} else {
+			int quality = args.size() > 1 ? StringToInt(args[1]) : 80;
+			if (quality < 1) quality = 1;
+			if (quality > 99) quality = 99;
+			TakeScreenshot(args[0], quality);
+		}
 		return true;
 	}
 };

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -2090,8 +2090,7 @@ public:
 			TakeScreenshot("", 80);
 		} else {
 			int quality = args.size() > 1 ? StringToInt(args[1]) : 80;
-			if (quality < 1) quality = 1;
-			if (quality > 99) quality = 99;
+			quality = std::clamp(quality, 1, 99);
 			TakeScreenshot(args[0], quality);
 		}
 		return true;

--- a/rts/Rendering/Screenshot.cpp
+++ b/rts/Rendering/Screenshot.cpp
@@ -22,11 +22,12 @@ struct FunctionArgs
 {
 	std::vector<uint8_t> pixelbuf;
 	std::string filename;
+	unsigned quality;
 	int x;
 	int y;
 };
 
-void TakeScreenshot(std::string type)
+void TakeScreenshot(std::string type, unsigned quality)
 {
 	if (type.empty())
 		type = "jpg";
@@ -44,6 +45,7 @@ void TakeScreenshot(std::string type)
 	// note: we no longer increment the counter until a "file not found" occurs
 	// since that stalls the thread and might run concurrently with an IL write
 	args.filename.assign("screenshots/screen" + IntToString(shotCounter, "%05d") + "." + type);
+	args.quality = quality;
 	args.pixelbuf.resize(args.x * args.y * 4);
 
 	configHandler->Set("ScreenshotCounter", shotCounter + 1);
@@ -53,6 +55,6 @@ void TakeScreenshot(std::string type)
 	ThreadPool::Enqueue([](const FunctionArgs& args) {
 		CBitmap bmp(&args.pixelbuf[0], args.x, args.y);
 		bmp.ReverseYAxis();
-		bmp.Save(args.filename, true, true);
+		bmp.Save(args.filename, args.quality, true, true);
 	}, args);
 }

--- a/rts/Rendering/Screenshot.h
+++ b/rts/Rendering/Screenshot.h
@@ -5,6 +5,6 @@
 
 #include <string>
 
-void TakeScreenshot(std::string type);
+void TakeScreenshot(std::string type, unsigned quality);
 
 #endif

--- a/rts/Rendering/Textures/Bitmap.cpp
+++ b/rts/Rendering/Textures/Bitmap.cpp
@@ -1244,7 +1244,7 @@ bool CBitmap::LoadGrayscale(const std::string& filename)
 }
 
 
-bool CBitmap::Save(std::string const& filename, bool opaque, bool logged) const
+bool CBitmap::Save(std::string const& filename, unsigned quality, bool opaque, bool logged) const
 {
 	if (compressed) {
 		#ifndef HEADLESS
@@ -1285,8 +1285,8 @@ bool CBitmap::Save(std::string const& filename, bool opaque, bool logged) const
 	ilOriginFunc(IL_ORIGIN_UPPER_LEFT);
 	ilEnable(IL_ORIGIN_SET);
 
-	ilHint(IL_COMPRESSION_HINT, IL_USE_COMPRESSION);
-	ilSetInteger(IL_JPG_QUALITY, 80);
+	ilHint(IL_COMPRESSION_HINT, IL_NO_COMPRESSION);
+	ilSetInteger(IL_JPG_QUALITY, quality);
 
 	ILuint imageID = 0;
 	ilGenImages(1, &imageID);

--- a/rts/Rendering/Textures/Bitmap.h
+++ b/rts/Rendering/Textures/Bitmap.h
@@ -48,7 +48,7 @@ public:
 	/// Load data from a gray-scale file on the VFS
 	bool LoadGrayscale(std::string const& filename);
 
-	bool Save(const std::string& filename, bool opaque = true, bool logged = false) const;
+	bool Save(const std::string& filename, unsigned quality = 80, bool opaque = true, bool logged = false) const;
 	bool SaveGrayScale(const std::string& filename) const;
 	bool SaveFloat(const std::string& filename) const;
 


### PR DESCRIPTION
Given the possibility of artifacts in large JPEG screenshots, I thought the most obvious thing to do was to enable to manually tune the quality setting of the screenshot itself.

This patch simply adds a new (optional) parameter to the "\screenshot" in-game command: quality. This is supposed to be an integer in the range 1-99 (because that's what the DevIL library wants, otherwise it is ignored). Note that the quality setting does not affect png screenshots (you can still pass it but it won't do anything).

This patch additionally disables compression for the screenshots. I didn't feel it necessary to add a separate parameter for that.

Do note that there are similar calls to DevIL to save greyscale screenshots; I did not change those, as I'm unsure who calls them and why.
