### PR TITLE
Fix SDL TextInput documentation link in changelog

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -108,7 +108,7 @@ Lua:
    this was done by the engine). You can prevent this filter by adding
    the `dont_remove` field to such movedefs. This is useful to make
    them available in `Spring.MoveCtrl.SetMoveDef` but beware the perf cost.
- - new TextEditing(utf8, start, length) callin, which holds the IME editing composition (https://wiki.libsdl.org/Tutorials/TextInput)
+ - new TextEditing(utf8, start, length) callin, which holds the IME editing composition (https://wiki.libsdl.org/Tutorials-TextInput)
  - new SDLSetTextInputRect(x, y, w, h), SDLStartTextInput() and SDLStopTextInput() functions for controlling IME input from Lua
  - Add AllowUnitTransport callin. Called when the engine tests whether unit A can transport unit B. Returning true will let
    the engine decide, returning false will force the engine to disallow transportation (for this specific call).


### PR DESCRIPTION
Current link takes you to 404