### PR TITLE
F16-F24 scancode keybind support

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -25,6 +25,7 @@ Misc:
    define a bogus custom colvol just to prevent the default sphere.
  - don't warn for archive checksum mismatch if server's checksum is zero
  - 3D and Cubemap .dds textures supported in Lua
+ - add support for f16-f24 scancodes; keycodes awaiting fix in SDL2
 
 -- 105.0 --------------------------------------------------------
 Sim:

--- a/rts/Game/UI/KeyCodes.cpp
+++ b/rts/Game/UI/KeyCodes.cpp
@@ -110,30 +110,10 @@ void CKeyCodes::Reset()
 	AddPair("pagedown", SDLK_PAGEDOWN);
 
 	// Function keys
-	AddPair("f1",  SDLK_F1);
-	AddPair("f2",  SDLK_F2);
-	AddPair("f3",  SDLK_F3);
-	AddPair("f4",  SDLK_F4);
-	AddPair("f5",  SDLK_F5);
-	AddPair("f6",  SDLK_F6);
-	AddPair("f7",  SDLK_F7);
-	AddPair("f8",  SDLK_F8);
-	AddPair("f9",  SDLK_F9);
-	AddPair("f10", SDLK_F10);
-	AddPair("f11", SDLK_F11);
-	AddPair("f12", SDLK_F12);
-	AddPair("f13", SDLK_F13);
-	AddPair("f14", SDLK_F14);
-	AddPair("f15", SDLK_F15);
-	AddPair("f16", SDLK_F16);
-	AddPair("f17", SDLK_F17);
-	AddPair("f18", SDLK_F18);
-	AddPair("f19", SDLK_F19);
-	AddPair("f20", SDLK_F20);
-	AddPair("f21", SDLK_F21);
-	AddPair("f22", SDLK_F22);
-	AddPair("f23", SDLK_F23);
-	AddPair("f24", SDLK_F24);
+	for (int i = 0; i < 12; i++) {
+		AddPair("f" + IntToString(i + 1 ), SDLK_F1  + i);
+		AddPair("f" + IntToString(i + 13), SDLK_F13 + i);
+	}
 
 	// Key state modifier keys
 	//AddPair("numlock", SDLK_NUMLOCK);

--- a/rts/Game/UI/KeyCodes.cpp
+++ b/rts/Game/UI/KeyCodes.cpp
@@ -125,6 +125,15 @@ void CKeyCodes::Reset()
 	AddPair("f13", SDLK_F13);
 	AddPair("f14", SDLK_F14);
 	AddPair("f15", SDLK_F15);
+	AddPair("f16", SDLK_F16);
+	AddPair("f17", SDLK_F17);
+	AddPair("f18", SDLK_F18);
+	AddPair("f19", SDLK_F19);
+	AddPair("f20", SDLK_F20);
+	AddPair("f21", SDLK_F21);
+	AddPair("f22", SDLK_F22);
+	AddPair("f23", SDLK_F23);
+	AddPair("f24", SDLK_F24);
 
 	// Key state modifier keys
 	//AddPair("numlock", SDLK_NUMLOCK);

--- a/rts/Game/UI/ScanCodes.cpp
+++ b/rts/Game/UI/ScanCodes.cpp
@@ -190,30 +190,10 @@ void CScanCodes::Reset()
 	AddPair("sc_pagedown", SDL_SCANCODE_PAGEDOWN);
 
 	// Function keys
-	AddPair("sc_f1",  SDL_SCANCODE_F1);
-	AddPair("sc_f2",  SDL_SCANCODE_F2);
-	AddPair("sc_f3",  SDL_SCANCODE_F3);
-	AddPair("sc_f4",  SDL_SCANCODE_F4);
-	AddPair("sc_f5",  SDL_SCANCODE_F5);
-	AddPair("sc_f6",  SDL_SCANCODE_F6);
-	AddPair("sc_f7",  SDL_SCANCODE_F7);
-	AddPair("sc_f8",  SDL_SCANCODE_F8);
-	AddPair("sc_f9",  SDL_SCANCODE_F9);
-	AddPair("sc_f10", SDL_SCANCODE_F10);
-	AddPair("sc_f11", SDL_SCANCODE_F11);
-	AddPair("sc_f12", SDL_SCANCODE_F12);
-	AddPair("sc_f13", SDL_SCANCODE_F13);
-	AddPair("sc_f14", SDL_SCANCODE_F14);
-	AddPair("sc_f15", SDL_SCANCODE_F15);
-	AddPair("sc_f16", SDL_SCANCODE_F16);
-	AddPair("sc_f17", SDL_SCANCODE_F17);
-	AddPair("sc_f18", SDL_SCANCODE_F18);
-	AddPair("sc_f19", SDL_SCANCODE_F19);
-	AddPair("sc_f20", SDL_SCANCODE_F20);
-	AddPair("sc_f21", SDL_SCANCODE_F21);
-	AddPair("sc_f22", SDL_SCANCODE_F22);
-	AddPair("sc_f23", SDL_SCANCODE_F23);
-	AddPair("sc_f24", SDL_SCANCODE_F24);
+	for (int i = 0; i < 12; i++) {
+		AddPair("sc_f" + IntToString(i + 1 ), SDL_SCANCODE_F1  + i);
+		AddPair("sc_f" + IntToString(i + 13), SDL_SCANCODE_F13 + i);
+	}
 
 	// Key state modifier keys
 	//AddPair("sc_numlock", SDL_SCANCODE_NUMLOCKCLEAR);

--- a/rts/Game/UI/ScanCodes.cpp
+++ b/rts/Game/UI/ScanCodes.cpp
@@ -205,6 +205,15 @@ void CScanCodes::Reset()
 	AddPair("sc_f13", SDL_SCANCODE_F13);
 	AddPair("sc_f14", SDL_SCANCODE_F14);
 	AddPair("sc_f15", SDL_SCANCODE_F15);
+	AddPair("sc_f16", SDL_SCANCODE_F16);
+	AddPair("sc_f17", SDL_SCANCODE_F17);
+	AddPair("sc_f18", SDL_SCANCODE_F18);
+	AddPair("sc_f19", SDL_SCANCODE_F19);
+	AddPair("sc_f20", SDL_SCANCODE_F20);
+	AddPair("sc_f21", SDL_SCANCODE_F21);
+	AddPair("sc_f22", SDL_SCANCODE_F22);
+	AddPair("sc_f23", SDL_SCANCODE_F23);
+	AddPair("sc_f24", SDL_SCANCODE_F24);
 
 	// Key state modifier keys
 	//AddPair("sc_numlock", SDL_SCANCODE_NUMLOCKCLEAR);


### PR DESCRIPTION
These values aren't available to Lua, since SDL1 only supports up to F15. Also it appears that due to a bug in SDL2, F13+ will only work with scancodes and not keycodes at this time. 

Keycode pairs have been added for bindings anyway, for when the SDL-internal fix is released.