### PR TITLE
Add `reclaim.unitDrainHealth` modrule

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -14,6 +14,8 @@ Lua:
  - allow empty argument for Spring.GetKeyBindings to return all keybindings
  - `firestarter` weapon tag no longer capped at 10000 in defs (which
    becomes 100 in Lua after rescale). Now uncapped.
+ - add modrule `reclaim.unitDrainHealth`, bool on whether reclaiming units drains health.
+   To be used with the revert-to-nanoframe method (since the 'classic' method relies on health drain).
  - add Spring.AddUnitExperience(unitID, delta_xp). Can subtract, but the result cannot be negative.
  - change widget, gadget and action handlers to support scancodes
  - Added Lua SyncedControl callins to modify the original/base heightmap (i.e. the values that the

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -1802,6 +1802,10 @@ EXPORT(float) skirmishAiCallback_Mod_getReclaimFeatureEnergyCostFactor(int skirm
 	return modInfo.reclaimFeatureEnergyCostFactor;
 }
 
+EXPORT(bool) skirmishAiCallback_Mod_getReclaimUnitDrainHealth(int skirmishAIId) {
+	return modInfo.reclaimUnitDrainHealth;
+}
+
 EXPORT(bool) skirmishAiCallback_Mod_getReclaimAllowEnemies(int skirmishAIId) {
 	return modInfo.reclaimAllowEnemies;
 }

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.h
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.h
@@ -839,6 +839,8 @@ EXPORT(float            ) skirmishAiCallback_Mod_getReclaimUnitEfficiency(int sk
 
 EXPORT(float            ) skirmishAiCallback_Mod_getReclaimFeatureEnergyCostFactor(int skirmishAIId);
 
+EXPORT(bool             ) skirmishAiCallback_Mod_getReclaimUnitDrainHealth(int skirmishAIId);
+
 EXPORT(bool             ) skirmishAiCallback_Mod_getReclaimAllowEnemies(int skirmishAIId);
 
 EXPORT(bool             ) skirmishAiCallback_Mod_getReclaimAllowAllies(int skirmishAIId);

--- a/rts/Lua/LuaConstGame.cpp
+++ b/rts/Lua/LuaConstGame.cpp
@@ -93,6 +93,7 @@ bool LuaConstGame::PushEntries(lua_State* L)
 		LuaPushNamedNumber(L, "reclaimUnitEnergyCostFactor"   , modInfo.reclaimUnitEnergyCostFactor);
 		LuaPushNamedNumber(L, "reclaimUnitEfficiency"         , modInfo.reclaimUnitEfficiency);
 		LuaPushNamedNumber(L, "reclaimFeatureEnergyCostFactor", modInfo.reclaimFeatureEnergyCostFactor);
+		LuaPushNamedBool  (L, "reclaimUnitDrainHealth"        , modInfo.reclaimUnitDrainHealth);
 		LuaPushNamedBool  (L, "reclaimAllowEnemies"           , modInfo.reclaimAllowEnemies);
 		LuaPushNamedBool  (L, "reclaimAllowAllies"            , modInfo.reclaimAllowAllies);
 		LuaPushNamedNumber(L, "repairEnergyCostFactor"        , modInfo.repairEnergyCostFactor);

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -50,6 +50,7 @@ void CModInfo::ResetState()
 		reclaimUnitEnergyCostFactor    = 0.0f;
 		reclaimUnitEfficiency          = 1.0f;
 		reclaimFeatureEnergyCostFactor = 0.0f;
+		reclaimUnitDrainHealth         = true;
 		reclaimAllowEnemies            = true;
 		reclaimAllowAllies             = true;
 	}
@@ -186,6 +187,7 @@ void CModInfo::Init(const std::string& modFileName)
 		reclaimUnitEnergyCostFactor = reclaimTbl.GetFloat("unitEnergyCostFactor", reclaimUnitEnergyCostFactor);
 		reclaimUnitEfficiency = reclaimTbl.GetFloat("unitEfficiency", reclaimUnitEfficiency);
 		reclaimFeatureEnergyCostFactor = reclaimTbl.GetFloat("featureEnergyCostFactor", reclaimFeatureEnergyCostFactor);
+		reclaimUnitDrainHealth = reclaimTbl.GetBool("unitDrainHealth", reclaimUnitDrainHealth);
 		reclaimAllowEnemies = reclaimTbl.GetBool("allowEnemies", reclaimAllowEnemies);
 		reclaimAllowAllies = reclaimTbl.GetBool("allowAllies", reclaimAllowAllies);
 	}

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -84,6 +84,8 @@ public:
 	float reclaimUnitEfficiency;
 	/// How much should energy should reclaiming a feature cost, default 0.0
 	float reclaimFeatureEnergyCostFactor;
+	/// Does wireframe reclaim drain health? default true
+	bool reclaimUnitDrainHealth;
 	/// Allow reclaiming enemies? default true
 	bool reclaimAllowEnemies;
 	/// Allow reclaiming allies? default true

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -1946,7 +1946,7 @@ bool CUnit::AddBuildPower(CUnit* builder, float amount)
 		const float metalRefundStep  =  cost.metal * step;
 		const float metalRefundStepScaled  =  metalRefundStep * modInfo.reclaimUnitEfficiency;
 		const float energyRefundStepScaled = energyRefundStep * modInfo.reclaimUnitEnergyCostFactor;
-		const float healthStep        = maxHealth * step;
+		const float healthStep        = modInfo.reclaimUnitDrainHealth ? maxHealth * step : 0;
 		const float buildProgressStep = int(modInfo.reclaimUnitMethod == 0) * step;
 		const float postHealth        = health + healthStep;
 		const float postBuildProgress = buildProgress + buildProgressStep;


### PR DESCRIPTION
Whether reclaiming drains health.
For the "wireframe reverse build" unit reclaim method (since the "classic" method relies on health drain).