### PR TITLE
fix spring camera moving sideways when changing pitch

### DIFF
--- a/rts/Game/Camera/SpringController.cpp
+++ b/rts/Game/Camera/SpringController.cpp
@@ -203,7 +203,7 @@ void CSpringController::Update()
 	rot.x = Clamp(rot.x, math::PI * 0.51f, math::PI * 0.99f);
 
 	// camera->SetRot(float3(rot.x, GetAzimuth(), rot.z));
-	dir = CCamera::GetFwdFromRot(rot);
+	dir = CCamera::GetFwdFromRot(this->GetRot());
 
 	curDist = Clamp(curDist, 20.0f, maxDist);
 	pixelSize = (camera->GetTanHalfFov() * 2.0f) / globalRendering->viewSizeY * curDist * 2.0f;


### PR DESCRIPTION
bug present only when CamSpringLockCardinalDirections was enabled. to get actual horizontal camera rotation use GetAzimuth() which takes under consideration rotation snap to cardinal directions

also fixes #347 