### PR TITLE
GetActionHotkeys: Sort results by binding order

### DIFF
--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -880,7 +880,7 @@ void CKeyBindings::BuildHotkeyMap()
 
 	for (const auto& action: GetActionList()) {
 		HotkeyList& hl = hotkeys[action.command + (action.extra.empty() ? "" : " " + action.extra)];
-		hl.insert(action.boundWith);
+		hl.push_back(action.boundWith);
 	}
 }
 

--- a/rts/Game/UI/KeyBindings.h
+++ b/rts/Game/UI/KeyBindings.h
@@ -16,7 +16,7 @@
 class CKeyBindings : public CommandReceiver
 {
 	public:
-		typedef spring::unsynced_set<std::string> HotkeyList;
+		typedef std::vector<std::string> HotkeyList;
 		typedef std::function<bool (Action, Action)> ActionComparison;
 
 	protected:


### PR DESCRIPTION
Ensure binding order is preserved when returning hotkeys filtered by action, this is helpful for game developers to know the order precedence.