### PR TITLE
KeyBindings: Fix KeyDebug and IKeys inheritance

### DIFF
--- a/rts/Game/UI/IKeys.h
+++ b/rts/Game/UI/IKeys.h
@@ -20,11 +20,11 @@ public:
 
 public:
 
-	virtual void PrintNameToCode() const {};
-	virtual void PrintCodeToName() const {};
-	virtual bool IsModifier(int code) { return false; };
-	virtual std::string GetName(int code) const { return ""; };
-	virtual std::string GetDefaultName(int code) const { return ""; };
+	virtual void PrintNameToCode() const = 0;
+	virtual void PrintCodeToName() const = 0;
+	virtual bool IsModifier(int code) const = 0;
+	virtual std::string GetName(int code) const = 0;
+	virtual std::string GetDefaultName(int code) const = 0;
 
 	static bool IsValidLabel(const std::string& label);
 

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -445,7 +445,13 @@ ActionList CKeyBindings::GetActionList(const CKeyChain& kc, const CKeyChain& sc)
 	MergeActionListsByTrigger(kList, sList, merged);
 
 	if (debugEnabled) {
-		LOG("GetActions: codeChain=\"%s\" scanChain=\"%s\":", kc.GetString().c_str(), sc.GetString().c_str());
+		LOG(
+			"GetActions: codeChain=\"%s\" scanChain=\"%s\" keyCode=\"%s\" scanCode=\"%s\":",
+			kc.GetString().c_str(),
+			sc.GetString().c_str(),
+			kc.back().GetCodeString().c_str(),
+			sc.back().GetCodeString().c_str()
+		);
 
 		DebugActionList(merged);
 	}
@@ -731,7 +737,7 @@ bool CKeyBindings::AddKeySymbol(const std::string& keysym, const std::string& co
 		LOG_L(L_WARNING, "AddKeySymbol: could not parse key: %s", code.c_str());
 		return false;
 	}
-	if (!ks.GetKeys().AddKeySymbol(keysym, ks.Key())) {
+	if (!(ks.GetKeys()->AddKeySymbol(keysym, ks.Key()))) {
 		LOG_L(L_WARNING, "AddKeySymbol: could not add: %s", keysym.c_str());
 		return false;
 	}

--- a/rts/Game/UI/KeyCodes.cpp
+++ b/rts/Game/UI/KeyCodes.cpp
@@ -28,7 +28,7 @@ int CKeyCodes::GetNormalizedSymbol(int sym)
 }
 
 
-bool CKeyCodes::IsModifier(int code)
+bool CKeyCodes::IsModifier(int code) const
 {
 	switch (code) {
 		case SDLK_LALT:
@@ -173,12 +173,18 @@ void CKeyCodes::Reset()
 }
 
 
+std::string CKeyCodes::GetCodeString(int code)
+{
+	return IntToString(code, "0x%03X");
+}
+
+
 std::string CKeyCodes::GetName(int code) const
 {
 	const auto iter = std::lower_bound(codeToName.begin(), codeToName.end(), CodeNamePair{code, ""}, codePred);
 
 	if (iter == codeToName.end() || iter->first != code)
-		return IntToString(code, "0x%03X");
+		return GetCodeString(code);
 
 	return iter->second;
 }
@@ -189,7 +195,7 @@ std::string CKeyCodes::GetDefaultName(int code) const
 	const auto iter = std::lower_bound(defaultCodeToName.begin(), defaultCodeToName.end(), CodeNamePair{code, ""}, codePred);
 
 	if (iter == defaultCodeToName.end() || iter->first != code)
-		return IntToString(code, "0x%03X");
+		return GetCodeString(code);
 
 	return iter->second;
 }

--- a/rts/Game/UI/KeyCodes.h
+++ b/rts/Game/UI/KeyCodes.h
@@ -8,14 +8,15 @@
 class CKeyCodes : public IKeys {
 public:
 
-	bool IsModifier(int code);
+	void Reset() override;
 
-	void Reset();
-	void PrintNameToCode() const;
-	void PrintCodeToName() const;
-	std::string GetName(int code) const;
-	std::string GetDefaultName(int code) const;
+	bool IsModifier(int code) const override;
+	void PrintNameToCode() const override;
+	void PrintCodeToName() const override;
+	std::string GetName(int code) const override;
+	std::string GetDefaultName(int code) const override;
 
+	static std::string GetCodeString(int code);
 	static int GetNormalizedSymbol(int sym);
 };
 

--- a/rts/Game/UI/KeySet.cpp
+++ b/rts/Game/UI/KeySet.cpp
@@ -46,7 +46,7 @@ bool CKeySet::IsPureModifier() const
 
 bool CKeySet::IsModifier() const
 {
-	return GetKeys().IsModifier(key);
+	return GetKeys()->IsModifier(key);
 }
 
 bool CKeySet::IsKeyCode() const
@@ -54,9 +54,13 @@ bool CKeySet::IsKeyCode() const
 	return type == KSKeyCode;
 }
 
-IKeys CKeySet::GetKeys() const
+IKeys* CKeySet::GetKeys() const
 {
-	return IsKeyCode() ? (IKeys)keyCodes : (IKeys)scanCodes;
+	if (IsKeyCode()) {
+		return &keyCodes;
+	} else {
+		return &scanCodes;
+	}
 }
 
 CKeySet::CKeySet(int k)
@@ -102,10 +106,16 @@ std::string CKeySet::GetString(bool useDefaultKeysym) const
 {
 	std::string name;
 
-	IKeys keys = GetKeys();
-	name = useDefaultKeysym ? keys.GetDefaultName(key) : keys.GetName(key);
+	const IKeys* keys = GetKeys();
+	name = useDefaultKeysym ? keys->GetDefaultName(key) : keys->GetName(key);
 	
 	return (GetHumanModifiers(modifiers) + name);
+}
+
+
+std::string CKeySet::GetCodeString() const
+{
+	return IsKeyCode() ? CKeyCodes::GetCodeString(key) : CScanCodes::GetCodeString(key);
 }
 
 

--- a/rts/Game/UI/KeySet.h
+++ b/rts/Game/UI/KeySet.h
@@ -28,6 +28,7 @@ class CKeySet {
 		bool Parse(const std::string& token, bool showerror = true);
 
 		std::string GetString(bool useDefaultKeysym) const;
+		std::string GetCodeString() const;
 
 		enum CKeySetModifiers {
 			KS_ALT     = (1 << 0),
@@ -49,7 +50,7 @@ class CKeySet {
 		bool IsPureModifier() const;
 		bool IsModifier() const;
 		bool IsKeyCode() const;
-		IKeys GetKeys() const;
+		IKeys* GetKeys() const;
 
 		bool operator<(const CKeySet& ks) const
 		{

--- a/rts/Game/UI/ScanCodes.cpp
+++ b/rts/Game/UI/ScanCodes.cpp
@@ -24,7 +24,7 @@ int CScanCodes::GetNormalizedSymbol(int sym)
 }
 
 
-bool CScanCodes::IsModifier(int code)
+bool CScanCodes::IsModifier(int code) const
 {
 	switch (code) {
 		case SDL_SCANCODE_LALT:
@@ -236,12 +236,18 @@ void CScanCodes::Reset()
 }
 
 
+std::string CScanCodes::GetCodeString(int code)
+{
+	return IntToString(code, "sc_0x%03X");
+}
+
+
 std::string CScanCodes::GetName(int code) const
 {
 	const auto iter = std::lower_bound(codeToName.begin(), codeToName.end(), CodeNamePair{code, ""}, codePred);
 
 	if (iter == codeToName.end() || iter->first != code)
-		return IntToString(code, "sc_0x%03X");
+		return GetCodeString(code);
 
 	return iter->second;
 }
@@ -252,7 +258,7 @@ std::string CScanCodes::GetDefaultName(int code) const
 	const auto iter = std::lower_bound(defaultCodeToName.begin(), defaultCodeToName.end(), CodeNamePair{code, ""}, codePred);
 
 	if (iter == defaultCodeToName.end() || iter->first != code)
-		return IntToString(code, "sc_0x%03X");
+		return GetCodeString(code);
 
 	return iter->second;
 }

--- a/rts/Game/UI/ScanCodes.h
+++ b/rts/Game/UI/ScanCodes.h
@@ -8,14 +8,15 @@
 class CScanCodes : public IKeys {
 public:
 
-	bool IsModifier(int code);
+	void Reset() override;
 
-	void Reset();
-	void PrintNameToCode() const;
-	void PrintCodeToName() const;
-	std::string GetName(int code) const;
-	std::string GetDefaultName(int code) const;
+	bool IsModifier(int code) const override;
+	void PrintNameToCode() const override;
+	void PrintCodeToName() const override;
+	std::string GetName(int code) const override;
+	std::string GetDefaultName(int code) const override;
 
+	static std::string GetCodeString(int code);
 	static int GetNormalizedSymbol(int sym);
 };
 


### PR DESCRIPTION
Fix: #460 

Output looks like this now:

```
[KeyBindings] GetActions: codeChain="Ctrl+z" scanChain="Ctrl+sc_z" keyCode="0x07A" scanCode="sc_0x01D":
[KeyBindings] Action List:
[KeyBindings]    1.  action="select"  rawline="select AllMap+_InPrevSel+_ClearSelection_SelectAll+"  shortcut="Ctrl+sc_z"  index="165"
[KeyBindings]    2.  action="selectbox_same"  rawline="selectbox_same"  shortcut="Any+sc_z"  index="11"
[KeyBindings]    3.  action="gridmenu_key"  rawline="gridmenu_key 1 1"  shortcut="Any+sc_z"  index="27"
```