### PR TITLE
Camera: Fix wrong windowcoords when offset present, rename to viewportcoords

### DIFF
--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -499,17 +499,17 @@ float3 CCamera::CalcPixelDir(int x, int y) const
 }
 
 
-float3 CCamera::CalcWindowCoordinates(const float3& objPos) const
+float3 CCamera::CalcViewPortCoordinates(const float3& objPos) const
 {
 	// same as gluProject()
 	const float4 projPos = viewProjectionMatrix * float4(objPos, 1.0f);
 	const float3 clipPos = float3(projPos) / projPos.w;
 
-	float3 winPos;
-	winPos.x = viewport[0] + viewport[2] * (clipPos.x + 1.0f) * 0.5f;
-	winPos.y = viewport[1] + viewport[3] * (clipPos.y + 1.0f) * 0.5f;
-	winPos.z =                             (clipPos.z + 1.0f) * 0.5f;
-	return winPos;
+	float3 vpPos;
+	vpPos.x = viewport[2] * (clipPos.x + 1.0f) * 0.5f;
+	vpPos.y = viewport[3] * (clipPos.y + 1.0f) * 0.5f;
+	vpPos.z =               (clipPos.z + 1.0f) * 0.5f;
+	return vpPos;
 }
 
 

--- a/rts/Game/Camera.h
+++ b/rts/Game/Camera.h
@@ -114,7 +114,7 @@ public:
 	void SetRotZ(const float z) { SetRot(float3(rot.x, rot.y,     z)); }
 
 	float3 CalcPixelDir(int x, int y) const;
-	float3 CalcWindowCoordinates(const float3& objPos) const;
+	float3 CalcViewPortCoordinates(const float3& objPos) const;
 
 	bool InView(const float3& point, float radius = 0.0f) const { return (frustum.IntersectSphere(pos, {point, radius})); }
 	bool InView(const float3& mins, const float3& maxs) const { return (InView(AABB{mins, maxs})); }

--- a/rts/Game/UI/CursorIcons.cpp
+++ b/rts/Game/UI/CursorIcons.cpp
@@ -109,9 +109,9 @@ void CCursorIcons::DrawCursors() const
 			lastCursor = currentCursor;
 		}
 
-		const float3 winCoors = camera->CalcWindowCoordinates(icon.pos);
-		const float2 winScale = { cmdColors.QueueIconScale(), 1.0f };
-		const float4& matParams = currentCursor->CalcFrameMatrixParams(winCoors, winScale);
+		const float3 vpCoors = camera->CalcViewPortCoordinates(icon.pos);
+		const float2 vpScale = { cmdColors.QueueIconScale(), 1.0f };
+		const float4& matParams = currentCursor->CalcFrameMatrixParams(vpCoors, vpScale);
 
 		CMatrix44f cursorMat;
 		cursorMat.Translate(matParams.x, matParams.y, 0.0f);
@@ -151,10 +151,10 @@ void CCursorIcons::DrawTexts() const
 	font->SetColors(); //default
 
 	for (const auto& text : texts) {
-		const float3 winPos = camera->CalcWindowCoordinates(text.pos);
-		if (winPos.z <= 1.0f) {
-			const float x = (winPos.x * globalRendering->pixelX);
-			const float y = (winPos.y * globalRendering->pixelY) + yOffset;
+		const float3 vpPos = camera->CalcViewPortCoordinates(text.pos);
+		if (vpPos.z <= 1.0f) {
+			const float x = (vpPos.x * globalRendering->pixelX);
+			const float y = (vpPos.y * globalRendering->pixelY) + yOffset;
 
 			if (guihandler->GetOutlineFonts()) {
 				font->glPrint(x, y, fontScale, FONT_OUTLINE | FONT_CENTER | FONT_TOP | FONT_SCALE | FONT_NORM, text.text);

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -3946,12 +3946,12 @@ void CGuiHandler::DrawCentroidCursor()
 	}
 	pos /= (float)selUnits.size();
 
-	const float3 winPos = camera->CalcWindowCoordinates(pos);
-	if (winPos.z <= 1.0f) {
+	const float3 vpPos = camera->CalcViewPortCoordinates(pos);
+	if (vpPos.z <= 1.0f) {
 		const CMouseCursor* mc = mouse->FindCursor("Centroid");
 		if (mc != nullptr) {
 			glDisable(GL_DEPTH_TEST);
-			mc->Draw((int)winPos.x, globalRendering->viewSizeY - (int)winPos.y, 1.0f);
+			mc->Draw((int)vpPos.x, globalRendering->viewSizeY - (int)vpPos.y, 1.0f);
 			glEnable(GL_DEPTH_TEST);
 		}
 	}

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -613,8 +613,8 @@ int LuaUnsyncedRead::GetSelectionBox(lua_State* L)
 		return 1;
 	}
 
-	const auto bottomLeft = camera->CalcWindowCoordinates(bl);
-	const auto topRight   = camera->CalcWindowCoordinates(tr);
+	const auto bottomLeft = camera->CalcViewPortCoordinates(bl);
+	const auto topRight   = camera->CalcViewPortCoordinates(tr);
 
 	lua_createtable(L, 4, 0);
 
@@ -1420,15 +1420,15 @@ int LuaUnsyncedRead::GetUnitsInScreenRectangle(lua_State* L)
 
 			unit->tempNum = tempNum;
 
-			const float3 winPos = camera->CalcWindowCoordinates(unit->drawPos);
+			const float3 vpPos = camera->CalcViewPortCoordinates(unit->drawPos);
 
-			if (winPos.x > r || winPos.x < l)
+			if (vpPos.x > r || vpPos.x < l)
 				continue;
 
-			if (winPos.y > b || winPos.y < t)
+			if (vpPos.y > b || vpPos.y < t)
 				continue;
 
-			if (winPos.z > 1.0f || winPos.z < 0.0f)
+			if (vpPos.z > 1.0f || vpPos.z < 0.0f)
 				continue;
 
 			lua_pushnumber(L, unit->id);
@@ -1864,10 +1864,10 @@ int LuaUnsyncedRead::WorldToScreenCoords(lua_State* L)
 	const float3 worldPos(luaL_checkfloat(L, 1),
 	                      luaL_checkfloat(L, 2),
 	                      luaL_checkfloat(L, 3));
-	const float3 winPos = camera->CalcWindowCoordinates(worldPos);
-	lua_pushnumber(L, winPos.x);
-	lua_pushnumber(L, winPos.y);
-	lua_pushnumber(L, winPos.z);
+	const float3 vpPos = camera->CalcViewPortCoordinates(worldPos);
+	lua_pushnumber(L, vpPos.x);
+	lua_pushnumber(L, vpPos.y);
+	lua_pushnumber(L, vpPos.z);
 	return 3;
 }
 

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -498,7 +498,7 @@ void CUnitDrawerLegacy::DrawUnitIconsScreen() const
 				unit->GetObjDrawErrorPos(gu->myAllyTeam) :
 				unit->GetObjDrawMidPos();
 
-			pos = camera->CalcWindowCoordinates(pos);
+			pos = camera->CalcViewPortCoordinates(pos);
 			if (pos.z > 1.0f || pos.z < 0.0f)
 				continue;
 

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -269,8 +269,8 @@ void CUnitDrawerData::UpdateUnitIconStateScreen(CUnit* unit)
 	float3 pos = unit->pos;
 	float3 radiusPos = pos + camera->right * unit->radius;
 
-	pos = camera->CalcWindowCoordinates(pos);
-	radiusPos = camera->CalcWindowCoordinates(radiusPos);
+	pos = camera->CalcViewPortCoordinates(pos);
+	radiusPos = camera->CalcViewPortCoordinates(radiusPos);
 
 	unit->iconRadius = unit->radius * ((limit * 0.9) / std::abs(pos.x - radiusPos.x)); // used for clicking on iconified units (world space!!!)
 


### PR DESCRIPTION
Translation has already been taken care of by glViewPort so when a viewPos offset is present it returns an inaccurate value