### PR TITLE
Serialize AtlasedTexture* members

### DIFF
--- a/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.cpp
+++ b/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.cpp
@@ -19,15 +19,16 @@ CR_REG_METADATA(CBitmapMuzzleFlame,
 (
 	CR_MEMBER(invttl),
 	CR_MEMBER_BEGINFLAG(CM_Config),
-		CR_MEMBER(sideTexture),
-		CR_MEMBER(frontTexture),
+		CR_IGNORED(sideTexture),
+		CR_IGNORED(frontTexture),
 		CR_MEMBER(colorMap),
 		CR_MEMBER(size),
 		CR_MEMBER(length),
 		CR_MEMBER(sizeGrowth),
 		CR_MEMBER(ttl),
 		CR_MEMBER(frontOffset),
-	CR_MEMBER_ENDFLAG(CM_Config)
+	CR_MEMBER_ENDFLAG(CM_Config),
+	CR_SERIALIZER(Serialize)
 ))
 
 CBitmapMuzzleFlame::CBitmapMuzzleFlame()
@@ -45,6 +46,21 @@ CBitmapMuzzleFlame::CBitmapMuzzleFlame()
 	useAirLos = true;
 	checkCol  = false;
 	deleteMe  = false;
+}
+
+void CBitmapMuzzleFlame::Serialize(creg::ISerializer* s)
+{
+	std::string sideName, frontName;
+	if (s->IsWriting()) {
+		sideName = projectileDrawer->textureAtlas->GetTextureName(sideTexture);
+		frontName = projectileDrawer->textureAtlas->GetTextureName(frontTexture);
+	}
+	creg::GetType(sideName)->Serialize(s, &sideName);
+	creg::GetType(frontName)->Serialize(s, &frontName);
+	if (!s->IsWriting()) {
+		sideTexture = projectileDrawer->textureAtlas->GetTexturePtr(sideName);
+		frontTexture = projectileDrawer->textureAtlas->GetTexturePtr(frontName);
+	}
 }
 
 void CBitmapMuzzleFlame::Draw()

--- a/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.h
+++ b/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.h
@@ -15,6 +15,8 @@ class CBitmapMuzzleFlame : public CProjectile
 public:
 	CBitmapMuzzleFlame();
 
+	void Serialize(creg::ISerializer* s);
+
 	void Draw() override;
 	void Update() override;
 

--- a/rts/Rendering/Env/Particles/Classes/DirtProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/DirtProjectile.cpp
@@ -23,8 +23,9 @@ CR_REG_METADATA(CDirtProjectile,
 		CR_MEMBER(sizeExpansion),
 		CR_MEMBER(slowdown),
 		CR_MEMBER(color),
-		CR_MEMBER(texture),
-	CR_MEMBER_ENDFLAG(CM_Config)
+		CR_IGNORED(texture),
+	CR_MEMBER_ENDFLAG(CM_Config),
+	CR_SERIALIZER(Serialize)
 ))
 
 
@@ -62,6 +63,16 @@ CDirtProjectile::CDirtProjectile() :
 	texture = projectileDrawer->randdotstex;
 }
 
+void CDirtProjectile::Serialize(creg::ISerializer* s)
+{
+	std::string name;
+	if (s->IsWriting())
+		name = projectileDrawer->textureAtlas->GetTextureName(texture);
+	creg::GetType(name)->Serialize(s, &name);
+	if (!s->IsWriting())
+		texture = name.empty() ? projectileDrawer->randdotstex
+				: projectileDrawer->textureAtlas->GetTexturePtr(name);
+}
 
 void CDirtProjectile::Update()
 {

--- a/rts/Rendering/Env/Particles/Classes/DirtProjectile.h
+++ b/rts/Rendering/Env/Particles/Classes/DirtProjectile.h
@@ -23,6 +23,8 @@ public:
 		const float3& color
 	);
 
+	void Serialize(creg::ISerializer* s);
+
 	void Draw() override;
 	void Update() override;
 

--- a/rts/Rendering/Env/Particles/Classes/GenericParticleProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/GenericParticleProjectile.cpp
@@ -5,6 +5,7 @@
 #include "GenericParticleProjectile.h"
 #include "Rendering/GL/RenderBuffers.h"
 #include "Rendering/Textures/ColorMap.h"
+#include "Rendering/Env/Particles/ProjectileDrawer.h"
 #include "Sim/Projectiles/ProjectileHandler.h"
 #include "System/creg/DefTypes.h"
 
@@ -12,7 +13,7 @@ CR_BIND_DERIVED(CGenericParticleProjectile, CProjectile, )
 
 CR_REG_METADATA(CGenericParticleProjectile,(
 	CR_MEMBER(gravity),
-	CR_MEMBER(texture),
+	CR_IGNORED(texture),
 	CR_MEMBER(colorMap),
 	CR_MEMBER(directional),
 	CR_MEMBER(life),
@@ -20,7 +21,8 @@ CR_REG_METADATA(CGenericParticleProjectile,(
 	CR_MEMBER(size),
 	CR_MEMBER(airdrag),
 	CR_MEMBER(sizeGrowth),
-	CR_MEMBER(sizeMod)
+	CR_MEMBER(sizeMod),
+	CR_SERIALIZER(Serialize)
 ))
 
 
@@ -44,6 +46,15 @@ CGenericParticleProjectile::CGenericParticleProjectile(const CUnit* owner, const
 	deleteMe  = false;
 }
 
+void CGenericParticleProjectile::Serialize(creg::ISerializer* s)
+{
+	std::string name;
+	if (s->IsWriting())
+		name = projectileDrawer->textureAtlas->GetTextureName(texture);
+	creg::GetType(name)->Serialize(s, &name);
+	if (!s->IsWriting())
+		texture = projectileDrawer->textureAtlas->GetTexturePtr(name);
+}
 
 void CGenericParticleProjectile::Update()
 {

--- a/rts/Rendering/Env/Particles/Classes/GenericParticleProjectile.h
+++ b/rts/Rendering/Env/Particles/Classes/GenericParticleProjectile.h
@@ -20,6 +20,8 @@ public:
 		const float3& speed
 	);
 
+	void Serialize(creg::ISerializer* s);
+
 	void Draw() override;
 	void Update() override;
 

--- a/rts/Rendering/Env/Particles/Classes/HeatCloudProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/HeatCloudProjectile.cpp
@@ -23,8 +23,9 @@ CR_REG_METADATA(CHeatCloudProjectile,
 		CR_MEMBER(sizeGrowth),
 		CR_MEMBER(sizemod),
 		CR_MEMBER(sizemodmod),
-		CR_MEMBER(texture),
-	CR_MEMBER_ENDFLAG(CM_Config)
+		CR_IGNORED(texture),
+	CR_MEMBER_ENDFLAG(CM_Config),
+	CR_SERIALIZER(Serialize)
 ))
 
 
@@ -66,6 +67,16 @@ CHeatCloudProjectile::CHeatCloudProjectile(
 	SetRadiusAndHeight(size + sizeGrowth * heat / heatFalloff, 0.0f);
 }
 
+void CHeatCloudProjectile::Serialize(creg::ISerializer* s)
+{
+	std::string name;
+	if (s->IsWriting())
+		name = projectileDrawer->textureAtlas->GetTextureName(texture);
+	creg::GetType(name)->Serialize(s, &name);
+	if (!s->IsWriting())
+		texture = name.empty() ? projectileDrawer->heatcloudtex
+				: projectileDrawer->textureAtlas->GetTexturePtr(name);
+}
 
 void CHeatCloudProjectile::Update()
 {

--- a/rts/Rendering/Env/Particles/Classes/HeatCloudProjectile.h
+++ b/rts/Rendering/Env/Particles/Classes/HeatCloudProjectile.h
@@ -21,6 +21,8 @@ public:
 		const float size
 	);
 
+	void Serialize(creg::ISerializer* s);
+
 	void Draw() override;
 	void Update() override;
 

--- a/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
@@ -25,7 +25,7 @@ CR_REG_METADATA(CSimpleParticleSystem,
 		CR_MEMBER(emitMul),
 		CR_MEMBER(gravity),
 		CR_MEMBER(colorMap),
-		CR_MEMBER(texture),
+		CR_IGNORED(texture),
 		CR_MEMBER(airdrag),
 		CR_MEMBER(particleLife),
 		CR_MEMBER(particleLifeSpread),
@@ -40,7 +40,8 @@ CR_REG_METADATA(CSimpleParticleSystem,
 		CR_MEMBER(sizeGrowth),
 		CR_MEMBER(sizeMod),
 	CR_MEMBER_ENDFLAG(CM_Config),
-	CR_MEMBER(particles)
+	CR_MEMBER(particles),
+	CR_SERIALIZER(Serialize)
 ))
 
 CR_BIND(CSimpleParticleSystem::Particle, )
@@ -81,6 +82,16 @@ CSimpleParticleSystem::CSimpleParticleSystem()
 {
 	checkCol = false;
 	useAirLos = true;
+}
+
+void CSimpleParticleSystem::Serialize(creg::ISerializer* s)
+{
+	std::string name;
+	if (s->IsWriting())
+		name = projectileDrawer->textureAtlas->GetTextureName(texture);
+	creg::GetType(name)->Serialize(s, &name);
+	if (!s->IsWriting())
+		texture = projectileDrawer->textureAtlas->GetTexturePtr(name);
 }
 
 void CSimpleParticleSystem::Draw()

--- a/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.h
+++ b/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.h
@@ -19,6 +19,8 @@ public:
 	CSimpleParticleSystem();
 	virtual ~CSimpleParticleSystem() { particles.clear(); }
 
+	void Serialize(creg::ISerializer* s);
+
 	void Draw() override;
 	void Update() override;
 	void Init(const CUnit* owner, const float3& offset) override;

--- a/rts/Rendering/Env/Particles/Classes/SmokeTrailProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SmokeTrailProjectile.cpp
@@ -31,7 +31,8 @@ CR_REG_METADATA(CSmokeTrailProjectile,(
 	CR_MEMBER(drawSegmented),
 	CR_MEMBER(firstSegment),
 	CR_MEMBER(lastSegment),
-	CR_MEMBER(texture)
+	CR_IGNORED(texture),
+	CR_SERIALIZER(Serialize)
 ))
 
 
@@ -75,6 +76,11 @@ CSmokeTrailProjectile::CSmokeTrailProjectile(
 	useAirLos |= ((pos.y - CGround::GetApproximateHeight(pos.x, pos.z)) > 10.0f);
 }
 
+void CSmokeTrailProjectile::Serialize(creg::ISerializer* s)
+{
+	if (!s->IsWriting())
+		texture = projectileDrawer->smoketrailtex;
+}
 
 void CSmokeTrailProjectile::UpdateEndPos(const float3 pos, const float3 dir)
 {

--- a/rts/Rendering/Env/Particles/Classes/SmokeTrailProjectile.h
+++ b/rts/Rendering/Env/Particles/Classes/SmokeTrailProjectile.h
@@ -28,6 +28,8 @@ public:
 		bool castShadow = true
 	);
 
+	void Serialize(creg::ISerializer* s);
+
 	void Update() override;
 	void Draw() override;
 

--- a/rts/Rendering/GroundFlash.cpp
+++ b/rts/Rendering/GroundFlash.cpp
@@ -47,12 +47,13 @@ CR_BIND_DERIVED(CSeismicGroundFlash, CGroundFlash, (ZeroVector, 1, 0, 1, 1, 1, Z
 CR_REG_METADATA(CSeismicGroundFlash, (
 	CR_MEMBER(side1),
 	CR_MEMBER(side2),
-	CR_MEMBER(texture),
+	CR_IGNORED(texture),
 	CR_MEMBER(sizeGrowth),
 	CR_MEMBER(alpha),
 	CR_MEMBER(fade),
 	CR_MEMBER(ttl),
-	CR_MEMBER(color)
+	CR_MEMBER(color),
+	CR_SERIALIZER(Serialize)
 ))
 
 CR_BIND_DERIVED(CSimpleGroundFlash, CGroundFlash, )
@@ -66,8 +67,9 @@ CR_REG_METADATA(CSimpleGroundFlash, (
 		CR_MEMBER(sizeGrowth),
 		CR_MEMBER(ttl),
 		CR_MEMBER(colorMap),
-		CR_MEMBER(texture),
-	CR_MEMBER_ENDFLAG(CM_Config)
+		CR_IGNORED(texture),
+	CR_MEMBER_ENDFLAG(CM_Config),
+	CR_SERIALIZER(Serialize)
 ))
 
 
@@ -282,6 +284,16 @@ CSimpleGroundFlash::CSimpleGroundFlash()
 
 }
 
+void CSimpleGroundFlash::Serialize(creg::ISerializer* s)
+{
+	std::string name;
+	if (s->IsWriting())
+		name = projectileDrawer->groundFXAtlas->GetTextureName(texture);
+	creg::GetType(name)->Serialize(s, &name);
+	if (!s->IsWriting())
+		texture = projectileDrawer->groundFXAtlas->GetTexturePtr(name);
+}
+
 void CSimpleGroundFlash::Init(const CUnit* owner, const float3& offset)
 {
 	pos += offset;
@@ -388,6 +400,12 @@ CSeismicGroundFlash::CSeismicGroundFlash(
 	side2 = side1.cross(normal);
 
 	projectileHandler.AddGroundFlash(this);
+}
+
+void CSeismicGroundFlash::Serialize(creg::ISerializer* s)
+{
+	if (!s->IsWriting())
+		texture = projectileDrawer->seismictex;
 }
 
 void CSeismicGroundFlash::Draw()

--- a/rts/Rendering/GroundFlash.h
+++ b/rts/Rendering/GroundFlash.h
@@ -93,6 +93,8 @@ public:
 
 	CSimpleGroundFlash();
 
+	void Serialize(creg::ISerializer* s);
+
 	void Init(const CUnit* owner, const float3& offset) override;
 	void Draw() override;
 	bool Update() override;
@@ -132,6 +134,8 @@ public:
 		float _alpha,
 		const float3& _color
 	);
+
+	void Serialize(creg::ISerializer* s);
 
 	void Draw() override;
 	/// @return false when it should be deleted

--- a/rts/Rendering/Textures/TextureAtlas.cpp
+++ b/rts/Rendering/Textures/TextureAtlas.cpp
@@ -296,6 +296,16 @@ AtlasedTexture& CTextureAtlas::GetTextureWithBackup(const std::string& name, con
 	return CTextureAtlas::dummy;
 }
 
+std::string CTextureAtlas::GetTextureName(AtlasedTexture* tex)
+{
+	if (texToName.empty()) {
+		for (auto& kv : textures)
+			texToName[&kv.second] = kv.first;
+	}
+	const auto it = texToName.find(tex);
+	return (it != texToName.end()) ? it->second : "";
+}
+
 int2 CTextureAtlas::GetSize() const {
 	return (atlasAllocator->GetAtlasSize());
 }

--- a/rts/Rendering/Textures/TextureAtlas.h
+++ b/rts/Rendering/Textures/TextureAtlas.h
@@ -80,6 +80,7 @@ public:
 			memTextures = std::move(ta.memTextures);
 			files = std::move(ta.files);
 			textures = std::move(ta.textures);
+			texToName = std::move(ta.texToName);
 			atlasTexID = ta.atlasTexID;
 			initialized = ta.initialized;
 			freeTexture = ta.freeTexture;
@@ -144,6 +145,8 @@ public:
 	 *         otherwise return a backup texture.
 	 */
 	AtlasedTexture& GetTextureWithBackup(const std::string& name, const std::string& backupName);
+
+	std::string GetTextureName(AtlasedTexture* tex);
 
 
 	IAtlasAllocator* GetAllocator() { return atlasAllocator; }
@@ -213,6 +216,7 @@ protected:
 
 	spring::unordered_map<std::string, size_t> files;
 	spring::unordered_map<std::string, AtlasedTexture> textures;
+	spring::unordered_map<AtlasedTexture*, std::string> texToName;  // non-creg serialization
 
 	uint32_t atlasTexID = 0;
 


### PR DESCRIPTION
Needs remake, can't initialize texture with `&CTextureAtlas::dummy`, so either have to add `PostLoad` to such classes, or convert pointer to embedded and save it - that requires special combination of x,y,z,w to consider it non-initialized.
Or consider serialization of CTextureAtlas - lifecycle container of AtlasedTexture.