### PR TITLE
fix wrong BuildDistance value in AI interface

### DIFF
--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -298,11 +298,9 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	cobID = udTable.GetInt("cobID", -1);
 
 	buildRange3D = udTable.GetBool("buildRange3D", false);
-	// 128.0f is the ancient default
-	buildDistance = udTable.GetFloat("buildDistance", 128.0f);
-	// 38.0f was evaluated by bobthedinosaur and FLOZi to be the bare minimum
-	// to not overlap for a 1x1 constructor building a 1x1 structure
-	buildDistance = std::max(38.0f, buildDistance);
+
+	buildDistance = udTable.GetFloat("buildDistance", 0.0f);
+
 	buildSpeed = udTable.GetFloat("workerTime", 0.0f);
 	builder = udTable.GetBool("builder", false);
 	builder &= IsBuilderUnit();


### PR DESCRIPTION

location: `AI interface` / `UnitDef_getBuildDistance()`

before:
```
	test BotLab build distance=128.0
	test Lazarus build distance=96.0
	test ConstructionTurret build distance=400.0
	test Tick build distance=128.0
```


```
	test BotLab build distance=0.0
	test Lazarus build distance=96.0
	test ConstructionTurret build distance=400.0
	test Tick build distance=0.0
```

description:
128.0 is a wrong value in any point of view, set to 0 should be right.


83d3d77afe
