### PR TITLE
Fix compilation under clang

### DIFF
--- a/rts/Rendering/GL/FixedPipelineState.h
+++ b/rts/Rendering/GL/FixedPipelineState.h
@@ -172,9 +172,9 @@ namespace GL {
 		void BindUnbind(const bool bind) const;
 
 		template <typename... T>
-		constexpr void DumpState(const std::tuple<T...>& tuple);
+		inline void DumpState(const std::tuple<T...>& tuple);
 		template <typename... T>
-		constexpr void HashState(const std::tuple<T...>& tuple);
+		inline void HashState(const std::tuple<T...>& tuple);
 	private:
 		static void BindTextureProxy(GLenum texUnit, GLenum texType, GLuint texID) { glActiveTexture(texUnit); glBindTexture(texType, texID); }
 	private:
@@ -223,7 +223,7 @@ namespace GL {
 
 
 	template<typename ...T>
-	inline constexpr void FixedPipelineState::DumpState(const std::tuple<T...>& tuple)
+	inline void FixedPipelineState::DumpState(const std::tuple<T...>& tuple)
 	{
 	#if (DEBUG_PIPELINE_STATE == 1)
 		std::ostringstream ss;
@@ -237,7 +237,7 @@ namespace GL {
 	}
 
 	template<typename ...T>
-	inline constexpr void GL::FixedPipelineState::HashState(const std::tuple<T...>& tuple)
+	inline void FixedPipelineState::HashState(const std::tuple<T...>& tuple)
 	{
 		const auto lambda = [this](auto&&... args) -> uint64_t {
 			return ((hashString(reinterpret_cast<const char*>(&args), sizeof(args)) * 65521) + ...);

--- a/rts/Rendering/GL/VertexArrayTypes.cpp
+++ b/rts/Rendering/GL/VertexArrayTypes.cpp
@@ -3,7 +3,7 @@
 #include "VertexArrayTypes.h"
 
 #define VA_TYPE_OFFSET(T, m) reinterpret_cast<const void*>(offsetof(T, m))
-#define VA_ATTR_DEF(T, idx, count, type, member, normalized, name) AttributeDef(idx, count, type, sizeof(T), VA_TYPE_OFFSET(T, T::member), normalized, name)
+#define VA_ATTR_DEF(T, idx, count, type, member, normalized, name) AttributeDef(idx, count, type, sizeof(T), VA_TYPE_OFFSET(T, member), normalized, name)
 
 std::array<AttributeDef, 1> VA_TYPE_0::attributeDefs = {
 	VA_ATTR_DEF(VA_TYPE_0, 0, 3, GL_FLOAT, p, false, "pos")


### PR DESCRIPTION
See the individual commits.

Overall there is also plenty of very interesting warning messages that seem (IMHO) very useful from clang, that are not present from gcc, like `spring/rts/Rendering/GL/FixedPipelineState.h:72:11: warning: binding reference member 'func' to stack allocated parameter 'func_' [-Wdangling-field]`.