### PR TITLE
MiniMap: Allow drawable events over minimap

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -99,6 +99,8 @@ System:
 
 UI:
  - Add `group unset` action to unassign any groups from selected units
+ - Allow drawlabel events inside minimap and add MiniMapCanDraw to enable drawing lines via
+   cursor over minimap
  - KeyPress and KeyRelease callins receive an additional scanCode
    argument
  - sc_<k> keysets are introduced for scancodes and handled in conjunction

--- a/rts/Game/UI/MiniMap.cpp
+++ b/rts/Game/UI/MiniMap.cpp
@@ -780,6 +780,11 @@ void CMiniMap::ProxyMouseRelease(int x, int y, int button)
 
 
 /******************************************************************************/
+bool CMiniMap::IsInside(int x, int y)
+{
+	return !minimized && mapBox.Inside(x, y);
+}
+
 
 bool CMiniMap::IsAbove(int x, int y)
 {

--- a/rts/Game/UI/MiniMap.h
+++ b/rts/Game/UI/MiniMap.h
@@ -29,6 +29,7 @@ public:
 	void MouseRelease(int x, int y, int button);
 	void MoveView(int x, int y);
 	bool IsAbove(int x, int y);
+	bool IsInside(int x, int y);
 	std::string GetTooltip(int x, int y);
 	void Draw();
 	void DrawForReal(bool useNormalizedCoors = true, bool updateTex = false, bool luaCall = false);

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -593,7 +593,13 @@ public:
 	}
 
 	bool Execute(const UnsyncedAction& action) const final {
-		const float3 pos = mouse->GetWorldMapPos();
+		float3 pos;
+
+		if (minimap != nullptr && minimap->IsInside(mouse->lastx, mouse->lasty)) {
+			pos = minimap->GetMapPosition(mouse->lastx, mouse->lasty);
+		} else {
+			pos = mouse->GetWorldMapPos();
+		}
 
 		if (pos.x >= 0.0f) {
 			inMapDrawer->SetDrawMode(false);


### PR DESCRIPTION
Allows drawlabel events and adds a MiniMapCanDraw spring setting for allowing drawing/erasing lines with cursor over minimap