### PR TITLE
Fix for when pre-match heightmap is updated by Lua code

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -443,7 +443,6 @@ void CGame::Load(const std::string& mapFileName)
 			eventHandler.CollectGarbage(true);
 
 			//needed in case pre-game terraform changed the map
-			readMap->Finalize();
 			readMap->UpdateHeightBounds();
 			pathManager->PostFinalizeRefresh();
 			LEAVE_SYNCED_CODE();

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -443,6 +443,7 @@ void CGame::Load(const std::string& mapFileName)
 			eventHandler.CollectGarbage(true);
 
 			//needed in case pre-game terraform changed the map
+			readMap->Finalize();
 			readMap->UpdateHeightBounds();
 			pathManager->PostFinalizeRefresh();
 			LEAVE_SYNCED_CODE();

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -89,6 +89,7 @@ static int heightMapz1 = 0;
 static int heightMapz2 = 0;
 
 static float heightMapAmountChanged = 0.0f;
+static float originalHeightMapAmountChanged = 0.0f;
 static float smoothMeshAmountChanged = 0.0f;
 
 
@@ -124,6 +125,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 		heightMapz2 = 0;
 
 		heightMapAmountChanged = 0.0f;
+		originalHeightMapAmountChanged = 0.0f;
 		smoothMeshAmountChanged = 0.0f;
 	}
 
@@ -282,6 +284,14 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(AddHeightMap);
 	REGISTER_LUA_CFUNC(SetHeightMap);
 	REGISTER_LUA_CFUNC(SetHeightMapFunc);
+
+	REGISTER_LUA_CFUNC(LevelOriginalHeightMap);
+	REGISTER_LUA_CFUNC(AdjustOriginalHeightMap);
+	REGISTER_LUA_CFUNC(RevertOriginalHeightMap);
+
+	REGISTER_LUA_CFUNC(AddOriginalHeightMap);
+	REGISTER_LUA_CFUNC(SetOriginalHeightMap);
+	REGISTER_LUA_CFUNC(SetOriginalHeightMapFunc);
 
 	REGISTER_LUA_CFUNC(LevelSmoothMesh);
 	REGISTER_LUA_CFUNC(AdjustSmoothMesh);
@@ -4008,6 +4018,194 @@ int LuaSyncedCtrl::SetHeightMapFunc(lua_State* L)
 	return 1;
 }
 
+
+/******************************************************************************/
+/* original mesh manipulation                                                   */
+/******************************************************************************/
+
+int LuaSyncedCtrl::LevelOriginalHeightMap(lua_State* L)
+{
+	if (mapDamage->Disabled()) {
+		return 0;
+	}
+	float height;
+	int x1, x2, z1, z2;
+	ParseMapParams(L, __func__, height, x1, z1, x2, z2);
+
+	for (int z = z1; z <= z2; z++) {
+		for (int x = x1; x <= x2; x++) {
+			readMap->SetOriginalHeight((z * mapDims.mapxp1) + x, height);
+		}
+	}
+
+	return 0;
+}
+
+
+int LuaSyncedCtrl::AdjustOriginalHeightMap(lua_State* L)
+{
+	if (mapDamage->Disabled()) {
+		return 0;
+	}
+
+	float height;
+	int x1, x2, z1, z2;
+
+	ParseMapParams(L, __func__, height, x1, z1, x2, z2);
+
+	for (int z = z1; z <= z2; z++) {
+		for (int x = x1; x <= x2; x++) {
+			readMap->AddOriginalHeight((z * mapDims.mapxp1) + x, height);
+		}
+	}
+
+	return 0;
+}
+
+
+int LuaSyncedCtrl::RevertOriginalHeightMap(lua_State* L)
+{
+	if (mapDamage->Disabled()) {
+		return 0;
+	}
+	float origFactor;
+	int x1, x2, z1, z2;
+	ParseMapParams(L, __func__, origFactor, x1, z1, x2, z2);
+
+	const float* origMap = readMap->GetMapFileHeightMapSynced();
+	const float* currMap = readMap->GetOriginalHeightMapSynced();
+
+	if (origFactor == 1.0f) {
+		for (int z = z1; z <= z2; z++) {
+			for (int x = x1; x <= x2; x++) {
+				const int idx = (z * mapDims.mapxp1) + x;
+
+				readMap->SetOriginalHeight(idx, origMap[idx]);
+			}
+		}
+	}
+	else {
+		const float currFactor = (1.0f - origFactor);
+		for (int z = z1; z <= z2; z++) {
+			for (int x = x1; x <= x2; x++) {
+				const int index = (z * mapDims.mapxp1) + x;
+				const float ofh = origFactor * origMap[index];
+				const float cfh = currFactor * currMap[index];
+				readMap->SetOriginalHeight(index, ofh + cfh);
+			}
+		}
+	}
+
+	return 0;
+}
+
+/******************************************************************************/
+/******************************************************************************/
+
+int LuaSyncedCtrl::AddOriginalHeightMap(lua_State* L)
+{
+	if (!inOriginalHeightMap) {
+		luaL_error(L, "AddOriginalHeightMap() can only be called in SetOriginalHeightMapFunc()");
+	}
+
+	const float xl = luaL_checkfloat(L, 1);
+	const float zl = luaL_checkfloat(L, 2);
+	const float h  = luaL_checkfloat(L, 3);
+
+	// quantize
+	const int x = (int)(xl / SQUARE_SIZE);
+	const int z = (int)(zl / SQUARE_SIZE);
+
+	// discard invalid coordinates
+	if ((x < 0) || (x > mapDims.mapx) ||
+	    (z < 0) || (z > mapDims.mapy)) {
+		return 0;
+	}
+
+	const int index = (z * mapDims.mapxp1) + x;
+	const float oldHeight = readMap->GetOriginalHeightMapSynced()[index];
+	originalHeightMapAmountChanged += math::fabsf(h);
+
+	readMap->AddOriginalHeight(index, h);
+	// push the new height
+	lua_pushnumber(L, oldHeight + h);
+	return 1;
+}
+
+
+int LuaSyncedCtrl::SetOriginalHeightMap(lua_State* L)
+{
+	if (!inOriginalHeightMap) {
+		luaL_error(L, "SetHeightMap() can only be called in SetOriginalHeightMapFunc()");
+	}
+
+	const float xl = luaL_checkfloat(L, 1);
+	const float zl = luaL_checkfloat(L, 2);
+	const float h  = luaL_checkfloat(L, 3);
+
+	// quantize
+	const int x = (int)(xl / SQUARE_SIZE);
+	const int z = (int)(zl / SQUARE_SIZE);
+
+	// discard invalid coordinates
+	if ((x < 0) || (x > mapDims.mapx) ||
+	    (z < 0) || (z > mapDims.mapy)) {
+		return 0;
+	}
+
+	const int index = (z * mapDims.mapxp1) + x;
+	const float oldHeight = readMap->GetOriginalHeightMapSynced()[index];
+	float height = oldHeight;
+
+	if (lua_israwnumber(L, 4)) {
+		const float t = lua_tofloat(L, 4);
+		height += (h - oldHeight) * t;
+	} else{
+		height = h;
+	}
+
+	const float heightDiff = (height - oldHeight);
+	originalHeightMapAmountChanged += math::fabsf(heightDiff);
+
+	readMap->SetOriginalHeight(index, height);
+	lua_pushnumber(L, heightDiff);
+	return 1;
+}
+
+
+int LuaSyncedCtrl::SetOriginalHeightMapFunc(lua_State* L)
+{
+	if (mapDamage->Disabled()) {
+		return 0;
+	}
+
+	const int args = lua_gettop(L); // number of arguments
+	if ((args < 1) || !lua_isfunction(L, 1)) {
+		luaL_error(L, "Incorrect arguments to Spring.SetOriginalHeightMapFunc(func, ...)");
+	}
+
+	if (inOriginalHeightMap) {
+		luaL_error(L, "SetOriginalHeightMapFunc() recursion is not permitted");
+	}
+
+	originalHeightMapAmountChanged = 0.0f;
+
+	inOriginalHeightMap = true;
+	const int error = lua_pcall(L, (args - 1), 0, 0);
+	inOriginalHeightMap = false;
+
+	if (error != 0) {
+		LOG_L(L_ERROR, "Spring.SetOriginalHeightMapFunc: error(%i) = %s",
+				error, lua_tostring(L, -1));
+		lua_error(L);
+	}
+
+	lua_pushnumber(L, originalHeightMapAmountChanged);
+	return 1;
+}
+
+
+
 /******************************************************************************/
 /* smooth mesh manipulation                                                   */
 /******************************************************************************/
@@ -4165,7 +4363,7 @@ int LuaSyncedCtrl::SetSmoothMeshFunc(lua_State* L)
 		luaL_error(L, "SetHeightMapFunc() recursion is not permitted");
 	}
 
-	heightMapAmountChanged = 0.0f;
+	smoothMeshAmountChanged = 0.0f;
 
 	inSmoothMesh = true;
 	const int error = lua_pcall(L, (args - 1), 0, 0);

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -4136,7 +4136,7 @@ int LuaSyncedCtrl::AddOriginalHeightMap(lua_State* L)
 int LuaSyncedCtrl::SetOriginalHeightMap(lua_State* L)
 {
 	if (!inOriginalHeightMap) {
-		luaL_error(L, "SetHeightMap() can only be called in SetOriginalHeightMapFunc()");
+		luaL_error(L, "SetOriginalHeightMap() can only be called in SetOriginalHeightMapFunc()");
 	}
 
 	const float xl = luaL_checkfloat(L, 1);

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -29,6 +29,7 @@ class LuaSyncedCtrl
 
 		inline static bool inTransferUnit = false;
 		inline static bool inHeightMap = false;
+		inline static bool inOriginalHeightMap = false;
 		inline static bool inSmoothMesh = false;
 
 	private:
@@ -181,6 +182,14 @@ class LuaSyncedCtrl
 		static int AddHeightMap(lua_State* L);
 		static int SetHeightMap(lua_State* L);
 		static int SetHeightMapFunc(lua_State* L);
+
+		static int LevelOriginalHeightMap(lua_State* L);
+		static int AdjustOriginalHeightMap(lua_State* L);
+		static int RevertOriginalHeightMap(lua_State* L);
+
+		static int AddOriginalHeightMap(lua_State* L);
+		static int SetOriginalHeightMap(lua_State* L);
+		static int SetOriginalHeightMapFunc(lua_State* L);
 
 		static int LevelSmoothMesh(lua_State* L);
 		static int AdjustSmoothMesh(lua_State* L);

--- a/rts/Map/ReadMap.cpp
+++ b/rts/Map/ReadMap.cpp
@@ -199,31 +199,20 @@ void CReadMap::Serialize(creg::ISerializer* s)
 
 void CReadMap::SerializeMapChangesBeforeMatch(creg::ISerializer* s)
 {
-	      int32_t*  ichms = reinterpret_cast<      int32_t*>(const_cast<float*>(GetOriginalHeightMapSynced()));
-	const int32_t* iochms = reinterpret_cast<const int32_t*>(GetMapFileHeightMapSynced());
-
-	int32_t height;
-
-	if (s->IsWriting()) {
-		for (unsigned int i = 0; i < (mapDims.mapxp1 * mapDims.mapyp1); i++) {
-			height = ichms[i] ^ iochms[i];
-			s->Serialize(&height, sizeof(int32_t));
-		}
-	} else {
-		for (unsigned int i = 0; i < (mapDims.mapxp1 * mapDims.mapyp1); i++) {
-			s->Serialize(&height, sizeof(int32_t));
-			ichms[i] = height ^ iochms[i];
-		}
-	}
+	SerializeMapChanges(s, GetMapFileHeightMapSynced(), const_cast<float*>(GetOriginalHeightMapSynced()));
 }
 
 void CReadMap::SerializeMapChangesDuringMatch(creg::ISerializer* s)
 {
+	SerializeMapChanges(s, GetOriginalHeightMapSynced(), const_cast<float*>(GetCornerHeightMapSynced()));
+}
+
+void CReadMap::SerializeMapChanges(creg::ISerializer* s, const float* refHeightMap, float* modifiedHeightMap) {
 	// using integers so we can xor the original heightmap with the
 	// current one (affected by Lua, explosions, etc) - long runs of
 	// zeros for unchanged squares should compress significantly better.
-	      int32_t*  ichms = reinterpret_cast<      int32_t*>(const_cast<float*>(GetCornerHeightMapSynced()));
-	const int32_t* iochms = reinterpret_cast<const int32_t*>(GetOriginalHeightMapSynced());
+	      int32_t*  ichms = reinterpret_cast<      int32_t*>(modifiedHeightMap);
+	const int32_t* iochms = reinterpret_cast<const int32_t*>(refHeightMap);
 
 	int32_t height;
 

--- a/rts/Map/ReadMap.cpp
+++ b/rts/Map/ReadMap.cpp
@@ -68,6 +68,7 @@ CR_REG_METADATA(CReadMap, (
 
 	CR_IGNORED(heightMapSyncedPtr),
 	CR_IGNORED(heightMapUnsyncedPtr),
+	CR_IGNORED(originalHeightMapPtr),
 
 	/*
 	CR_IGNORED(originalHeightMap),
@@ -364,6 +365,8 @@ void CReadMap::Initialize()
 	mipPointerHeightMaps.fill(nullptr);
 	mipPointerHeightMaps[0] = &centerHeightMap[0];
 
+	originalHeightMapPtr = &originalHeightMap;
+
 	for (int i = 1; i < numHeightMipMaps; i++) {
 		mipCenterHeightMaps[i - 1].clear();
 		mipCenterHeightMaps[i - 1].resize((mapDims.mapx >> i) * (mapDims.mapy >> i));
@@ -386,6 +389,7 @@ void CReadMap::Initialize()
 	// for SMF maps so indexing it is forbidden (!)
 	assert(heightMapSyncedPtr != nullptr);
 	assert(heightMapUnsyncedPtr != nullptr);
+	assert(originalHeightMapPtr != nullptr);
 
 	{
 		#ifndef USE_UNSYNCED_HEIGHTMAP

--- a/rts/Map/ReadMap.cpp
+++ b/rts/Map/ReadMap.cpp
@@ -788,10 +788,6 @@ void CReadMap::UpdateCenterHeightmap(const SRectangle& rect, bool initialize)
 
 void CReadMap::Finalize()
 {
-	// set map start height map to modified levels
-	// recalculate checksums
-	// do the checksums need to be sent out?
-
 	LoadOriginalHeightMapAndChecksum();
 }
 

--- a/rts/Map/ReadMap.cpp
+++ b/rts/Map/ReadMap.cpp
@@ -790,11 +790,6 @@ void CReadMap::UpdateCenterHeightmap(const SRectangle& rect, bool initialize)
 	}
 }
 
-void CReadMap::Finalize()
-{
-	LoadOriginalHeightMapAndChecksum();
-}
-
 
 void CReadMap::UpdateMipHeightmaps(const SRectangle& rect, bool initialize)
 {

--- a/rts/Map/ReadMap.h
+++ b/rts/Map/ReadMap.h
@@ -89,6 +89,7 @@ public:
 private:
 	void SerializeMapChangesBeforeMatch(creg::ISerializer* s);
 	void SerializeMapChangesDuringMatch(creg::ISerializer* s);
+	void SerializeMapChanges(creg::ISerializer* s, const float* refHeightMap, float* modifiedHeightMap);
 	void SerializeTypeMap(creg::ISerializer* s);
 
 public:

--- a/rts/Map/ReadMap.h
+++ b/rts/Map/ReadMap.h
@@ -235,6 +235,8 @@ private:
 	inline void HeightMapUpdateLOSCheck(const SRectangle& hgtMapRect);
 	inline bool HasHeightMapViewChanged(const int2 losMapPos);
 
+	float SetHeightValue(float& heightRef, const int idx, const float h, const int add = 0);
+
 public:
 	/// number of heightmap mipmaps, including full resolution
 	static constexpr int numHeightMipMaps = 7;
@@ -307,23 +309,17 @@ private:
 extern CReadMap* readMap;
 extern MapDimensions mapDims;
 
-//#include "System/Log/ILog.h"
-
 inline float CReadMap::AddHeight(const int idx, const float a) { return SetHeight(idx, a, 1); }
 inline float CReadMap::SetHeight(const int idx, const float h, const int add) {
-	float& heightRef = (*heightMapSyncedPtr)[idx];
-//LOG("%s called", __func__);
-	// add=0 <--> x = x*0 + h =   h
-	// add=1 <--> x = x*1 + h = x+h
-	float newHeight = heightRef * add + h;
-	hmUpdated |= (newHeight != heightRef);
-	return (heightRef = newHeight);
+	return SetHeightValue((*heightMapSyncedPtr)[idx], idx, h, add);
 }
 
 inline float CReadMap::AddOriginalHeight(const int idx, const float a) { return SetOriginalHeight(idx, a, 1); }
 inline float CReadMap::SetOriginalHeight(const int idx, const float h, const int add) {
-	float& heightRef = (*originalHeightMapPtr)[idx];
-//LOG("%s called", __func__);
+	return SetHeightValue((*originalHeightMapPtr)[idx], idx, h, add);
+}
+
+inline float CReadMap::SetHeightValue(float& heightRef, const int idx, const float h, const int add) {
 	// add=0 <--> x = x*0 + h =   h
 	// add=1 <--> x = x*1 + h = x+h
 	float newHeight = heightRef * add + h;

--- a/rts/Map/ReadMap.h
+++ b/rts/Map/ReadMap.h
@@ -85,6 +85,13 @@ public:
 
 	/// creg serialize callback
 	void Serialize(creg::ISerializer* s);
+
+private:
+	void SerializeMapChangesBeforeMatch(creg::ISerializer* s);
+	void SerializeMapChangesDuringMatch(creg::ISerializer* s);
+	void SerializeTypeMap(creg::ISerializer* s);
+
+public:
 	void PostLoad();
 
 	void InitHeightMapDigestVectors(const int2 losMapSize);
@@ -156,6 +163,7 @@ public:
 
 
 	/// synced only
+	const float* GetMapFileHeightMapSynced() const { return &mapFileHeightMap[0]; }
 	const float* GetOriginalHeightMapSynced() const { return &originalHeightMap[0]; }
 	const float* GetCenterHeightMapSynced() const { return &centerHeightMap[0]; }
 	const float* GetMIPHeightMapSynced(unsigned int mip) const { return mipPointerHeightMaps[mip]; }
@@ -210,8 +218,11 @@ public:
 	void UpdateHeightBounds();
 
 	bool GetHeightMapUpdated() const { return hmUpdated; }
+
+	void Finalize();
 private:
 	void InitHeightBounds();
+	void LoadOriginalHeightMapAndChecksum();
 	void UpdateHeightBounds(int syncFrame);
 
 	void UpdateCenterHeightmap(const SRectangle& rect, bool initialize);
@@ -235,6 +246,7 @@ protected:
 
 	// note: intentionally declared static, s.t. repeated reloading to the same
 	// (or any smaller) map does not fragment the heap which invites bad_alloc's
+	static std::vector<float> mapFileHeightMap;			// raw heightMap unmodified from the map file
 	static std::vector<float> originalHeightMap;        //< size: (mapx+1)*(mapy+1) (per vertex) [SYNCED, does NOT update on terrain deformation]
 	static std::vector<float> centerHeightMap;          //< size: (mapx  )*(mapy  ) (per face) [SYNCED, updates on terrain deformation]
 	static std::array<std::vector<float>, numHeightMipMaps - 1> mipCenterHeightMaps;

--- a/rts/Map/ReadMap.h
+++ b/rts/Map/ReadMap.h
@@ -222,7 +222,6 @@ public:
 
 	bool GetHeightMapUpdated() const { return hmUpdated; }
 
-	void Finalize();
 private:
 	void InitHeightBounds();
 	void LoadOriginalHeightMapAndChecksum();
@@ -308,11 +307,12 @@ private:
 extern CReadMap* readMap;
 extern MapDimensions mapDims;
 
+//#include "System/Log/ILog.h"
 
 inline float CReadMap::AddHeight(const int idx, const float a) { return SetHeight(idx, a, 1); }
 inline float CReadMap::SetHeight(const int idx, const float h, const int add) {
 	float& heightRef = (*heightMapSyncedPtr)[idx];
-
+//LOG("%s called", __func__);
 	// add=0 <--> x = x*0 + h =   h
 	// add=1 <--> x = x*1 + h = x+h
 	float newHeight = heightRef * add + h;
@@ -320,10 +320,10 @@ inline float CReadMap::SetHeight(const int idx, const float h, const int add) {
 	return (heightRef = newHeight);
 }
 
-inline float CReadMap::AddOriginalHeight(const int idx, const float a) { return SetHeight(idx, a, 1); }
+inline float CReadMap::AddOriginalHeight(const int idx, const float a) { return SetOriginalHeight(idx, a, 1); }
 inline float CReadMap::SetOriginalHeight(const int idx, const float h, const int add) {
 	float& heightRef = (*originalHeightMapPtr)[idx];
-
+//LOG("%s called", __func__);
 	// add=0 <--> x = x*0 + h =   h
 	// add=1 <--> x = x*1 + h = x+h
 	float newHeight = heightRef * add + h;

--- a/rts/Map/ReadMap.h
+++ b/rts/Map/ReadMap.h
@@ -196,6 +196,9 @@ public:
 	float SetHeight(const int idx, const float h, const int add = 0);
 	float AddHeight(const int idx, const float a);
 
+	/// These will not modify the current heightmap, only the original
+	float SetOriginalHeight(const int idx, const float h, const int add = 0);
+	float AddOriginalHeight(const int idx, const float a);
 
 	float GetInitMinHeight() const { return initHeightBounds.x; }
 	float GetCurrMinHeight() const { return currHeightBounds.x; }
@@ -243,6 +246,7 @@ protected:
 	std::vector<float>* heightMapSyncedPtr = nullptr;      //< size: (mapx+1)*(mapy+1) (per vertex) [SYNCED, updates on terrain deformation]
 	std::vector<float>* heightMapUnsyncedPtr = nullptr;    //< size: (mapx+1)*(mapy+1) (per vertex) [UNSYNCED]
 
+	std::vector<float>* originalHeightMapPtr = nullptr;
 
 	// note: intentionally declared static, s.t. repeated reloading to the same
 	// (or any smaller) map does not fragment the heap which invites bad_alloc's
@@ -316,7 +320,16 @@ inline float CReadMap::SetHeight(const int idx, const float h, const int add) {
 	return (heightRef = newHeight);
 }
 
+inline float CReadMap::AddOriginalHeight(const int idx, const float a) { return SetHeight(idx, a, 1); }
+inline float CReadMap::SetOriginalHeight(const int idx, const float h, const int add) {
+	float& heightRef = (*originalHeightMapPtr)[idx];
 
+	// add=0 <--> x = x*0 + h =   h
+	// add=1 <--> x = x*1 + h = x+h
+	float newHeight = heightRef * add + h;
+	hmUpdated |= (newHeight != heightRef);
+	return (heightRef = newHeight);
+}
 
 
 static inline float3 CornerSqrToPosRaw(const float* hm, int sqx, int sqz) { return {sqx * SQUARE_SIZE * 1.0f, hm[(sqz * mapDims.mapxp1) + sqx], sqz * SQUARE_SIZE * 1.0f}; }


### PR DESCRIPTION
Updated readmap to work correctly when Lua code changes the heightmap before the match starts.

Tested on Quicksilver with map_waterlevel set to 200 - restore command doesn't build a pillar to the sky as it has done in the past, the correct height maintained by restore command now.

Made map changes on the same setup by spawning and self-d coms. Made some restores to land - parts restored went to the expected height level. Left plenty of crater. Saved game and loaded to show that the map is reloaded with correct waterlevel and the terrain deformation is restored correctly. Also tried a restore command and the it worked as expected - as per prior to save/load cycle.

Test on Zero-K with a random map. Save/load, the map looked indentical without additional warping or changes. Any prior terraforming was also correctly loaded after save. Restore command worked as expected.