### PR TITLE
DualScreenMode: Use separate display for dual view

### DIFF
--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -97,7 +97,7 @@ void CCamera::Update(const UpdateParams& p)
 	if (p.updateMats)
 		UpdateMatrices(globalRendering->viewSizeX, globalRendering->viewSizeY, aspectRatio);
 	if (p.updateViewPort)
-		UpdateViewPort(globalRendering->viewPosX, 0, globalRendering->viewSizeX, globalRendering->viewSizeY);
+		UpdateViewPort(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
 	if (p.updateFrustum)
 		UpdateFrustum();
 
@@ -665,37 +665,48 @@ float3 CCamera::GetMoveVectorFromState(bool fromKeyState) const
 		v.y -= (camDeltaTime * 0.001f * movState[MOVE_STATE_BCK]);
 		v.x += (camDeltaTime * 0.001f * movState[MOVE_STATE_RGT]);
 		v.x -= (camDeltaTime * 0.001f * movState[MOVE_STATE_LFT]);
-	} else {
-		const int screenH = globalRendering->viewSizeY;
-		const int screenW = globalRendering->viewSizeX << static_cast<uint32_t>(globalRendering->dualScreenMode);
 
-		const float width = configHandler->GetFloat("EdgeMoveWidth");
-
-		int2 border;
-		border.x = std::max<int>(1, screenW * width);
-		border.y = std::max<int>(1, screenH * width);
-
-		float2 move;
-		// must be float, ints don't save the sign in case of 0 and we need it for copysign()
-		float2 distToEdge = {Clamp(mouse->lastx, 0, screenW) * 1.0f, Clamp(mouse->lasty, 0, screenH) * 1.0f};
-
-		if (((screenW - 1) - distToEdge.x) < distToEdge.x) distToEdge.x = -((screenW - 1) - distToEdge.x);
-		if (((screenH - 1) - distToEdge.y) < distToEdge.y) distToEdge.y = -((screenH - 1) - distToEdge.y);
-
-		if (configHandler->GetBool("EdgeMoveDynamic")) {
-			move.x = Clamp(float(border.x - std::abs(distToEdge.x)) / border.x, 0.0f, 1.0f);
-			move.y = Clamp(float(border.y - std::abs(distToEdge.y)) / border.y, 0.0f, 1.0f);
-		} else {
-			move.x = int(std::abs(distToEdge.x) < border.x);
-			move.y = int(std::abs(distToEdge.y) < border.y);
-		}
-
-		move.x = std::copysign(move.x, -distToEdge.x);
-		move.y = std::copysign(move.y,  distToEdge.y);
-
-		v.x = (camDeltaTime * 0.001f * move.x);
-		v.y = (camDeltaTime * 0.001f * move.y);
+		return v;
 	}
+
+	const int windowW = globalRendering->winSizeX;
+	int mouseY = mouse->lasty;
+	int viewH;
+
+	// Translate mouseY so it maps from mousecoords: top of view to 0 and bottom of view to viewSize
+	if (globalRendering->dualScreenMode && (mouse->lastx >= globalRendering->dualViewPosX) && (mouse->lastx <= globalRendering->dualViewPosX + globalRendering->dualViewSizeX)) {
+		viewH = globalRendering->dualViewSizeY;
+		mouseY -= globalRendering->dualWindowOffsetY - globalRendering->viewWindowOffsetY;
+	} else {
+		viewH = globalRendering->viewSizeY;
+	}
+
+	const float width = configHandler->GetFloat("EdgeMoveWidth");
+
+	int2 border;
+	border.x = std::max<int>(1, windowW * width);
+	border.y = std::max<int>(1, viewH * width);
+
+	float2 move;
+	// must be float, ints don't save the sign in case of 0 and we need it for copysign()
+	float2 distToEdge = {Clamp(mouse->lastx, 0, windowW) * 1.0f, Clamp(mouseY, 0, viewH) * 1.0f};
+
+	if (((windowW - 1) - distToEdge.x) < distToEdge.x) distToEdge.x = -((windowW - 1) - distToEdge.x);
+	if (((viewH - 1) - distToEdge.y) < distToEdge.y) distToEdge.y = -((viewH - 1) - distToEdge.y);
+
+	if (configHandler->GetBool("EdgeMoveDynamic")) {
+		move.x = Clamp(float(border.x - std::abs(distToEdge.x)) / border.x, 0.0f, 1.0f);
+		move.y = Clamp(float(border.y - std::abs(distToEdge.y)) / border.y, 0.0f, 1.0f);
+	} else {
+		move.x = int(std::abs(distToEdge.x) < border.x);
+		move.y = int(std::abs(distToEdge.y) < border.y);
+	}
+
+	move.x = std::copysign(move.x, -distToEdge.x);
+	move.y = std::copysign(move.y,  distToEdge.y);
+
+	v.x = (camDeltaTime * 0.001f * move.x);
+	v.y = (camDeltaTime * 0.001f * move.y);
 
 	return v;
 }

--- a/rts/Game/UI/InputReceiver.h
+++ b/rts/Game/UI/InputReceiver.h
@@ -38,8 +38,8 @@ public:
 	bool InBox(float x, float y, const TRectangle<float>& box) const;
 
 	// transform from mouse X/Y to OpenGL X/Y value in screen pixels
-	static float MouseX(int x) { return (float(x - globalRendering->viewPosX     ) * globalRendering->pixelX); }
-	static float MouseY(int y) { return (float(    globalRendering->viewSizeY - y) * globalRendering->pixelY); }
+	static float MouseX(int x) { return (float(                             x - globalRendering->viewPosX) * globalRendering->pixelX); }
+	static float MouseY(int y) { return (float(globalRendering->viewSizeY - y + globalRendering->viewPosY) * globalRendering->pixelY); }
 
 	// transform from mouse X/Y to OpenGL X/Y value in
 	// orthogonal projection 0-1 left-right/bottom-top

--- a/rts/Game/UI/MiniMap.cpp
+++ b/rts/Game/UI/MiniMap.cpp
@@ -83,15 +83,7 @@ CMiniMap::CMiniMap()
 	, allyColor(0.3f, 0.3f, 0.9f, 1.0f)
 	, enemyColor(0.9f, 0.2f, 0.2f, 1.0f)
  {
-	lastWindowSizeX = globalRendering->viewSizeX;
-	lastWindowSizeY = globalRendering->viewSizeY;
-
-	if (globalRendering->dualScreenMode) {
-		curDim.x = globalRendering->viewSizeX;
-		curDim.y = globalRendering->viewSizeY;
-		curPos.x = (globalRendering->viewSizeX - globalRendering->viewPosX);
-		curPos.y = 0;
-	} else {
+	if (!globalRendering->dualScreenMode) {
 		ParseGeometry(configHandler->GetString("MiniMapGeometry"));
 	}
 
@@ -394,12 +386,11 @@ void CMiniMap::SetGeometry(int px, int py, int sx, int sy)
 void CMiniMap::UpdateGeometry()
 {
 	// keep the same distance to the top
-	curPos.y -= (lastWindowSizeY - globalRendering->viewSizeY);
 	if (globalRendering->dualScreenMode) {
-		curDim.x = globalRendering->viewSizeX;
-		curDim.y = globalRendering->viewSizeY;
-		curPos.x = (globalRendering->viewSizeX - globalRendering->viewPosX);
-		curPos.y = 0;
+		curPos.x = globalRendering->dualViewPosX;
+		curPos.y = globalRendering->dualViewPosY;
+		curDim.x = globalRendering->dualViewSizeX;
+		curDim.y = globalRendering->dualViewSizeY;
 	}
 	else if (maximized) {
 		SetMaximizedGeometry();
@@ -435,9 +426,6 @@ void CMiniMap::UpdateGeometry()
 		projMats[1] = CMatrix44f::ClipOrthoProj(0.0f, 1.0f, 0.0f, 1.0f, 0.0f, -1.0f, globalRendering->supportClipSpaceControl * 1.0f);
 		projMats[2] = projMats[1];
 	}
-
-	lastWindowSizeX = globalRendering->viewSizeX;
-	lastWindowSizeY = globalRendering->viewSizeY;
 
 	// setup the unit scaling
 	const float w = float(curDim.x);
@@ -748,8 +736,12 @@ float3 CMiniMap::GetMapPosition(int x, int y) const
 	//   (x = dim.x, y =     0) maps to world-coors (mapX, h,    0)
 	//   (x = dim.x, y = dim.y) maps to world-coors (mapX, h, mapZ)
 	//   (x =     0, y = dim.y) maps to world-coors (   0, h, mapZ)
-	float sx = Clamp(float(x -                               tmpPos.x            ) / curDim.x, 0.0f, 1.0f);
-	float sz = Clamp(float(y - (globalRendering->viewSizeY - tmpPos.y - curDim.y)) / curDim.y, 0.0f, 1.0f);
+
+	// translate mouse coords orientation and origin to map coords
+	y = y - globalRendering->viewPosY + curDim.y - globalRendering->viewSizeY;
+
+	float sx = Clamp(float(x - tmpPos.x) / curDim.x, 0.0f, 1.0f);
+	float sz = Clamp(float(y + tmpPos.y) / curDim.y, 0.0f, 1.0f);
 
 	if (flipped) {
 		sx = 1 - sx;
@@ -923,7 +915,11 @@ void CMiniMap::DrawSurfaceSquare(const float3& pos, float xsize, float ysize)
 void CMiniMap::ApplyConstraintsMatrix() const
 {
 	if (!renderToTexture) {
-		glTranslatef(curPos.x * globalRendering->pixelX, curPos.y * globalRendering->pixelY, 0.0f);
+		if (globalRendering->dualScreenMode) {
+			glTranslatef(curPos.x, curPos.y, 0.0f);
+		} else {
+			glTranslatef(curPos.x * globalRendering->pixelX, curPos.y * globalRendering->pixelY, 0.0f);
+		}
 		glScalef(curDim.x * globalRendering->pixelX, curDim.y * globalRendering->pixelY, 1.0f);
 	}
 }
@@ -1134,7 +1130,6 @@ void CMiniMap::DrawForReal(bool useNormalizedCoors, bool updateTex, bool luaCall
 		// switch to normalized minimap coords
 		if (globalRendering->dualScreenMode) {
 			glViewport(curPos.x, curPos.y, curDim.x, curDim.y);
-			glScalef(curDim.x * globalRendering->pixelX, curDim.y * globalRendering->pixelY, 1.0f);
 		} else {
 			glTranslatef(curPos.x * globalRendering->pixelX, curPos.y * globalRendering->pixelY, 0.0f);
 			glScalef(curDim.x * globalRendering->pixelX, curDim.y * globalRendering->pixelY, 1.0f);
@@ -1174,8 +1169,12 @@ void CMiniMap::DrawForReal(bool useNormalizedCoors, bool updateTex, bool luaCall
 
 	if (!updateTex) {
 		glPushMatrix();
-			glTranslatef(curPos.x * globalRendering->pixelX, curPos.y * globalRendering->pixelY, 0.0f);
-			glScalef(curDim.x * globalRendering->pixelX, curDim.y * globalRendering->pixelY, 1.0f);
+			if (globalRendering->dualScreenMode) {
+				glTranslatef(curPos.x, curPos.y, 0.0f);
+			} else {
+				glTranslatef(curPos.x * globalRendering->pixelX, curPos.y * globalRendering->pixelY, 0.0f);
+				glScalef(curDim.x * globalRendering->pixelX, curDim.y * globalRendering->pixelY, 1.0f);
+			}
 			DrawCameraFrustumAndMouseSelection();
 		glPopMatrix();
 	}
@@ -1183,7 +1182,7 @@ void CMiniMap::DrawForReal(bool useNormalizedCoors, bool updateTex, bool luaCall
 	// Finish
 	// Reset of GL state
 	if (useNormalizedCoors && globalRendering->dualScreenMode)
-		glViewport(globalRendering->viewPosX, 0, globalRendering->viewSizeX, globalRendering->viewSizeY);
+		CCamera::GetActive()->LoadViewPort();
 
 	// disable ClipPlanes
 	glDisable(GL_CLIP_PLANE0);
@@ -1587,12 +1586,12 @@ bool CMiniMap::RenderCachedTexture(bool useNormalizedCoors)
 	if (useNormalizedCoors) {
 		glPushMatrix();
 
-		if (globalRendering->dualScreenMode)
+		if (globalRendering->dualScreenMode) {
 			glViewport(curPos.x, curPos.y, curDim.x, curDim.y);
-		else
+		} else {
 			glTranslatef(curPos.x * globalRendering->pixelX, curPos.y * globalRendering->pixelY, 0.0f);
-
-		glScalef(curDim.x * globalRendering->pixelX, curDim.y * globalRendering->pixelY, 1.0f);
+			glScalef(curDim.x * globalRendering->pixelX, curDim.y * globalRendering->pixelY, 1.0f);
+		}
 	}
 
 	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
@@ -1610,7 +1609,7 @@ bool CMiniMap::RenderCachedTexture(bool useNormalizedCoors)
 
 	if (useNormalizedCoors) {
 		if (globalRendering->dualScreenMode)
-			glViewport(globalRendering->viewPosX, 0, globalRendering->viewSizeX, globalRendering->viewSizeY);
+			CCamera::GetActive()->LoadViewPort();
 
 		glPopMatrix();
 	}

--- a/rts/Game/UI/MiniMap.h
+++ b/rts/Game/UI/MiniMap.h
@@ -166,9 +166,6 @@ protected:
 		float xminTx, xmaxTx, yminTx, ymaxTx;  // texture coordinates
 	};
 
-	int lastWindowSizeX = 0;
-	int lastWindowSizeY = 0;
-
 	int buttonSize = 0;
 
 	int drawCommands = 0;

--- a/rts/Game/UI/MouseHandler.h
+++ b/rts/Game/UI/MouseHandler.h
@@ -50,6 +50,7 @@ public:
 	void MousePress(int x, int y, int button);
 	void MouseMove(int x, int y, int dx, int dy);
 	void MouseWheel(float delta);
+	void WindowLeave();
 
 	bool AssignMouseCursor(const std::string& cmdName,
 	                       const std::string& fileName,
@@ -84,6 +85,7 @@ public:
 	bool GetSelectionBoxVertices(float3& bl, float3& br, float3& tl, float3& tr) const;
 
 private:
+	int2 GetViewMouseCenter() const;
 	void SetCursor(const std::string& cmdName, const bool forceRebind = false);
 
 	void DrawScrollCursor(TypedRenderBuffer<VA_TYPE_C>& rb);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -549,7 +549,7 @@ int LuaUnsyncedRead::GetScreenGeometry(lua_State* L)
 	}
 	else {
 		SDL_Rect r{};
-		globalRendering->GetScreenBounds(r, displayIndexPtr);
+		globalRendering->GetDisplayBounds(r, displayIndexPtr);
 		lua_pushnumber(L, r.w);
 		lua_pushnumber(L, r.h);
 		lua_pushnumber(L, r.x);
@@ -561,7 +561,7 @@ int LuaUnsyncedRead::GetScreenGeometry(lua_State* L)
 
 	{
 		SDL_Rect r{};
-		globalRendering->GetUsableScreenBounds(r, displayIndexPtr);
+		globalRendering->GetUsableDisplayBounds(r, displayIndexPtr);
 		lua_pushnumber(L, r.w);
 		lua_pushnumber(L, r.h);
 		lua_pushnumber(L, r.x);
@@ -648,7 +648,7 @@ int LuaUnsyncedRead::IsAboveMiniMap(lua_State* L)
 		return false;
 
 	const int x = luaL_checkint(L, 1) + globalRendering->viewPosX;
-	const int y = luaL_checkint(L, 2);
+	const int y = luaL_checkint(L, 2) + globalRendering->viewPosY;
 
 	const int x0 = minimap->GetPosX();
 	const int y0 = minimap->GetPosY();
@@ -1899,8 +1899,8 @@ int LuaUnsyncedRead::TraceScreenRay(lua_State* L)
 	const int mx = luaL_checkint(L, 1);
 	const int my = luaL_checkint(L, 2);
 
-	const int wx =                                  mx + globalRendering->viewPosX;
-	const int wy = globalRendering->viewSizeY - 1 - my - globalRendering->viewPosY;
+	const int wx = mx + globalRendering->viewPosX;
+	const int wy = globalRendering->viewSizeY - 1 - my;
 
 	const int optArgIdx = 3 + lua_isnumber(L, 3); // 3 or 4
 	const int newArgIdx = 3 + 4 * (optArgIdx == 3); // 7 or 3
@@ -1911,8 +1911,8 @@ int LuaUnsyncedRead::TraceScreenRay(lua_State* L)
 	const bool ignoreWater = luaL_optboolean(L, optArgIdx + 3, false);
 
 	if (useMiniMap && (minimap != nullptr) && !minimap->GetMinimized()) {
-		const int px = minimap->GetPosX() - globalRendering->viewPosX; // for left dualscreen
-		const int py = minimap->GetPosY();
+		const int px = minimap->GetPosX() - globalRendering->viewPosX;
+		const int py = minimap->GetPosY() - globalRendering->viewPosY;
 		const int sx = minimap->GetSizeX();
 		const int sy = minimap->GetSizeY();
 

--- a/rts/Rendering/GlobalRendering.h
+++ b/rts/Rendering/GlobalRendering.h
@@ -95,13 +95,12 @@ public:
 
 	void UpdateWindowBorders(SDL_Window* window) const;
 
-	int2 GetScreenCenter() const { return {viewPosX + (viewSizeX >> 1), viewPosY + (viewSizeY >> 1)}; }
 	int2 GetMaxWinRes() const;
 	int2 GetCfgWinRes() const;
 
 	int GetCurrentDisplayIndex() const;
-	void GetScreenBounds(SDL_Rect& r, const int* di = nullptr) const;
-	void GetUsableScreenBounds(SDL_Rect& r, const int* di = nullptr) const;
+	void GetDisplayBounds(SDL_Rect& r, const int* di = nullptr) const;
+	void GetUsableDisplayBounds(SDL_Rect& r, const int* di = nullptr) const;
 
 	bool CheckGLMultiSampling() const;
 	bool CheckGLContextVersion(const int2& minCtx) const;
@@ -142,6 +141,8 @@ public:
 	/// Frames Per Second
 	float FPS;
 
+	/// the number of displays
+	int numDisplays;
 
 	/// the screen size in pixels
 	int screenSizeX;
@@ -151,7 +152,7 @@ public:
 	int screenPosX;
 	int screenPosY;
 
-	/// the window position relative to the screen's bottom-left corner
+	/// the window position relative to the screen's top-left corner
 	int winPosX;
 	int winPosY;
 
@@ -159,13 +160,25 @@ public:
 	int winSizeX;
 	int winSizeY;
 
-	/// the viewport position relative to the window's bottom-left corner
+	/// the viewport position relative to the window's top-left corner
 	int viewPosX;
 	int viewPosY;
 
 	/// the viewport size in pixels
 	int viewSizeX;
 	int viewSizeY;
+
+	/// the y offset in relation to window top border
+	int viewWindowOffsetY;
+	int dualWindowOffsetY;
+
+	/// the dual viewport position relative to the window's top-left corner (DualScreenMode = 1)
+	int dualViewPosX;
+	int dualViewPosY;
+
+	/// the dual viewport size in pixels (DualScreenMode = 1)
+	int dualViewSizeX;
+	int dualViewSizeY;
 
 	/// the window borders
 	mutable std::array<int, 4> winBorder;

--- a/rts/Rendering/Screenshot.cpp
+++ b/rts/Rendering/Screenshot.cpp
@@ -36,8 +36,8 @@ void TakeScreenshot(std::string type, unsigned quality)
 		return;
 
 	FunctionArgs args;
-	args.x  = globalRendering->dualScreenMode? globalRendering->viewSizeX << 1: globalRendering->viewSizeX;
-	args.y  = globalRendering->viewSizeY;
+	args.x  = globalRendering->winSizeX;
+	args.y  = globalRendering->winSizeY;
 	args.x += ((4 - (args.x % 4)) * int((args.x % 4) != 0));
 
 	const int shotCounter = configHandler->GetInt("ScreenshotCounter");

--- a/rts/Rendering/UniformConstants.cpp
+++ b/rts/Rendering/UniformConstants.cpp
@@ -233,8 +233,8 @@ void UniformConstants::UpdateParamsImpl(UniformParamsBuffer* updateBuffer)
 	updateBuffer->windInfo = float4{ envResHandler.GetCurrentWindVec(), envResHandler.GetCurrentWindStrength() };
 
 	updateBuffer->mouseScreenPos = float2{
-		static_cast<float>(mouse->lastx - globalRendering->viewPosX),
-		static_cast<float>(globalRendering->viewSizeY - mouse->lasty - 1)
+		static_cast<float>(mouse->lastx),
+		static_cast<float>(globalRendering->viewPosY + globalRendering->viewSizeY - mouse->lasty - 1)
 	};
 
 	updateBuffer->mouseStatus = (
@@ -249,7 +249,7 @@ void UniformConstants::UpdateParamsImpl(UniformParamsBuffer* updateBuffer)
 
 	{
 		const int wx = mouse->lastx;
-		const int wy = mouse->lasty - globalRendering->viewPosY;
+		const int wy = mouse->lasty;
 
 		const CUnit* unit = nullptr;
 		const CFeature* feature = nullptr;

--- a/rts/System/Input/MouseInput.cpp
+++ b/rts/System/Input/MouseInput.cpp
@@ -97,11 +97,14 @@ bool IMouseInput::HandleSDLMouseEvent(const SDL_Event& event)
 		} break;
 		case SDL_WINDOWEVENT: {
 			if (event.window.event == SDL_WINDOWEVENT_LEAVE) {
-				// mouse left window; set pos internally to center-pixel to prevent endless scrolling
-				mousepos = globalRendering->GetScreenCenter();
+				// mouse left window; set pos internally to view center-pixel to prevent endless scrolling
+				mousepos = {
+					globalRendering->viewPosX          + (globalRendering->viewSizeX >> 1),
+					globalRendering->viewWindowOffsetY + (globalRendering->viewSizeY >> 1)
+				};
 
 				if (mouse != nullptr)
-					mouse->MouseMove(-mousepos.x, -mousepos.y, 0, 0);
+					mouse->WindowLeave();
 
 			} break;
 		}

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -431,7 +431,7 @@ void SpringApp::UpdateInterfaceGeometry()
 {
 	#ifndef HEADLESS
 	const int vpx = globalRendering->viewPosX;
-	const int vpy = globalRendering->winSizeY - globalRendering->viewSizeY - globalRendering->viewPosY;
+	const int vpy = globalRendering->viewWindowOffsetY;
 
 	agui::gui->UpdateScreenGeometry(globalRendering->viewSizeX, globalRendering->viewSizeY, vpx, vpy);
 	#endif
@@ -1011,6 +1011,17 @@ bool SpringApp::MainEventHandler(const SDL_Event& event)
 						, globalRendering->winPosY);
 
 					SaveWindowPosAndSize();
+
+					if (globalRendering->numDisplays > 1 && globalRendering->dualScreenMode) {
+						{
+							ScopedOnceTimer timer("GlobalRendering::UpdateGL");
+
+							globalRendering->UpdateGLConfigs();
+							globalRendering->UpdateGLGeometry();
+							globalRendering->InitGLState();
+							UpdateInterfaceGeometry();
+						}
+					}
 
 					LOG("[SpringApp::%s][SDL_WINDOWEVENT_MOVED][2] di=%d, ssx=%d, ssy=%d, wsx=%d, wsy=%d, wpx=%d, wpy=%d"
 						, __func__

--- a/rts/lib/headlessStubs/sdlstub.c
+++ b/rts/lib/headlessStubs/sdlstub.c
@@ -296,6 +296,14 @@ extern DECLSPEC int SDL_GetNumVideoDisplays(void) {
 	return 0;
 }
 
+extern DECLSPEC SDL_bool SDL_HasIntersection(const SDL_Rect * A, const SDL_Rect * B) {
+	return SDL_TRUE;
+}
+
+extern DECLSPEC SDL_bool SDL_IntersectRect(const SDL_Rect * A, const SDL_Rect * B, SDL_Rect * result) {
+	return SDL_TRUE;
+}
+
 extern DECLSPEC int SDL_GetDisplayBounds(int displayIndex, SDL_Rect* rect) {
 	if (rect == 0) return -1;
 	rect->w = 640;


### PR DESCRIPTION
When viewport geometry is updated:

- Run through all displays currently connected
- Intersect their screen rectangles with the application windows
  rectangle
- Sort the intersections left to right and make positions relative to
  each other
- If DualScreenModeMiniMapOnLeft is enabled use the leftmost
  intersection as the dualView, otherwise use the rightmost one. Use the
  other screens as the main view
- Extract PosX, PosY, SizeX, SizeY and WindowOffsetY for dual and view from
  the intersections in the form of: viewPosX, dualViewPosX, ..., and so on

If view is offset from bottom of window it has a positive
PosY, same if offset from left of window for PosX.

If view is offset from top of the window it has a positive
WindowOffsetY.

For GL coordinates:

Origin starts at bottom left of main view and orients bottom-left to
top-right. GL viewport ensures this geometry is respected when drawing
to the screen. For dual mode rendering a temporary viewport is applied
internally so origin is bottom left of dualView with same orientation.

For in-game mouse coordinates:

Origin starts at bottom left of main view and orients bottom-left to
top-right. This implies negative or higher than main view geometry values
are possible when mouse coordinates refers to points in dual view.

For in-engine mouse coordinates:

Origin starts at left border of window and top border of main view and
orients top-left to bottom-right. All mouse coordinates are translated
before interacting or being passed to game space.