### PR TITLE
Callouts: Add GetKeyFromScanSymbol(scanSymbol)

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -5,6 +5,8 @@ Spring changelog
 -- 106.0 --------------------------------------------------------
 
 Lua:
+ - Add Spring.GetKeyFromScanSymbol(scanSymbol) that receives a scancode and
+   returns the users correspondent key in the current keyboard layout
  - allow empty argument for Spring.GetKeyBindings to return all keybindings
  - `firestarter` weapon tag no longer capped at 10000 in defs (which
    becomes 100 in Lua after rescale). Now uncapped.

--- a/rts/Game/UI/KeyCodes.cpp
+++ b/rts/Game/UI/KeyCodes.cpp
@@ -74,10 +74,25 @@ void CKeyCodes::Reset()
 		AddPair(std::string(1, i), i, true);
 	}
 
-	AddPair("§", 0xA7, true);
 	AddPair("~", SDLK_BACKQUOTE, true);
 	AddPair("tilde", SDLK_BACKQUOTE, true);
 	AddPair("backquote", SDLK_BACKQUOTE, true);
+	AddPair("caret", SDLK_CARET, true);
+
+	AddPair("§", 0xA7, true);
+	AddPair("¨", 0xA8, true);
+	AddPair("²", 0xB2, true);
+	AddPair("ß", 0xDF, true);
+	AddPair("ä", 0xE4, true);
+	AddPair("ç", 0xE7, true);
+	AddPair("ö", 0xF6, true);
+	AddPair("ü", 0xFC, true);
+	AddPair("ù", 0xF9, true);
+	// Dead keys have low reliability in keydown events and keymap translations from scancodes in SDL
+	AddPair("´", 0xFE51, true); // dead_acute
+	//AddPair("^", 0xFE52, true); // dead_circumflex
+	//AddPair("~", 0xFE53, true); // dead_tilde
+
 
 	// Numeric keypad
 	AddPair("numpad0", SDLK_KP_0, true);

--- a/rts/Lua/LuaIntro.cpp
+++ b/rts/Lua/LuaIntro.cpp
@@ -240,6 +240,7 @@ bool CLuaIntro::LoadUnsyncedReadFunctions(lua_State* L)
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetMouseState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetMouseCursor);
 
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyFromScanSymbol);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetModKeyState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetPressedKeys);

--- a/rts/Lua/LuaMenu.cpp
+++ b/rts/Lua/LuaMenu.cpp
@@ -288,6 +288,7 @@ bool CLuaMenu::LoadUnsyncedReadFunctions(lua_State* L)
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetMouseState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetMouseCursor);
 
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyFromScanSymbol);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetKeyState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetModKeyState);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedRead, GetPressedKeys);

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -134,6 +134,7 @@ class LuaUnsyncedRead {
 		static int GetMouseCursor(lua_State* L);
 		static int GetMouseStartPosition(lua_State* L);
 
+		static int GetKeyFromScanSymbol(lua_State* L);
 		static int GetKeyState(lua_State* L);
 		static int GetModKeyState(lua_State* L);
 		static int GetPressedKeys(lua_State* L);


### PR DESCRIPTION
Returns the keysymbol correspondent to the keycode received by the game when the scanCode represented by the scanSymbol is received. In other terms: receives the position on the keyboard and returns the key in spring keycode format (uikeys).

For example, on a qwertz keyboard (see https://kbdlayout.info/kbdgr for reference):

Spring.GetKeyFromScanSymbol('sc_z') => 'y'
Spring.GetKeyFromScanSymbol('sc_[') => 'ü'