### PR TITLE
Fix #243 (nil attacker in `Spring.DestroyUnit`)

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -1407,7 +1407,7 @@ int LuaSyncedCtrl::DestroyUnit(lua_State* L)
 	const bool recycleID = luaL_optboolean(L, 5, false);
 
 	CUnit* attacker = nullptr;
-	if (args >= 4)
+	if (!lua_isnil(L, 4))
 		attacker = ParseUnit(L, __func__, 4);
 
 	if (inDestroyUnit >= MAX_CMD_RECURSION_DEPTH)


### PR DESCRIPTION
Just because there are at least 4 args doesn't mean that the 4th arg isn't nil, and ParseUnit errors if it is.