### PR TITLE
Camera: Fix hardcoded reset and tilt bindings

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -5,6 +5,10 @@ Spring changelog
 -- 106.0 --------------------------------------------------------
 
 Lua:
+ - Add movetilt and movereset for previously hardcoded ALT and CTRL camera
+   bindings
+ - Fix moveslow and movefast camera bindings not being respected in favor of
+   hardcoded ones
  - Add Spring.GetPressedScans, for new returns output similar to
    GetPressedKeys but with scancodes
  - Add minx, maxy, maxx, miny = Spring.GetSelectionBox() returning coordinates

--- a/rts/Game/Camera.h
+++ b/rts/Game/Camera.h
@@ -49,6 +49,8 @@ public:
 		MOVE_STATE_DWN = 5, // down
 		MOVE_STATE_FST = 6, // fast
 		MOVE_STATE_SLW = 7, // slow
+		MOVE_STATE_TLT = 8, // tilt
+		MOVE_STATE_RST = 9, // reset
 	};
 
 	struct Frustum {
@@ -260,7 +262,7 @@ private:
 	// PROJTYPE_*
 	unsigned int projType = -1u;
 
-	bool movState[8]; // fwd, back, left, right, up, down, fast, slow
+	bool movState[10]; // fwd, back, left, right, up, down, fast, slow, tilt, reset
 	bool rotState[4]; // unused
 };
 

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -238,6 +238,9 @@ static const DefaultBinding defaultBindings[] = {
 	{    "Any+ctrl",     "moveslow"     },
 	{    "Any+shift",    "movefast"     },
 
+	{    "Any+ctrl",     "movetilt"     },
+	{    "Any+alt",      "movereset"    },
+
 	// selection keys
 	{ "Ctrl+a",    "select AllMap++_ClearSelection_SelectAll+"                                         },
 	{ "Ctrl+b",    "select AllMap+_Builder_Idle+_ClearSelection_SelectOne+"                            },
@@ -277,6 +280,8 @@ void CKeyBindings::Init()
 	statefulCommands.insert("movedown");
 	statefulCommands.insert("moveslow");
 	statefulCommands.insert("movefast");
+	statefulCommands.insert("movetilt");
+	statefulCommands.insert("movereset");
 
 	RegisterAction("bind");
 	RegisterAction("unbind");

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -3613,6 +3613,12 @@ bool CGame::ActionReleased(const Action& action)
 		case hashString("moveslow"): {
 			camera->SetMovState(CCamera::MOVE_STATE_SLW, false);
 		} break;
+		case hashString("movetilt"): {
+			camera->SetMovState(CCamera::MOVE_STATE_TLT, false);
+		} break;
+		case hashString("movereset"): {
+			camera->SetMovState(CCamera::MOVE_STATE_RST, false);
+		} break;
 
 		case hashString("mouse1"): {
 			mouse->MouseRelease(mouse->lastx, mouse->lasty, 1);
@@ -3686,14 +3692,16 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<MouseActionExecutor>(5));
 	AddActionExecutor(AllocActionExecutor<MouseCancelSelectionRectangleActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<ViewSelectionActionExecutor>());
-	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(0, "Forward"));
-	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(1, "Back"));
-	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(2, "Left"));
-	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(3, "Right"));
-	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(4, "Up"));
-	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(5, "Down"));
-	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(6, "Fast"));
-	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(7, "Slow"));
+	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_FWD, "Forward"));
+	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_BCK, "Back"));
+	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_LFT, "Left"));
+	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_RGT, "Right"));
+	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_UP , "Up"));
+	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_DWN, "Down"));
+	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_FST, "Fast"));
+	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_SLW, "Slow"));
+	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_TLT, "Tilt"));
+	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_RST, "Reset"));
 	AddActionExecutor(AllocActionExecutor<AIKillReloadActionExecutor>(true));
 	AddActionExecutor(AllocActionExecutor<AIKillReloadActionExecutor>(false));
 	AddActionExecutor(AllocActionExecutor<AIControlActionExecutor>());


### PR DESCRIPTION
Add movetilt and movereset for the previous hardcoded ctrl and alt bindings.

Fix movefast and moveslow not being respected for certain camera states (relying on hardcoded bindings instead)