### PR TITLE
Link libnghttp2 together with libcurl.

### DIFF
--- a/docker-build/scripts/02_configure.sh
+++ b/docker-build/scripts/02_configure.sh
@@ -48,7 +48,7 @@ if [ "${PLATFORM}" == "linux-64" ]; then
         -DLIBUNWIND_INCLUDE_DIRS:PATH=${INCLUDEDIR}
         -DLIBUNWIND_LIBRARY:PATH=${LIBDIR}/libunwind.a
         -DCURL_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DCURL_LIBRARY:PATH=${LIBDIR}/libcurl.a
+        -DCURL_LIBRARY:PATH="${LIBDIR}/libcurl.a;${LIBDIR}/libnghttp2.a"
         -DOPENSSL_INCLUDE_DIR:PATH=${INCLUDEDIR}
         -DOPENSSL_SSL_LIBRARY:PATH=${LIBDIR}/libssl.a
         -DOPENSSL_CRYPTO_LIBRARY:PATH=${LIBDIR}/libcrypto.a


### PR DESCRIPTION
This is needed once https://github.com/beyond-all-reason/spring-static-libs/pull/1 is merged, to enable HTTP2 support needed by https://github.com/beyond-all-reason/pr-downloader/pull/9. Without this change, linking of pr-downloader on linux-64 platform will fail.

Why do it this way, see commit message text.