### PR TITLE
MiniMap: Respond to mousewheel events

### DIFF
--- a/rts/Game/Camera/CameraController.h
+++ b/rts/Game/Camera/CameraController.h
@@ -97,6 +97,7 @@ public:
 	virtual void MouseMove(float3 move) = 0;
 	virtual void ScreenEdgeMove(float3 move) = 0;
 	virtual void MouseWheelMove(float move) = 0;
+	virtual void MouseWheelMove(float move, const float3& dir) = 0;
 
 	virtual void Update() {}
 

--- a/rts/Game/Camera/DummyController.h
+++ b/rts/Game/Camera/DummyController.h
@@ -15,6 +15,7 @@ public:
 	void MouseMove(float3 move) override {}
 	void ScreenEdgeMove(float3 move) override {}
 	void MouseWheelMove(float move) override {}
+	void MouseWheelMove(float move, const float3& newDir) override {}
 
 	float3 SwitchFrom() const override { return ZeroVector; }
 	void SwitchTo(const int, const bool) override {}

--- a/rts/Game/Camera/FPSController.cpp
+++ b/rts/Game/Camera/FPSController.cpp
@@ -63,9 +63,9 @@ void CFPSController::MouseMove(float3 move)
 }
 
 
-void CFPSController::MouseWheelMove(float move)
+void CFPSController::MouseWheelMove(float move, const float3& newDir)
 {
-	pos += (camera->GetUp() * move);
+	pos += (newDir * move);
 	Update();
 }
 

--- a/rts/Game/Camera/FPSController.h
+++ b/rts/Game/Camera/FPSController.h
@@ -3,6 +3,7 @@
 #ifndef _FPS_CONTROLLER_H
 #define _FPS_CONTROLLER_H
 
+#include "Game/Camera.h"
 #include "CameraController.h"
 
 class CFPSController : public CCameraController
@@ -16,7 +17,8 @@ public:
 	void KeyMove(float3 move);
 	void MouseMove(float3 move);
 	void ScreenEdgeMove(float3 move) { KeyMove(move); }
-	void MouseWheelMove(float move);
+	void MouseWheelMove(float move) { MouseWheelMove(move, camera->GetUp()); }
+	void MouseWheelMove(float move, const float3& newDir);
 
 	void SetPos(const float3& newPos);
 	void SetDir(const float3& newDir);

--- a/rts/Game/Camera/FreeController.h
+++ b/rts/Game/Camera/FreeController.h
@@ -17,6 +17,7 @@ public:
 	void MouseMove(float3 move);
 	void ScreenEdgeMove(float3 move);
 	void MouseWheelMove(float move);
+	void MouseWheelMove(float move, const float3& newDir) { MouseWheelMove(move); }
 
 	bool DisableTrackingByKey() { return false; }
 

--- a/rts/Game/Camera/OverheadController.cpp
+++ b/rts/Game/Camera/OverheadController.cpp
@@ -101,7 +101,7 @@ void COverheadController::ScreenEdgeMove(float3 move)
 }
 
 
-void COverheadController::MouseWheelMove(float move)
+void COverheadController::MouseWheelMove(float move, const float3& newDir)
 {
 	if (move == 0.0f)
 		return;
@@ -134,9 +134,9 @@ void COverheadController::MouseWheelMove(float move)
 
 			// instazoom in to standard view
 			if (moveReset)
-				dif = (height - oldAltHeight) / mouse->dir.y * dir.y;
+				dif = (height - oldAltHeight) / newDir.y * dir.y;
 
-			float3 wantedPos = cpos + mouse->dir * dif;
+			float3 wantedPos = cpos + newDir * dif;
 
 			float newHeight = CGround::LineGroundCol(wantedPos, wantedPos + dir * 15000.0f, false);
 			float yDirClamp = std::max(std::fabs(dir.y), 0.0001f) * std::copysign(1.0f, dir.y);

--- a/rts/Game/Camera/OverheadController.h
+++ b/rts/Game/Camera/OverheadController.h
@@ -4,6 +4,7 @@
 #define _OVERHEAD_CONTROLLER_H
 
 #include "CameraController.h"
+#include "Game/UI/MouseHandler.h"
 
 
 class COverheadController : public CCameraController
@@ -17,7 +18,8 @@ public:
 	void KeyMove(float3 move);
 	void MouseMove(float3 move);
 	void ScreenEdgeMove(float3 move);
-	void MouseWheelMove(float move);
+	void MouseWheelMove(float move) { MouseWheelMove(move, mouse->dir); }
+	void MouseWheelMove(float move, const float3& newDir);
 
 	void Update();
 	float3 GetPos() const { return (pos - dir * height); }

--- a/rts/Game/Camera/OverviewController.h
+++ b/rts/Game/Camera/OverviewController.h
@@ -16,6 +16,7 @@ public:
 	void MouseMove(float3 move) override {}
 	void ScreenEdgeMove(float3 move) override {}
 	void MouseWheelMove(float move) override {}
+	void MouseWheelMove(float move, const float3& newDir) override { }
 
 	void SetPos(const float3& newPos) override {}
 	void SetDir(const float3& newDir) override {}

--- a/rts/Game/Camera/RotOverheadController.h
+++ b/rts/Game/Camera/RotOverheadController.h
@@ -16,6 +16,7 @@ public:
 	void MouseMove(float3 move);
 	void ScreenEdgeMove(float3 move);
 	void MouseWheelMove(float move);
+	void MouseWheelMove(float move, const float3& newDir) { MouseWheelMove(move); }
 
 	void SetPos(const float3& newPos);
 

--- a/rts/Game/Camera/SpringController.h
+++ b/rts/Game/Camera/SpringController.h
@@ -4,6 +4,7 @@
 #define _SPRING_CONTROLLER_H
 
 #include "CameraController.h"
+#include "Game/UI/MouseHandler.h"
 #include "System/type2.h"
 
 class CSpringController : public CCameraController
@@ -16,7 +17,8 @@ public:
 	void KeyMove(float3 move);
 	void MouseMove(float3 move);
 	void ScreenEdgeMove(float3 move);
-	void MouseWheelMove(float move);
+	void MouseWheelMove(float move) { MouseWheelMove(move, mouse->dir); }
+	void MouseWheelMove(float move, const float3& newDir);
 
 	void Update();
 	void SetPos(const float3& newPos) { pos = newPos; Update(); }
@@ -33,8 +35,8 @@ private:
 	float GetAzimuth() const;
 	float MoveAzimuth(float move);
 
-	inline float ZoomIn(const float3& curCamPos, const float2& zoomParams);
-	inline float ZoomOut(const float3& curCamPos, const float2& zoomParams);
+	inline float ZoomIn(const float3& curCamPos, const float3& dir, const float& scaledMode);
+	inline float ZoomOut(const float3& curCamPos, const float3& dir, const float& curDistPre, const float& scaledMode);
 
 private:
 	float3 rot;

--- a/rts/Game/UI/MiniMap.cpp
+++ b/rts/Game/UI/MiniMap.cpp
@@ -510,12 +510,10 @@ void CMiniMap::UpdateGeometry()
 
 /******************************************************************************/
 
-void CMiniMap::MoveView(int x, int y)
+void CMiniMap::MoveView(const float3& mapPos)
 {
-	const float3 clickPos = GetMapPosition(x, y);
-
 	camHandler->CameraTransition(0.0f);
-	camHandler->GetCurrentController().SetPos({clickPos.x, 0.0f, clickPos.z});
+	camHandler->GetCurrentController().SetPos({mapPos.x, 0.0f, mapPos.z});
 	unitTracker.Disable();
 }
 
@@ -564,6 +562,23 @@ void CMiniMap::SelectUnits(int x, int y)
 }
 
 /******************************************************************************/
+
+void CMiniMap::MouseWheel(bool up, float delta)
+{
+	float3 mapPos = GetMapPosition(mouse->lastx, mouse->lasty);
+	mapPos.y = CGround::GetHeightAboveWater(mapPos.x, mapPos.z, false);
+
+	// If cursor position in minimap refers to a point outside camera view just move to it
+	if (!camera->InView(mapPos)) {
+		MoveView(mapPos);
+		return;
+	}
+
+	float3 newDir = (mapPos - camera->pos);
+	newDir.LengthNormalize();
+
+	camHandler->GetCurrentController().MouseWheelMove(delta * mouse->scrollWheelSpeed, newDir);
+}
 
 bool CMiniMap::MousePress(int x, int y, int button)
 {

--- a/rts/Game/UI/MiniMap.h
+++ b/rts/Game/UI/MiniMap.h
@@ -25,9 +25,10 @@ public:
 	virtual ~CMiniMap();
 
 	bool MousePress(int x, int y, int button);
-	void MouseMove(int x, int y, int dx,int dy, int button);
+	void MouseMove(int x, int y, int dx, int dy, int button);
 	void MouseRelease(int x, int y, int button);
-	void MoveView(int x, int y);
+	void MouseWheel(bool up, float delta);
+	void MoveView(int x, int y) { MoveView(GetMapPosition(x, y)); }
 	bool IsAbove(int x, int y);
 	bool IsInside(int x, int y);
 	std::string GetTooltip(int x, int y);
@@ -90,6 +91,7 @@ protected:
 	void SelectUnits(int x, int y);
 	void ProxyMousePress(int x, int y, int button);
 	void ProxyMouseRelease(int x, int y, int button);
+	void MoveView(const float3& mapPos);
 
 	bool RenderCachedTexture(bool useGeom);
 	void DrawBackground() const;

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -50,6 +50,7 @@
 CONFIG(bool, HardwareCursor).defaultValue(false).description("Sets hardware mouse cursor rendering. If you have a low framerate, your mouse cursor will seem \"laggy\". Setting hardware cursor will render the mouse cursor separately from spring and the mouse will behave normally. Note, not all GPU drivers support it in fullscreen mode!");
 CONFIG(bool, InvertMouse).defaultValue(false);
 CONFIG(bool, MouseRelativeModeWarp).defaultValue(true);
+CONFIG(bool, MiniMapMouseWheel).defaultValue(false).description("Whether MiniMap responds to MouseWheel events");
 
 CONFIG(float, CrossSize).defaultValue(12.0f);
 CONFIG(float, CrossAlpha).defaultValue(0.5f);
@@ -95,12 +96,13 @@ CMouseHandler::CMouseHandler()
 	ConfigUpdate();
 
 	configHandler->NotifyOnChange(this, {
-		"InvertMouse",
+		"MiniMapMouseWheel",
 		"MouseDragScrollThreshold",
 		"MouseDragSelectionThreshold",
 		"MouseDragBoxCommandThreshold",
 		"MouseDragCircleCommandThreshold",
-		"MouseDragFrontCommandThreshold"
+		"MouseDragFrontCommandThreshold",
+		"InvertMouse",
 		"ScrollWheelSpeed",
 	});
 }
@@ -515,6 +517,11 @@ void CMouseHandler::MouseWheel(float delta)
 {
 	if (eventHandler.MouseWheel(delta > 0.0f, delta))
 		return;
+
+	if (miniMapMouseWheel && (minimap != nullptr) && minimap->IsInside(mouse->lastx, mouse->lasty)) {
+		minimap->MouseWheel(delta > 0.0f, delta);
+		return;
+	}
 
 	camHandler->GetCurrentController().MouseWheelMove(delta * scrollWheelSpeed);
 }
@@ -1013,19 +1020,20 @@ bool CMouseHandler::ReplaceMouseCursor(
 
 
 /******************************************************************************/
-void CMouseHandler::ConfigUpdate()
-{
-	invertMouse = configHandler->GetBool("InvertMouse");
-	dragScrollThreshold = configHandler->GetFloat("MouseDragScrollThreshold");
-	dragSelectionThreshold = configHandler->GetInt("MouseDragSelectionThreshold");
-	dragBoxCommandThreshold = configHandler->GetInt("MouseDragBoxCommandThreshold");
-	dragCircleCommandThreshold = configHandler->GetInt("MouseDragCircleCommandThreshold");
-	dragFrontCommandThreshold = configHandler->GetInt("MouseDragFrontCommandThreshold");
-	scrollWheelSpeed = configHandler->GetFloat("ScrollWheelSpeed");
-}
 
 void CMouseHandler::ConfigNotify(const std::string& key, const std::string& value)
 {
 	ConfigUpdate();
 }
 
+void CMouseHandler::ConfigUpdate()
+{
+	dragScrollThreshold = configHandler->GetFloat("MouseDragScrollThreshold");
+	dragSelectionThreshold = configHandler->GetInt("MouseDragSelectionThreshold");
+	dragBoxCommandThreshold = configHandler->GetInt("MouseDragBoxCommandThreshold");
+	dragCircleCommandThreshold = configHandler->GetInt("MouseDragCircleCommandThreshold");
+	dragFrontCommandThreshold = configHandler->GetInt("MouseDragFrontCommandThreshold");
+	invertMouse = configHandler->GetBool("InvertMouse");
+	miniMapMouseWheel = configHandler->GetBool("MiniMapMouseWheel");
+	scrollWheelSpeed = configHandler->GetFloat("ScrollWheelSpeed");
+}

--- a/rts/Game/UI/MouseHandler.h
+++ b/rts/Game/UI/MouseHandler.h
@@ -135,6 +135,8 @@ public:
 	float scrollWheelSpeed = 0.0f;
 	float dragScrollThreshold = 0.0f;
 
+	bool miniMapMouseWheel = false;
+
 	int dragSelectionThreshold = 0;
 	int dragBoxCommandThreshold = 0;
 	int dragCircleCommandThreshold = 0;


### PR DESCRIPTION
When cursor in minimap refers to a point outside current camera view, move to it. Otherwise perform identical mousewheel at referred point for current camera.