### PR TITLE
Placement-new serialization of objects with container reference

### DIFF
--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -147,7 +147,8 @@ CR_REG_METADATA(CGroundMoveType, (
 	CR_MEMBER(useMainHeading),
 	CR_MEMBER(useRawMovement),
 
-	CR_POSTLOAD(PostLoad)
+	CR_POSTLOAD(PostLoad),
+	CR_PREALLOC(GetPreallocContainer)
 ))
 
 

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -29,6 +29,7 @@ public:
 	};
 
 	void PostLoad();
+	void* GetPreallocContainer() { return owner; }  // creg
 
 	bool Update() override;
 	void SlowUpdate() override;

--- a/rts/Sim/MoveTypes/HoverAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.cpp
@@ -47,7 +47,9 @@ CR_REG_METADATA(CHoverAirMoveType, (
 	CR_MEMBER(forcedHeading),
 
 	CR_MEMBER(waitCounter),
-	CR_MEMBER(lastMoveRate)
+	CR_MEMBER(lastMoveRate),
+
+	CR_PREALLOC(GetPreallocContainer)
 ))
 
 

--- a/rts/Sim/MoveTypes/HoverAirMoveType.h
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.h
@@ -13,6 +13,8 @@ class CHoverAirMoveType: public AAirMoveType
 public:
 	CHoverAirMoveType(CUnit* owner);
 
+	void* GetPreallocContainer() { return owner; }  // creg
+
 	// MoveType interface
 	bool Update() override;
 	void SlowUpdate() override;

--- a/rts/Sim/MoveTypes/ScriptMoveType.cpp
+++ b/rts/Sim/MoveTypes/ScriptMoveType.cpp
@@ -42,7 +42,9 @@ CR_REG_METADATA(CScriptMoveType, (
 	CR_MEMBER(groundStop),
 	CR_MEMBER(limitsStop),
 
-	CR_MEMBER(scriptNotify)
+	CR_MEMBER(scriptNotify),
+
+	CR_PREALLOC(GetPreallocContainer)
 ))
 
 

--- a/rts/Sim/MoveTypes/ScriptMoveType.h
+++ b/rts/Sim/MoveTypes/ScriptMoveType.h
@@ -13,6 +13,8 @@ class CScriptMoveType : public AMoveType
 		CScriptMoveType(CUnit* owner);
 		virtual ~CScriptMoveType();
 
+		void* GetPreallocContainer() { return owner; }  // creg
+
 	public:
 		bool Update() override;
 		void ForceUpdates();

--- a/rts/Sim/MoveTypes/StaticMoveType.cpp
+++ b/rts/Sim/MoveTypes/StaticMoveType.cpp
@@ -7,7 +7,9 @@
 #include "Sim/Units/UnitDef.h"
 
 CR_BIND_DERIVED(CStaticMoveType, AMoveType, (nullptr))
-CR_REG_METADATA(CStaticMoveType, )
+CR_REG_METADATA(CStaticMoveType, (
+	CR_PREALLOC(GetPreallocContainer)
+))
 
 void CStaticMoveType::SlowUpdate()
 {

--- a/rts/Sim/MoveTypes/StaticMoveType.h
+++ b/rts/Sim/MoveTypes/StaticMoveType.h
@@ -15,6 +15,8 @@ public:
 		useWantedSpeed[ true] = false;
 	}
 
+	void* GetPreallocContainer() { return owner; }  // creg
+
 	void StartMoving(float3 pos, float goalRadius) override {}
 	void StartMoving(float3 pos, float goalRadius, float speed) override {}
 	void StopMoving(bool callScript = false, bool hardStop = false, bool cancelRaw = false) override {}

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -51,7 +51,9 @@ CR_REG_METADATA(CStrafeAirMoveType, (
 
 	CR_MEMBER(lastRudderPos),
 	CR_MEMBER(lastElevatorPos),
-	CR_MEMBER(lastAileronPos)
+	CR_MEMBER(lastAileronPos),
+
+	CR_PREALLOC(GetPreallocContainer)
 ))
 
 

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.h
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.h
@@ -24,6 +24,8 @@ public:
 
 	CStrafeAirMoveType(CUnit* owner);
 
+	void* GetPreallocContainer() { return owner; }  // creg
+
 	bool Update() override;
 	void SlowUpdate() override;
 

--- a/rts/Sim/Units/CommandAI/AirCAI.cpp
+++ b/rts/Sim/Units/CommandAI/AirCAI.cpp
@@ -44,7 +44,9 @@ CR_REG_METADATA(CAirCAI, (
 	CR_MEMBER(targetAge),
 
 	CR_MEMBER(lastPC1),
-	CR_MEMBER(lastPC2)
+	CR_MEMBER(lastPC2),
+
+	CR_PREALLOC(GetPreallocContainer)
 ))
 
 CAirCAI::CAirCAI()

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -49,7 +49,8 @@ CR_REG_METADATA(CBuilderCAI , (
 	CR_MEMBER(lastPC1),
 	CR_MEMBER(lastPC2),
 	CR_MEMBER(lastPC3),
-	CR_POSTLOAD(PostLoad)
+	CR_POSTLOAD(PostLoad),
+	CR_PREALLOC(GetPreallocContainer)
 ))
 
 // not adding to members, should repopulate itself

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -75,7 +75,9 @@ CR_REG_METADATA(CCommandAI, (
 	CR_MEMBER(repeatOrders),
 	CR_MEMBER(lastSelectedCommandPage),
 	CR_MEMBER(commandDeathDependences),
-	CR_MEMBER(targetLostTimer)
+	CR_MEMBER(targetLostTimer),
+
+	CR_PREALLOC(GetPreallocContainer)
 ))
 
 CCommandAI::CCommandAI():

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -26,6 +26,8 @@ public:
 	CCommandAI();
 	virtual ~CCommandAI();
 
+	void* GetPreallocContainer() { return owner; }  // creg
+
 	void DependentDied(CObject* o);
 
 	static void InitCommandDescriptionCache();

--- a/rts/Sim/Units/CommandAI/FactoryCAI.cpp
+++ b/rts/Sim/Units/CommandAI/FactoryCAI.cpp
@@ -24,7 +24,8 @@ CR_BIND_DERIVED(CFactoryCAI ,CCommandAI , )
 
 CR_REG_METADATA(CFactoryCAI , (
 	CR_MEMBER(newUnitCommands),
-	CR_MEMBER(buildOptions)
+	CR_MEMBER(buildOptions),
+	CR_PREALLOC(GetPreallocContainer)
 ))
 
 static std::string GetUnitDefBuildOptionToolTip(const UnitDef* ud, bool disabled) {

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -75,7 +75,9 @@ CR_REG_METADATA(CMobileCAI, (
 	CR_MEMBER(lastCloseInTry),
 	CR_MEMBER(lastBuggerOffTime),
 	CR_MEMBER(numNonMovingCalls),
-	CR_MEMBER(lastIdleCheck)
+	CR_MEMBER(lastIdleCheck),
+
+	CR_PREALLOC(GetPreallocContainer)
 ))
 
 CMobileCAI::CMobileCAI():

--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -47,7 +47,8 @@ CR_REG_METADATA(CCobInstance, (
 	CR_MEMBER(staticVars),
 	CR_MEMBER(threadIDs),
 
-	CR_POSTLOAD(PostLoad)
+	CR_POSTLOAD(PostLoad),
+	CR_PREALLOC(GetUnit)
 ))
 
 

--- a/rts/Sim/Units/Scripts/LuaUnitScript.cpp
+++ b/rts/Sim/Units/Scripts/LuaUnitScript.cpp
@@ -33,7 +33,8 @@ CR_REG_METADATA(CLuaUnitScript, (
 	CR_MEMBER(scriptNames),
 	CR_IGNORED(inKilled),
 	CR_SERIALIZER(Serialize),
-	CR_POSTLOAD(PostLoad)
+	CR_POSTLOAD(PostLoad),
+	CR_PREALLOC(GetUnit)
 ))
 
 void CLuaUnitScript::PostLoad()

--- a/rts/System/creg/creg.cpp
+++ b/rts/System/creg/creg.cpp
@@ -197,6 +197,16 @@ void* Class::CreateInstance(size_t size)
 	return inst;
 }
 
+void* Class::CreateInstance(size_t size, void* addr)
+{
+	void* inst = ::operator new(size, addr);
+
+	if (constructor != nullptr)
+		constructor(inst);
+
+	return inst;
+}
+
 void Class::DeleteInstance(void* inst)
 {
 	if (destructor != nullptr)

--- a/rts/System/creg/creg_cond.h
+++ b/rts/System/creg/creg_cond.h
@@ -48,6 +48,7 @@
 #define CR_MEMBER_ENDFLAG(Flag)
 #define CR_SERIALIZER(SerializeFunc)
 #define CR_POSTLOAD(PostLoadFunc)
+#define CR_PREALLOC(GetContainerFunc)
 #endif // NOT_USING_CREG
 
 #endif // _CREG_COND_H_


### PR DESCRIPTION
Checking alternative approach: feels like developing interface for containers that does placement-new (acts like factory) could be more intuitive thing for understanding and future re-use. Unless it adds additional overhead during main game loop, then it's no go.