### PR TITLE
[AI] Filter out -1 unitIDs

### DIFF
--- a/rts/ExternalAI/AICallback.cpp
+++ b/rts/ExternalAI/AICallback.cpp
@@ -793,6 +793,8 @@ static int FilterUnitsVector(const std::vector<CUnit*>& units, int* unitIds, int
 
 	for (auto ui = units.begin(); (ui != units.end()) && (a < maxUnitIds); ++ui) {
 		const CUnit* u = *ui;
+		if (!CHECK_UNITID(u->id))
+			continue;
 
 		if ((includeUnit == nullptr) || (*includeUnit)(u)) {
 			if (unitIds != nullptr)


### PR DESCRIPTION
Currently under some un-investigated (or forgotten) conditions AI API functions may return array with -1 unit IDs. That forces AI-side to make redundant check, and it messes up number of actually returned units.
Affected functions:
```
skirmishAiCallback_getEnemyUnits,
skirmishAiCallback_getEnemyUnitsInRadarAndLos,
skirmishAiCallback_getEnemyUnitsIn,
skirmishAiCallback_getFriendlyUnits,
skirmishAiCallback_getFriendlyUnitsIn,
skirmishAiCallback_getNeutralUnits,
skirmishAiCallback_getNeutralUnitsIn
```
NB: Features doesn't suffer from same issue AFAIK.
And i don't know if `skirmishAiCallback_getTeamUnits` is affected, as usually it's not used, and current fix doesn't change its behaviour.