### PR TITLE
fix choppy spring camera

### DIFF
--- a/rts/Game/Camera/SpringController.cpp
+++ b/rts/Game/Camera/SpringController.cpp
@@ -202,8 +202,8 @@ void CSpringController::Update()
 	pos.y = CGround::GetHeightReal(pos.x, pos.z, false);
 	rot.x = Clamp(rot.x, math::PI * 0.51f, math::PI * 0.99f);
 
-	camera->SetRot(float3(rot.x, GetAzimuth(), rot.z));
-	dir = camera->GetDir();
+	// camera->SetRot(float3(rot.x, GetAzimuth(), rot.z));
+	dir = CCamera::GetFwdFromRot(rot);
 
 	curDist = Clamp(curDist, 20.0f, maxDist);
 	pixelSize = (camera->GetTanHalfFov() * 2.0f) / globalRendering->viewSizeY * curDist * 2.0f;


### PR DESCRIPTION
spring camera gets choppy when smoothing from gui_options widget is
activated as widget is continously calling CameraTransition from
SetCameraTarget function. as long as SpringCameraController does not
change the position of camera directly the animation remains smooth.
the camera will be updated by camera handler in the game loop instead.