### PR TITLE
Add option for rapid tag resolution domain preference order

### DIFF
--- a/rts/System/FileSystem/RapidHandler.cpp
+++ b/rts/System/FileSystem/RapidHandler.cpp
@@ -111,6 +111,9 @@ std::string GetRapidPackageFromTag(const std::string& tag)
 	for (const std::string& file: dataDirsAccess.FindFiles("rapid", "versions.gz", FileQueryFlags::RECURSE)) {
 		RapidEntry re;
 		if (GetRapidEntry(dataDirsAccess.LocateFile(file), &re, [&](const RapidEntry& re) { return re.GetTag() == tag; })) {
+			// The `file` path looks like `rapid/[domain]/[repo]/versions.gz`
+			// e.g: `rapid/repos.springrts.com/byar-chobby/versions.gz` as created
+			// by pr-downloader. We extract the domain part from it.
 			const auto rapidDomain = std::filesystem::path{file}.parent_path().parent_path().filename().string();
 			std::size_t new_rank = std::numeric_limits<std::size_t>::max() - 1;
 			if (auto it = std::find(order.begin(), order.end(), rapidDomain); it != order.end()) {

--- a/rts/System/FileSystem/RapidHandler.cpp
+++ b/rts/System/FileSystem/RapidHandler.cpp
@@ -100,6 +100,11 @@ static std::vector<std::string> ParseRapidTagResolutionOrder() {
 		order.emplace_back(orderStr.substr(beg, end - beg));
 	}
 	order.emplace_back(orderStr.substr(beg,orderStr.size() - beg));
+
+	static const std::string springRtsRepo = "repos.springrts.com";
+	if (std::find(order.begin(), order.end(), springRtsRepo) == order.end()) {
+		order.emplace_back(springRtsRepo);
+	}
 	return order;
 }
 


### PR DESCRIPTION
There can be multiple domains from which the packages are being
downloaded, for example when additonal mirrors are used. This adds
support for picking from which domain version.gz files should be
used first.