### PR TITLE
Replace unportable UB dereference of nullptr with std::abort

### DIFF
--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -3124,8 +3124,7 @@ public:
 	}
 
 	bool Execute(const UnsyncedAction& action) const final {
-		int* a = nullptr;
-		*a = 0;
+		std::abort();
 		return true;
 	}
 };


### PR DESCRIPTION
This commit replaces the trivially detectable undefined behavior of
dereferencing a nullptr to cause a crash with `std::abort()`.

The change is not exact, as `std::abort()` triggers a SIGABRT, while the
original behavior was to trigger a SIGSEGV. This was done for
simplicity.

Note that the final result doesn't change: a crash is still triggered,
and `CrashHandler` is called regardless, as it registers with all
possible signals in all platforms. Thus, the `CrashActionExecutor`'s
objective is achieved anyway: to cause a crash which logs the stack
trace.