### PR TITLE
Allow using <random> from c++ standard library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,7 +344,6 @@ else (MSVC)
 endif(MSVC)
 
 add_definitions(-D_GLIBCXX_USE_NANOSLEEP) # issue in std::chrono with gentoo and few other distros
-add_definitions(-D_RANDOM_TCC) # don't include <bits/random.tcc>, it fails to compile with single precision constants
 
 
 ### our custom OpenMP replacement


### PR DESCRIPTION
It was added when c++11 was introduced 9 years ago but now without it it compiles fine. I'm using <random> in https://github.com/beyond-all-reason/pr-downloader/pull/9 and with that define set, compilation fails with

```
[ 46%] Linking CXX executable pr-downloader
/usr/include/c++/10/bits/random.h:192: error: undefined reference to 'double std::generate_canonical<double, 53ul, std::linear_congruential_engine<unsigned long, 16807ul, 0ul, 2147483647ul> >(std::linear_congruential_engine<unsigned long, 16807ul, 0ul, 2147483647ul>&)'
/usr/include/c++/10/bits/random.h:294: error: undefined reference to 'std::linear_congruential_engine<unsigned long, 16807ul, 0ul, 2147483647ul>::seed(unsigned long)'
/usr/include/c++/10/bits/random.h:294: error: undefined reference to 'std::linear_congruential_engine<unsigned long, 16807ul, 0ul, 2147483647ul>::seed(unsigned long)'
collect2: error: ld returned 1 exit status
```