### PR TITLE
Clear comments when reading setting to prevent duplicating comments

### DIFF
--- a/rts/System/Config/ConfigSource.cpp
+++ b/rts/System/Config/ConfigSource.cpp
@@ -135,6 +135,7 @@ void FileConfigSource::Read(FILE* file)
 	std::ostringstream commentBuffer;
 	char line[500];
 	rewind(file);
+	comments.clear();
 	while (fgets(line, sizeof(line), file)) {
 		char* line_stripped = Strip(line, strchr(line, '\0') - 1);
 		if (*line_stripped == '\0' || *line_stripped == '#') {


### PR DESCRIPTION
Without that, when the config is:

```
# comment
KeyToBedeleted = 1
KeyZ = 1
```

when you read you get:
`comments = {'KeyToBedeleted': '# comment'}`

after you delete `KeyToBedeleted` and read file again *without* clearing `comments` variable, you end up with
`comments = {'KeyToBedeleted': '# comment', 'KeyZ': '# comment'}`

and when you write with this state, you duplicate comment.