### PR TITLE
Add `Spring.AddUnitExperience(unitID, deltaXP)`

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -8,6 +8,8 @@ Lua:
  - allow empty argument for Spring.GetKeyBindings to return all keybindings
  - `firestarter` weapon tag no longer capped at 10000 in defs (which
    becomes 100 in Lua after rescale). Now uncapped.
+ - add Spring.AddUnitExperience(unitID, delta_xp). Can subtract, but the result cannot be negative.
+
 Maps:
  - New bumpwater params, most of these were just hard-coded values:
     - waveOffsetFactor    (0.0)

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -166,6 +166,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetUnitWeaponDamages);
 	REGISTER_LUA_CFUNC(SetUnitMaxRange);
 	REGISTER_LUA_CFUNC(SetUnitExperience);
+	REGISTER_LUA_CFUNC(AddUnitExperience);
 	REGISTER_LUA_CFUNC(SetUnitArmored);
 	REGISTER_LUA_CFUNC(SetUnitLosMask);
 	REGISTER_LUA_CFUNC(SetUnitLosState);
@@ -1878,6 +1879,18 @@ int LuaSyncedCtrl::SetUnitExperience(lua_State* L)
 		return 0;
 
 	unit->AddExperience(std::max(0.0f, luaL_checkfloat(L, 2)) - unit->experience);
+	return 0;
+}
+
+int LuaSyncedCtrl::AddUnitExperience(lua_State* L)
+{
+	CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	// can subtract, but the result can't be negative
+	unit->AddExperience(std::max(-unit->experience, luaL_checkfloat(L, 2)));
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -79,6 +79,7 @@ class LuaSyncedCtrl
 		static int SetUnitWeaponDamages(lua_State* L);
 		static int SetUnitMaxRange(lua_State* L);
 		static int SetUnitExperience(lua_State* L);
+		static int AddUnitExperience(lua_State* L);
 		static int SetUnitArmored(lua_State* L);
 		static int SetUnitLosMask(lua_State* L);
 		static int SetUnitLosState(lua_State* L);


### PR DESCRIPTION
Perf/convenience so that I don't have to do `Set(Get() + deltaXP)`.

Possibly Add should be made available for other common functions that abuse the Set+Get pattern (in particular SetUnitHealth) but that is outside the scope of this patch.