### PR TITLE
Fix wrong logic in alcIsExtensionPresent; fix audio device reconnect

### DIFF
--- a/rts/System/Sound/ISound.cpp
+++ b/rts/System/Sound/ISound.cpp
@@ -24,7 +24,7 @@
 CONFIG(bool, Sound).defaultValue(true).description("Enables (OpenAL) or disables sound.");
 
 CONFIG(bool, UseEFX     ).defaultValue( true).safemodeValue(false);
-CONFIG(bool, UseSDLAudio).defaultValue( true).safemodeValue(false);
+CONFIG(bool, UseSDLAudio).defaultValue( true).safemodeValue(false).headlessValue(0).description("If enabled, OpenAL-soft only renders audio into a SDL buffer and playback is done by the SDL audio layer, i.e. SDL handles the hardware");
 
 // defined here so spring-headless contains them, too (default & headless should contain the same set of configtags!)
 CONFIG(int, MaxSounds).defaultValue(128).headlessValue(1).minimumValue(1).description("Maximum sounds played in parallel.");


### PR DESCRIPTION
    Fix wrong logic in alcIsExtensionPresent; fix audio device reconnect

    What did not work before this patch:

    * have a USB headset attached and start a game
    * then unplugged it and replugged it
    * a result was: the sound was gone forever
    * also logging was not good, did not know if it was using UseSDLAudio or
      not

    FIX in this patch:

    * using alcIsExtensionPresent we can now correctly identify that the
      ALC_SOFT_loopback is available
    * the sdlDeviceID is initialized with 0 instead of -1 so we don't
      segfault. therefore we can make use of SDL audio as an intermediate
      buffer to render audio to
    * with UseSDLAudio = 1 (default) and the fixes above the audio devices
      can now be reconnected and audio resumes **awesome**
    * headless defaults to 0 for SDLAudio usage:
      CONFIG(bool, UseSDLAudio).defaultValue(
      true).safemodeValue(false).headlessValue(0).description("If enabled,
      OpenAL-soft only renders audio into a SDL buffer and playback is done
      by the SDL audio layer, i.e. SDL handles the hardware");
    * lists all SDL audio devices during startup

    The basic concept here is to bypass direct openal-soft soundcard access
    and instead let SDL audio handle the soundcard and audio output.
    Therefore openal-soft renders audio into a SDL buffer and SDL puts it
    on the device. SDL audio has a better device disconnect/reconnect
    implementation as openal-soft at time of writing.

    I verified this patch on Windows 10 with building it using docker. Not
    tested Linux or other platforms.