### PR TITLE
fix amd gpu memory negative size

### DIFF
--- a/rts/Rendering/GL/myGL.cpp
+++ b/rts/Rendering/GL/myGL.cpp
@@ -135,7 +135,7 @@ static bool GetVideoMemInfoATI(GLint* memInfo)
 	// these are not disjoint, don't sum
 	for (uint32_t param: {/*GL_VBO_FREE_MEMORY_ATI,*/ GL_TEXTURE_FREE_MEMORY_ATI/*, GL_RENDERBUFFER_FREE_MEMORY_ATI*/}) {
 		glGetIntegerv(param, &memInfo[0]);
-		if (memInfo[2] < 0) memInfo[2] = ( 1 << 27 ) + memInfo[2]; // workaround
+		if (memInfo[2] < 0) memInfo[2] = ( 1 << 27 ) + memInfo[2]; // a workaround for AMD GPU that might return negative sizes
 		memInfo[4] += (memInfo[0] + memInfo[2]); // total main plus aux. memory free in pool
 		memInfo[5] += (memInfo[1] + memInfo[3]); // largest main plus aux. free block in pool
 	}

--- a/rts/Rendering/GL/myGL.cpp
+++ b/rts/Rendering/GL/myGL.cpp
@@ -135,7 +135,7 @@ static bool GetVideoMemInfoATI(GLint* memInfo)
 	// these are not disjoint, don't sum
 	for (uint32_t param: {/*GL_VBO_FREE_MEMORY_ATI,*/ GL_TEXTURE_FREE_MEMORY_ATI/*, GL_RENDERBUFFER_FREE_MEMORY_ATI*/}) {
 		glGetIntegerv(param, &memInfo[0]);
-
+		if (memInfo[2] < 0) memInfo[2] = ( 1 << 27 ) + memInfo[2]; // workaround
 		memInfo[4] += (memInfo[0] + memInfo[2]); // total main plus aux. memory free in pool
 		memInfo[5] += (memInfo[1] + memInfo[3]); // largest main plus aux. free block in pool
 	}


### PR DESCRIPTION
AMD GPU memory negative size. (workaround)

real memory: 
16GB(RX 6800) + 64GB(shared, system has 128GB)

before:
`GPU memory  : -49938MB (total) / -49938MB (available)`

after:
`GPU memory  : 81111MB (total) / 81111MB (available)`


test on Linux
```
	SDL version : 2.0.22 (linked) / 2.0.22 (compiled)
	GL version  : 4.6 (Compatibility Profile) Mesa 20.3.5
	GL vendor   : AMD
	GL renderer : AMD Radeon RX 6800 (SIENNA_CICHLID, DRM 3.46.0, 5.18.0-rc3-gs, LLVM 11.0.1)
	GLSL version: 4.60
	GLEW version: 2.1.0
	GPU memory  : 81031MB (total) / 81031MB (available)
	SDL swap-int: -1
	SDL driver  : x11
	
	Initialized OpenGL Context: 4.6 (Compat)
```

test on Windows (not effected)
```
	SDL version : 2.0.18 (linked) / 2.0.18 (compiled)
	GL version  : 3.0.14800 Compatibility Profile/Debug Context 22.3.2 30.0.15019.1005
	GL vendor   : ATI Technologies Inc.
	GL renderer : AMD Radeon RX 6800
	GLSL version: 4.60
	GLEW version: 2.1.0
	GPU memory  : unknown
	SDL swap-int: 0
	SDL driver  : windows
	
	Initialized OpenGL Context: 3.0 (Compat)
```


ce784e7dd2
