### PR TITLE
Fix SDL stubs for version >=2.24

### DIFF
--- a/rts/lib/headlessStubs/sdlstub.c
+++ b/rts/lib/headlessStubs/sdlstub.c
@@ -341,8 +341,13 @@ extern DECLSPEC SDL_bool SDL_SetHint(const char* name, const char* value) {
 	return SDL_TRUE;
 }
 
+#if SDL_VERSION_ATLEAST(2,24,0)
+extern DECLSPEC void SDLCALL SDL_SetTextInputRect(SDL_Rect const *rect) {
+}
+#else
 extern DECLSPEC void SDLCALL SDL_SetTextInputRect(SDL_Rect *rect) {
 }
+#endif
 
 extern DECLSPEC void SDLCALL SDL_StartTextInput(void) {
 }


### PR DESCRIPTION
rect become const in 2.24 with commit [b085c18251bc0298b1a78a621025978702ca07f7](https://github.com/libsdl-org/SDL/commit/b085c18251bc0298b1a78a621025978702ca07f7) in the SDL repository.