### PR TITLE
Add GetKeyFromScanSymbol callout

### DIFF
--- a/rts/Game/UI/KeyCodes.cpp
+++ b/rts/Game/UI/KeyCodes.cpp
@@ -75,6 +75,7 @@ void CKeyCodes::Reset()
 	}
 
 	AddPair("§", 0xA7, true);
+	AddPair("`", SDLK_BACKQUOTE, true);
 	AddPair("~", SDLK_BACKQUOTE, true);
 	AddPair("tilde", SDLK_BACKQUOTE, true);
 	AddPair("backquote", SDLK_BACKQUOTE, true);

--- a/rts/Lua/LuaIntro.cpp
+++ b/rts/Lua/LuaIntro.cpp
@@ -240,6 +240,7 @@ bool CLuaIntro::LoadUnsyncedReadFunctions(lua_State* L)
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetMouseState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetMouseCursor);
 
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyFromScanSymbol);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetModKeyState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetPressedKeys);

--- a/rts/Lua/LuaMenu.cpp
+++ b/rts/Lua/LuaMenu.cpp
@@ -288,6 +288,7 @@ bool CLuaMenu::LoadUnsyncedReadFunctions(lua_State* L)
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetMouseState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetMouseCursor);
 
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyFromScanSymbol);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetModKeyState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetPressedKeys);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -82,6 +82,7 @@
 #include <cctype>
 #include <algorithm>
 
+#include "SDL_keyboard.h"
 #include <SDL_clipboard.h>
 #include <SDL_keycode.h>
 #include <SDL_mouse.h>
@@ -226,6 +227,7 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetMouseCursor);
 	REGISTER_LUA_CFUNC(GetMouseStartPosition);
 
+	REGISTER_LUA_CFUNC(GetKeyFromScanSymbol);
 	REGISTER_LUA_CFUNC(GetKeyState);
 	REGISTER_LUA_CFUNC(GetModKeyState);
 	REGISTER_LUA_CFUNC(GetPressedKeys);
@@ -2537,6 +2539,26 @@ int LuaUnsyncedRead::IsUserWriting(lua_State* L)
 
 /******************************************************************************/
 /******************************************************************************/
+int LuaUnsyncedRead::GetKeyFromScanSymbol(lua_State* L)
+{
+	const std::string& symbol = luaL_optstring(L, 1, "");
+
+	std::string result = "";
+
+	if (!symbol.empty()) {
+
+		LOG_L(L_ERROR, "Received \"%s\".", symbol.c_str());
+		SDL_Scancode scanCode = (SDL_Scancode)scanCodes.GetCode(symbol);
+		LOG_L(L_ERROR, "Found scancode: \"%d\", name %s.", scanCode, scanCodes.GetName(scanCode).c_str());
+		SDL_KeyCode keyCode = (SDL_KeyCode)SDL_GetKeyFromScancode(scanCode);
+		result = keyCodes.GetName(keyCode);
+		LOG_L(L_ERROR, "Found keycode: \"%d\", name %s.", keyCode, result.c_str());
+	}
+
+	lua_pushstring(L, result.c_str());
+
+	return 1;
+}
 
 int LuaUnsyncedRead::GetKeyState(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -134,6 +134,7 @@ class LuaUnsyncedRead {
 		static int GetMouseCursor(lua_State* L);
 		static int GetMouseStartPosition(lua_State* L);
 
+		static int GetKeyFromScanSymbol(lua_State* L);
 		static int GetKeyState(lua_State* L);
 		static int GetModKeyState(lua_State* L);
 		static int GetPressedKeys(lua_State* L);


### PR DESCRIPTION
Retrieves the key on the user keyboard layout for a given scan symbol.

e.g.: Spring.GetKeyFromScanSymbol('sc_z') == 'y' // qwertz keylayout