### PR TITLE
[AI] API: Remove dead code, duplicates and memory leaks

### DIFF
--- a/AI/Interfaces/C/src/Interface.cpp
+++ b/AI/Interfaces/C/src/Interface.cpp
@@ -197,7 +197,7 @@ std::string CInterface::FindLibFile(const SSkirmishAISpecifier& spec)
 	const char* sn = spec.shortName;
 	const char* sv = spec.version;
 
-	std::string dataDir = callback->SkirmishAIs_Info_getValueByKey(interfaceId, sn, sv, SKIRMISH_AI_PROPERTY_DATA_DIR);
+	std::string dataDir = callback->SkirmishAI_Info_getValueByKey(interfaceId, sn, sv, SKIRMISH_AI_PROPERTY_DATA_DIR);
 
 	if (dataDir.empty()) {
 		reportError(std::string("Missing Skirmish AI data-dir for ") + sn + " " + sv);

--- a/AI/Interfaces/Java/src/main/native/InterfaceExport.c
+++ b/AI/Interfaces/Java/src/main/native/InterfaceExport.c
@@ -139,7 +139,7 @@ EXPORT(int) unloadSkirmishAILibrary(
 	const char* const shortName,
 	const char* const version
 ) {
-	const char* const className = callback->SkirmishAIs_Info_getValueByKey(interfaceId, shortName, version, JAVA_SKIRMISH_AI_PROPERTY_CLASS_NAME);
+	const char* const className = callback->SkirmishAI_Info_getValueByKey(interfaceId, shortName, version, JAVA_SKIRMISH_AI_PROPERTY_CLASS_NAME);
 
 	if (java_releaseSkirmishAIClass(className))
 		return 0;

--- a/AI/Skirmish/NullJavaAI/src/nulljavaai/NullJavaAI.java
+++ b/AI/Skirmish/NullJavaAI/src/nulljavaai/NullJavaAI.java
@@ -84,9 +84,7 @@ public class NullJavaAI extends AbstractAI implements AI {
 		// initialize the log
 		try {
 			int teamId = clb.SkirmishAI_getTeamId();
-			// most likely, this causes a memory leak, as the C string
-			// allocated by this, is never freed
-			myLogFile = callback.DataDirs_allocatePath("log-team-" + teamId + "-" + skirmishAIId + ".txt", true, true, false, false);
+			myLogFile = callback.DataDirs_locatePath("log-team-" + teamId + "-" + skirmishAIId + ".txt", true, true, false, false);
 			FileHandler fileLogger = new FileHandler(myLogFile, false);
 			fileLogger.setFormatter(new MyCustomLogFormatter());
 			fileLogger.setLevel(Level.ALL);

--- a/AI/Skirmish/NullOOJavaAI/src/main/java/nulloojavaai/NullOOJavaAI.java
+++ b/AI/Skirmish/NullOOJavaAI/src/main/java/nulloojavaai/NullOOJavaAI.java
@@ -89,7 +89,7 @@ public class NullOOJavaAI extends OOAI implements AI {
 	private int sendTextMsg(String msg) {
 
 		try {
-			clb.getGame().sendTextMessage(msg, DEFAULT_ZONE);
+			clb.getGame().sendTextMessage("/say " + msg, DEFAULT_ZONE);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			return 1;
@@ -131,7 +131,7 @@ public class NullOOJavaAI extends OOAI implements AI {
 
 		// initialize the log
 		try {
-			myLogFile = callback.getDataDirs().allocatePath("log-team-" + teamId + ".txt", true, true, false, false);
+			myLogFile = callback.getDataDirs().locatePath("log-team-" + teamId + ".txt", true, true, false, false);
 			FileHandler fileLogger = new FileHandler(myLogFile, false);
 			fileLogger.setFormatter(new MyCustomLogFormatter());
 			fileLogger.setLevel(Level.ALL);

--- a/AI/Wrappers/CUtils/bin/common.awk
+++ b/AI/Wrappers/CUtils/bin/common.awk
@@ -484,6 +484,30 @@ function convertCToCppType(cType__common) {
 ################################################################################
 
 
+
+################################################################################
+### BEGIN: Meta comment functions
+
+function part_isRetString(namePart_p, metaInfo_p) {
+	return match(metaInfo_p, /RET_STRING:/)
+}
+function part_getRetString(metaInfo_p) {
+
+	retStringPart_p = metaInfo_p;
+
+	# remove pre class part
+	sub(/.*RET_STRING:/, "", retStringPart_p);
+
+	# remove post class part
+	sub(/: .*/,     "", retStringPart_p);
+
+	return retStringPart_p;
+}
+
+### END: Meta comment functions
+################################################################################
+
+
 END {
 	# finalize things
 }

--- a/AI/Wrappers/Cpp/CMakeLists.txt
+++ b/AI/Wrappers/Cpp/CMakeLists.txt
@@ -64,7 +64,6 @@ if    (BUILD_${myName}_AIWRAPPER)
 	set(myGeneratedCombineSources
 		${myGeneratedSourceDir}/CombinedCallbackBridge.c)
 	set(myGeneratedWrapperSources
-		${myGeneratedSourceDir}/AbstractCamera.cpp
 		${myGeneratedSourceDir}/AbstractCheats.cpp
 		${myGeneratedSourceDir}/AbstractCommand.cpp
 		${myGeneratedSourceDir}/AbstractCommandDescription.cpp
@@ -80,7 +79,6 @@ if    (BUILD_${myName}_AIWRAPPER)
 		${myGeneratedSourceDir}/AbstractFlankingBonus.cpp
 		${myGeneratedSourceDir}/AbstractGame.cpp
 		${myGeneratedSourceDir}/AbstractGroup.cpp
-		${myGeneratedSourceDir}/AbstractGui.cpp
 		${myGeneratedSourceDir}/AbstractInfo.cpp
 		${myGeneratedSourceDir}/AbstractLine.cpp
 		${myGeneratedSourceDir}/AbstractLog.cpp
@@ -99,16 +97,13 @@ if    (BUILD_${myName}_AIWRAPPER)
 		${myGeneratedSourceDir}/AbstractRoots.cpp
 		${myGeneratedSourceDir}/AbstractShield.cpp
 		${myGeneratedSourceDir}/AbstractSkirmishAI.cpp
-		${myGeneratedSourceDir}/AbstractSkirmishAIs.cpp
 		${myGeneratedSourceDir}/AbstractTeam.cpp
-		${myGeneratedSourceDir}/AbstractTeams.cpp
 		${myGeneratedSourceDir}/AbstractUnit.cpp
 		${myGeneratedSourceDir}/AbstractUnitDef.cpp
 		${myGeneratedSourceDir}/AbstractVersion.cpp
 		${myGeneratedSourceDir}/AbstractWeaponDef.cpp
 		${myGeneratedSourceDir}/AbstractWeaponMount.cpp
 		${myGeneratedSourceDir}/AbstractWeapon.cpp
-		${myGeneratedSourceDir}/StubCamera.cpp
 		${myGeneratedSourceDir}/StubCheats.cpp
 		${myGeneratedSourceDir}/StubCommand.cpp
 		${myGeneratedSourceDir}/StubCommandDescription.cpp
@@ -124,7 +119,6 @@ if    (BUILD_${myName}_AIWRAPPER)
 		${myGeneratedSourceDir}/StubFlankingBonus.cpp
 		${myGeneratedSourceDir}/StubGame.cpp
 		${myGeneratedSourceDir}/StubGroup.cpp
-		${myGeneratedSourceDir}/StubGui.cpp
 		${myGeneratedSourceDir}/StubInfo.cpp
 		${myGeneratedSourceDir}/StubLine.cpp
 		${myGeneratedSourceDir}/StubLog.cpp
@@ -143,16 +137,13 @@ if    (BUILD_${myName}_AIWRAPPER)
 		${myGeneratedSourceDir}/StubRoots.cpp
 		${myGeneratedSourceDir}/StubShield.cpp
 		${myGeneratedSourceDir}/StubSkirmishAI.cpp
-		${myGeneratedSourceDir}/StubSkirmishAIs.cpp
 		${myGeneratedSourceDir}/StubTeam.cpp
-		${myGeneratedSourceDir}/StubTeams.cpp
 		${myGeneratedSourceDir}/StubUnit.cpp
 		${myGeneratedSourceDir}/StubUnitDef.cpp
 		${myGeneratedSourceDir}/StubVersion.cpp
 		${myGeneratedSourceDir}/StubWeaponDef.cpp
 		${myGeneratedSourceDir}/StubWeaponMount.cpp
 		${myGeneratedSourceDir}/StubWeapon.cpp
-		${myGeneratedSourceDir}/WrappCamera.cpp
 		${myGeneratedSourceDir}/WrappCheats.cpp
 		${myGeneratedSourceDir}/WrappCurrentCommand.cpp
 		${myGeneratedSourceDir}/WrappDamage.cpp
@@ -171,7 +162,6 @@ if    (BUILD_${myName}_AIWRAPPER)
 		${myGeneratedSourceDir}/WrappGraphLine.cpp
 		${myGeneratedSourceDir}/WrappGroup.cpp
 		${myGeneratedSourceDir}/WrappGroupSupportedCommand.cpp
-		${myGeneratedSourceDir}/WrappGui.cpp
 		${myGeneratedSourceDir}/WrappInfo.cpp
 		${myGeneratedSourceDir}/WrappLine.cpp
 		${myGeneratedSourceDir}/WrappLog.cpp
@@ -190,9 +180,7 @@ if    (BUILD_${myName}_AIWRAPPER)
 		${myGeneratedSourceDir}/WrappRoots.cpp
 		${myGeneratedSourceDir}/WrappShield.cpp
 		${myGeneratedSourceDir}/WrappSkirmishAI.cpp
-		${myGeneratedSourceDir}/WrappSkirmishAIs.cpp
 		${myGeneratedSourceDir}/WrappTeam.cpp
-		${myGeneratedSourceDir}/WrappTeams.cpp
 		${myGeneratedSourceDir}/WrappUnit.cpp
 		${myGeneratedSourceDir}/WrappUnitDef.cpp
 		${myGeneratedSourceDir}/WrappUnitSupportedCommand.cpp

--- a/AI/Wrappers/JavaOO/CMakeLists.txt
+++ b/AI/Wrappers/JavaOO/CMakeLists.txt
@@ -104,7 +104,6 @@ if    (BUILD_${myName}_AIWRAPPER)
 		)
 
 	set(myGenClbClasses
-		"Camera"
 		"Cheats"
 		"CommandDescription"
 		"Command"
@@ -122,7 +121,6 @@ if    (BUILD_${myName}_AIWRAPPER)
 		"GraphDrawer"
 		"GraphLine"
 		"Group"
-		"Gui"
 		"Info"
 		"Line"
 		"Log"
@@ -140,9 +138,7 @@ if    (BUILD_${myName}_AIWRAPPER)
 		"Roots"
 		"Shield"
 		"SkirmishAI"
-		"SkirmishAIs"
 		"Team"
-		"Teams"
 		"OverlayTexture"
 		"UnitDef"
 		"Unit"

--- a/AI/Wrappers/LegacyCpp/AIAICallback.cpp
+++ b/AI/Wrappers/LegacyCpp/AIAICallback.cpp
@@ -956,24 +956,20 @@ bool springLegacyAI::CAIAICallback::GetValue(int valueId, void *data)
 		}case AIVAL_GAME_SPEED_FACTOR:{
 			*(float*)data = sAICallback->Game_getSpeedFactor(skirmishAIId);
 			return true;
-		}case AIVAL_GUI_VIEW_RANGE:{
-			*(float*)data = sAICallback->Gui_getViewRange(skirmishAIId);
+		}case AIVAL_GUI_VIEW_RANGE:{  // deprecated
+			*(float*)data = 0;
 			return true;
-		}case AIVAL_GUI_SCREENX:{
-			*(float*)data = sAICallback->Gui_getScreenX(skirmishAIId);
+		}case AIVAL_GUI_SCREENX:{  // deprecated
+			*(float*)data = 0;
 			return true;
-		}case AIVAL_GUI_SCREENY:{
-			*(float*)data = sAICallback->Gui_getScreenY(skirmishAIId);
+		}case AIVAL_GUI_SCREENY:{  // deprecated
+			*(float*)data = 0;
 			return true;
-		}case AIVAL_GUI_CAMERA_DIR:{
-			float3 dir;
-			sAICallback->Gui_Camera_getDirection(skirmishAIId, &dir[0]);
-			*(static_cast<float3*>(data)) = dir;
+		}case AIVAL_GUI_CAMERA_DIR:{  // deprecated
+			*(static_cast<float3*>(data)) = ZeroVector;
 			return true;
-		}case AIVAL_GUI_CAMERA_POS:{
-			float3 pos;
-			sAICallback->Gui_Camera_getPosition(skirmishAIId, &pos[0]);
-			*(static_cast<float3*>(data)) = pos;
+		}case AIVAL_GUI_CAMERA_POS:{  // deprecated
+			*(static_cast<float3*>(data)) = ZeroVector;
 			return true;
 		}case AIVAL_LOCATE_FILE_R:{
 			//sAICallback->File_locateForReading(skirmishAIId, (char*) data);
@@ -1800,14 +1796,16 @@ int springLegacyAI::CAIAICallback::HandleCommand(int commandId, void* data) {
 
 		case AIHCGetDataDirId: {
 			AIHCGetDataDir* cppCmdData = static_cast<AIHCGetDataDir*>(data);
-			cppCmdData->ret_path = sAICallback->DataDirs_allocatePath(
+			const bool located = sAICallback->DataDirs_locatePath(
 					skirmishAIId,
+					cppCmdData->ret_path,
+					cppCmdData->pathMaxSize,
 					cppCmdData->relPath,
 					cppCmdData->writeable,
 					cppCmdData->create,
 					cppCmdData->dir,
 					cppCmdData->common);
-			ret = (cppCmdData->ret_path[0] != 0);
+			ret = located && (cppCmdData->ret_path[0] != 0);
 			break;
 		}
 	}

--- a/rts/ExternalAI/AILegacySupport.h
+++ b/rts/ExternalAI/AILegacySupport.h
@@ -153,7 +153,7 @@ struct AIHCPause
 
 /**
  * See Clb_DataDirs_allocatePath in rts/ExternalAI/Interface/SSkirmishAICallback.h
- * ret_path should be copied by the AI after retrieving it, but not freed!
+ * ret_path should be allocated and freed by AI!
  */
 struct AIHCGetDataDir ///< result of HandleCommand is 1 for if path fetched, 0 for fail
 {
@@ -163,6 +163,7 @@ struct AIHCGetDataDir ///< result of HandleCommand is 1 for if path fetched, 0 f
 	bool dir;
 	bool common;
 	char* ret_path;
+	int pathMaxSize;
 };
 
 struct AIHCDebugDraw

--- a/rts/ExternalAI/Interface/AISCommands.h
+++ b/rts/ExternalAI/Interface/AISCommands.h
@@ -1523,7 +1523,7 @@ struct SAddOverlayTextureDrawerDebugCommand {
 	const float* texData;
 	int w;
 	int h;
-}; //$ COMMAND_DEBUG_DRAWER_OVERLAYTEXTURE_ADD Debug_addOverlayTexture REF:ret_textureId->OverlayTexture
+}; //$ COMMAND_DEBUG_DRAWER_OVERLAYTEXTURE_ADD Debug_addOverlayTexture REF:ret_overlayTextureId->OverlayTexture
 
 struct SUpdateOverlayTextureDrawerDebugCommand {
 	int overlayTextureId;

--- a/rts/ExternalAI/Interface/SAIInterfaceCallback.h
+++ b/rts/ExternalAI/Interface/SAIInterfaceCallback.h
@@ -132,16 +132,16 @@ struct SAIInterfaceCallback {
 
 
 	/// the number of teams in this game
-	int               (CALLING_CONV *Teams_getSize)(int interfaceId);
+	int               (CALLING_CONV *getNumTeams)(int interfaceId);
 
 	/// the number of skirmish AIs in this game
-	int               (CALLING_CONV *SkirmishAIs_getSize)(int interfaceId);
+	int               (CALLING_CONV *getNumSkirmishAIs)(int interfaceId);
 
 	/// the maximum number of skirmish AIs in any game
-	int               (CALLING_CONV *SkirmishAIs_getMax)(int interfaceId);
+	int               (CALLING_CONV *getMaxSkirmishAIs)(int interfaceId);
 
 	/// Returns the value accosiated to the given key from the skirmish AIs info map
-	const char*       (CALLING_CONV *SkirmishAIs_Info_getValueByKey)(int interfaceId, const char* const shortName, const char* const version, const char* const key);
+	const char*       (CALLING_CONV *SkirmishAI_Info_getValueByKey)(int interfaceId, const char* const shortName, const char* const version, const char* const key);
 
 	/// This will end up in infolog
 	void              (CALLING_CONV *Log_log)(int interfaceId, const char* const msg);
@@ -203,11 +203,6 @@ struct SAIInterfaceCallback {
 	 */
 	bool              (CALLING_CONV *DataDirs_locatePath)(int interfaceId, char* path, int path_sizeMax, const char* const relPath, bool writeable, bool create, bool dir, bool common);
 
-	/**
-	 * @see     locatePath()
-	 */
-	char*             (CALLING_CONV *DataDirs_allocatePath)(int interfaceId, const char* const relPath, bool writeable, bool create, bool dir, bool common);
-
 	/// Returns the number of springs data dirs.
 	int               (CALLING_CONV *DataDirs_Roots_getSize)(int interfaceId);
 
@@ -238,8 +233,6 @@ struct SAIInterfaceCallback {
 	 *          -> the path exists and is stored in an absolute form in path
 	 */
 	bool              (CALLING_CONV *DataDirs_Roots_locatePath)(int interfaceId, char* path, int path_sizeMax, const char* const relPath, bool writeable, bool create, bool dir);
-
-	char*             (CALLING_CONV *DataDirs_Roots_allocatePath)(int interfaceId, const char* const relPath, bool writeable, bool create, bool dir);
 
 	// Reading the file is better done directly by the interface, eg with fopen()
 	//int               (CALLING_CONV *DataDirs_File_getSize)(int interfaceId, const char* const filePath);

--- a/rts/ExternalAI/Interface/SSkirmishAICallback.h
+++ b/rts/ExternalAI/Interface/SSkirmishAICallback.h
@@ -114,13 +114,13 @@ struct SSkirmishAICallback {
 	const char*       (CALLING_CONV *Engine_Version_getFull)(int skirmishAIId);
 
 	/** Returns the number of teams in this game */
-	int               (CALLING_CONV *Teams_getSize)(int skirmishAIId);
+	int               (CALLING_CONV *getNumTeams)(int skirmishAIId);
 
 	/** Returns the number of skirmish AIs in this game */
-	int               (CALLING_CONV *SkirmishAIs_getSize)(int skirmishAIId);
+	int               (CALLING_CONV *getNumSkirmishAIs)(int skirmishAIId);
 
 	/** Returns the maximum number of skirmish AIs in any game */
-	int               (CALLING_CONV *SkirmishAIs_getMax)(int skirmishAIId);
+	int               (CALLING_CONV *getMaxSkirmishAIs)(int skirmishAIId);
 
 	/**
 	 * Returns the ID of the team controled by this Skirmish AI.
@@ -236,18 +236,13 @@ struct SSkirmishAICallback {
 	 * @return  whether the locating process was successfull
 	 *          -> the path exists and is stored in an absolute form in path
 	 */
-	bool              (CALLING_CONV *DataDirs_locatePath)(int skirmishAIId, char* path, int path_sizeMax, const char* const relPath, bool writeable, bool create, bool dir, bool common);
-
-	/**
-	 * @see     locatePath()
-	 */
-	char*             (CALLING_CONV *DataDirs_allocatePath)(int skirmishAIId, const char* const relPath, bool writeable, bool create, bool dir, bool common);
+	bool              (CALLING_CONV *DataDirs_locatePath)(int skirmishAIId, char* path, int path_sizeMax, const char* const relPath, bool writeable, bool create, bool dir, bool common); //$ RET_STRING:path:path_sizeMax
 
 	/** Returns the number of springs data dirs. */
 	int               (CALLING_CONV *DataDirs_Roots_getSize)(int skirmishAIId);
 
 	/** Returns the data dir at dirIndex, which is valid between 0 and (DataDirs_Roots_getSize() - 1). */
-	bool              (CALLING_CONV *DataDirs_Roots_getDir)(int skirmishAIId, char* path, int path_sizeMax, int dirIndex);
+	bool              (CALLING_CONV *DataDirs_Roots_getDir)(int skirmishAIId, char* path, int path_sizeMax, int dirIndex); //$ RET_STRING:path:path_sizeMax
 
 	/**
 	 * Returns an absolute path which consists of:
@@ -272,9 +267,7 @@ struct SSkirmishAICallback {
 	 * @return  whether the locating process was successfull
 	 *          -> the path exists and is stored in an absolute form in path
 	 */
-	bool              (CALLING_CONV *DataDirs_Roots_locatePath)(int skirmishAIId, char* path, int path_sizeMax, const char* const relPath, bool writeable, bool create, bool dir);
-
-	char*             (CALLING_CONV *DataDirs_Roots_allocatePath)(int skirmishAIId, const char* const relPath, bool writeable, bool create, bool dir);
+	bool              (CALLING_CONV *DataDirs_Roots_locatePath)(int skirmishAIId, char* path, int path_sizeMax, const char* const relPath, bool writeable, bool create, bool dir); //$ RET_STRING:path:path_sizeMax
 
 // BEGINN misc callback functions
 	/**
@@ -420,20 +413,6 @@ struct SSkirmishAICallback {
 	const char*       (CALLING_CONV *Game_getRulesParamString)(int skirmishAIId, const char* gameRulesParamName, const char* defaultValue);
 
 // END misc callback functions
-
-
-// BEGINN Visualization related callback functions
-	float             (CALLING_CONV *Gui_getViewRange)(int skirmishAIId);
-
-	float             (CALLING_CONV *Gui_getScreenX)(int skirmishAIId);
-
-	float             (CALLING_CONV *Gui_getScreenY)(int skirmishAIId);
-
-	void              (CALLING_CONV *Gui_Camera_getDirection)(int skirmishAIId, float* return_posF3_out);
-
-	void              (CALLING_CONV *Gui_Camera_getPosition)(int skirmishAIId, float* return_posF3_out);
-
-// END Visualization related callback functions
 
 
 // BEGINN OBJECT Cheats
@@ -1264,7 +1243,7 @@ struct SSkirmishAICallback {
 
 	int               (CALLING_CONV *getEnemyTeams)(int skirmishAIId, int* teamIds, int teamIds_sizeMax); //$ FETCHER:MULTI:IDs:Team:teamIds
 
-	int               (CALLING_CONV *getAllyTeams)(int skirmishAIId, int* teamIds, int teamIds_sizeMax); //$ FETCHER:MULTI:IDs:Team:teamIds
+	int               (CALLING_CONV *getAlliedTeams)(int skirmishAIId, int* teamIds, int teamIds_sizeMax); //$ FETCHER:MULTI:IDs:Team:teamIds
 
 	/**
 	 * @return float value of parameter if it's set, defaultValue otherwise.

--- a/rts/ExternalAI/SAIInterfaceCallbackImpl.cpp
+++ b/rts/ExternalAI/SAIInterfaceCallbackImpl.cpp
@@ -124,20 +124,20 @@ EXPORT(const char*) aiInterfaceCallback_AIInterface_Info_getValueByKey(int inter
 	return info->GetInfo(key).c_str();
 }
 
-EXPORT(int) aiInterfaceCallback_Teams_getSize(int UNUSED_interfaceId) {
+EXPORT(int) aiInterfaceCallback_getNumTeams(int UNUSED_interfaceId) {
 	return teamHandler.ActiveTeams();
 }
 
-EXPORT(int) aiInterfaceCallback_SkirmishAIs_getSize(int UNUSED_interfaceId) {
+EXPORT(int) aiInterfaceCallback_getNumSkirmishAIs(int UNUSED_interfaceId) {
 	return skirmishAIHandler.GetNumSkirmishAIs();
 }
 
-EXPORT(int) aiInterfaceCallback_SkirmishAIs_getMax(int UNUSED_interfaceId) {
+EXPORT(int) aiInterfaceCallback_getMaxSkirmishAIs(int UNUSED_interfaceId) {
 	// TODO: should rather be something like (maxPlayers - numPlayers)
 	return MAX_TEAMS;
 }
 
-EXPORT(const char*) aiInterfaceCallback_SkirmishAIs_Info_getValueByKey(
+EXPORT(const char*) aiInterfaceCallback_SkirmishAI_Info_getValueByKey(
 	int UNUSED_interfaceId,
 	const char* const shortName,
 	const char* const version,
@@ -248,18 +248,6 @@ EXPORT(bool) aiInterfaceCallback_DataDirs_Roots_locatePath(
 	return (locatedPath != relPath);
 }
 
-EXPORT(char*) aiInterfaceCallback_DataDirs_Roots_allocatePath(int UNUSED_interfaceId, const char* const relPath, bool writeable, bool create, bool dir) {
-	static const unsigned int pathMaxSize = 2048;
-
-	// FIXME LEAK
-	char* path = (char*) calloc(pathMaxSize, sizeof(char*));
-
-	if (!aiInterfaceCallback_DataDirs_Roots_locatePath(-1, path, pathMaxSize, relPath, writeable, create, dir))
-		FREE(path);
-
-	return path;
-}
-
 EXPORT(const char*) aiInterfaceCallback_DataDirs_getConfigDir(int interfaceId) {
 	CHECK_INTERFACE_ID(interfaceId);
 	return infos[interfaceId]->GetDataDir().c_str();
@@ -284,18 +272,6 @@ EXPORT(bool) aiInterfaceCallback_DataDirs_locatePath(int interfaceId, char* path
 	interfaceRelPath += (ps + std::string(relPath));
 
 	return aiInterfaceCallback_DataDirs_Roots_locatePath(interfaceId, path, pathMaxSize, interfaceRelPath.c_str(), writeable, create, dir);
-}
-
-EXPORT(char*) aiInterfaceCallback_DataDirs_allocatePath(int interfaceId, const char* const relPath, bool writeable, bool create, bool dir, bool common) {
-	static const unsigned int pathMaxSize = 2048;
-
-	// FIXME LEAK
-	char* path = (char*) calloc(pathMaxSize, sizeof(char*));
-
-	if (!aiInterfaceCallback_DataDirs_locatePath(interfaceId, path, pathMaxSize, relPath, writeable, create, dir, common))
-		FREE(path);
-
-	return path;
 }
 
 
@@ -354,10 +330,10 @@ static void aiInterfaceCallback_init(struct SAIInterfaceCallback* callback) {
 	callback->AIInterface_Info_getValue = &aiInterfaceCallback_AIInterface_Info_getValue;
 	callback->AIInterface_Info_getDescription = &aiInterfaceCallback_AIInterface_Info_getDescription;
 	callback->AIInterface_Info_getValueByKey = &aiInterfaceCallback_AIInterface_Info_getValueByKey;
-	callback->Teams_getSize = &aiInterfaceCallback_Teams_getSize;
-	callback->SkirmishAIs_getSize = &aiInterfaceCallback_SkirmishAIs_getSize;
-	callback->SkirmishAIs_getMax = &aiInterfaceCallback_SkirmishAIs_getMax;
-	callback->SkirmishAIs_Info_getValueByKey = &aiInterfaceCallback_SkirmishAIs_Info_getValueByKey;
+	callback->getNumTeams = &aiInterfaceCallback_getNumTeams;
+	callback->getNumSkirmishAIs = &aiInterfaceCallback_getNumSkirmishAIs;
+	callback->getMaxSkirmishAIs = &aiInterfaceCallback_getMaxSkirmishAIs;
+	callback->SkirmishAI_Info_getValueByKey = &aiInterfaceCallback_SkirmishAI_Info_getValueByKey;
 	callback->Log_log = &aiInterfaceCallback_Log_log;
 	callback->Log_logsl = &aiInterfaceCallback_Log_logsl;
 	callback->Log_exception = &aiInterfaceCallback_Log_exception;
@@ -365,11 +341,9 @@ static void aiInterfaceCallback_init(struct SAIInterfaceCallback* callback) {
 	callback->DataDirs_getConfigDir = &aiInterfaceCallback_DataDirs_getConfigDir;
 	callback->DataDirs_getWriteableDir = &aiInterfaceCallback_DataDirs_getWriteableDir;
 	callback->DataDirs_locatePath = &aiInterfaceCallback_DataDirs_locatePath;
-	callback->DataDirs_allocatePath = &aiInterfaceCallback_DataDirs_allocatePath;
 	callback->DataDirs_Roots_getSize = &aiInterfaceCallback_DataDirs_Roots_getSize;
 	callback->DataDirs_Roots_getDir = &aiInterfaceCallback_DataDirs_Roots_getDir;
 	callback->DataDirs_Roots_locatePath = &aiInterfaceCallback_DataDirs_Roots_locatePath;
-	callback->DataDirs_Roots_allocatePath = &aiInterfaceCallback_DataDirs_Roots_allocatePath;
 }
 
 int aiInterfaceCallback_getInstanceFor(const CAIInterfaceLibraryInfo* info, struct SAIInterfaceCallback* callback) {

--- a/rts/ExternalAI/SAIInterfaceCallbackImpl.h
+++ b/rts/ExternalAI/SAIInterfaceCallbackImpl.h
@@ -29,11 +29,11 @@ EXPORT(const char*      ) aiInterfaceCallback_AIInterface_Info_getValue(int inte
 EXPORT(const char*      ) aiInterfaceCallback_AIInterface_Info_getDescription(int interfaceId, int infoIndex);
 EXPORT(const char*      ) aiInterfaceCallback_AIInterface_Info_getValueByKey(int interfaceId, const char* const key);
 
-EXPORT(int              ) aiInterfaceCallback_Teams_getSize(int UNUSED_interfaceId);
+EXPORT(int              ) aiInterfaceCallback_getNumTeams(int UNUSED_interfaceId);
 
-EXPORT(int              ) aiInterfaceCallback_SkirmishAIs_getSize(int UNUSED_interfaceId);
-EXPORT(int              ) aiInterfaceCallback_SkirmishAIs_getMax(int UNUSED_interfaceId);
-EXPORT(const char*      ) aiInterfaceCallback_SkirmishAIs_Info_getValueByKey(int UNUSED_interfaceId, const char* const shortName, const char* const version, const char* const key);
+EXPORT(int              ) aiInterfaceCallback_getNumSkirmishAIs(int UNUSED_interfaceId);
+EXPORT(int              ) aiInterfaceCallback_getMaxSkirmishAIs(int UNUSED_interfaceId);
+EXPORT(const char*      ) aiInterfaceCallback_SkirmishAI_Info_getValueByKey(int UNUSED_interfaceId, const char* const shortName, const char* const version, const char* const key);
 
 EXPORT(void             ) aiInterfaceCallback_Log_log(int interfaceId, const char* const msg);
 EXPORT(void             ) aiInterfaceCallback_Log_logsl(int interfaceId, const char* section, int loglevel, const char* const msg);
@@ -43,10 +43,8 @@ EXPORT(char             ) aiInterfaceCallback_DataDirs_getPathSeparator(int UNUS
 EXPORT(int              ) aiInterfaceCallback_DataDirs_Roots_getSize(int UNUSED_interfaceId);
 EXPORT(bool             ) aiInterfaceCallback_DataDirs_Roots_getDir(int UNUSED_interfaceId, char* path, int path_sizeMax, int dirIndex);
 EXPORT(bool             ) aiInterfaceCallback_DataDirs_Roots_locatePath(int UNUSED_interfaceId, char* path, int path_sizeMax, const char* const relPath, bool writeable, bool create, bool dir);
-EXPORT(char*            ) aiInterfaceCallback_DataDirs_Roots_allocatePath(int UNUSED_interfaceId, const char* const relPath, bool writeable, bool create, bool dir);
 EXPORT(const char*      ) aiInterfaceCallback_DataDirs_getConfigDir(int interfaceId);
 EXPORT(bool             ) aiInterfaceCallback_DataDirs_locatePath(int interfaceId, char* path, int path_sizeMax, const char* const relPath, bool writeable, bool create, bool dir, bool common);
-EXPORT(char*            ) aiInterfaceCallback_DataDirs_allocatePath(int interfaceId, const char* const relPath, bool writeable, bool create, bool dir, bool common);
 EXPORT(const char*      ) aiInterfaceCallback_DataDirs_getWriteableDir(int interfaceId);
 
 

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -1213,16 +1213,16 @@ EXPORT(const char*) skirmishAiCallback_Engine_Version_getFull(int skirmishAIId) 
 	return aiInterfaceCallback_Engine_Version_getFull(-1);
 }
 
-EXPORT(int) skirmishAiCallback_Teams_getSize(int skirmishAIId) {
+EXPORT(int) skirmishAiCallback_getNumTeams(int skirmishAIId) {
 	return teamHandler.ActiveTeams();
 }
 
-EXPORT(int) skirmishAiCallback_SkirmishAIs_getSize(int skirmishAIId) {
-	return aiInterfaceCallback_SkirmishAIs_getSize(-1);
+EXPORT(int) skirmishAiCallback_getNumSkirmishAIs(int skirmishAIId) {
+	return aiInterfaceCallback_getNumSkirmishAIs(-1);
 }
 
-EXPORT(int) skirmishAiCallback_SkirmishAIs_getMax(int skirmishAIId) {
-	return aiInterfaceCallback_SkirmishAIs_getMax(-1);
+EXPORT(int) skirmishAiCallback_getMaxSkirmishAIs(int skirmishAIId) {
+	return aiInterfaceCallback_getMaxSkirmishAIs(-1);
 }
 
 EXPORT(int) skirmishAiCallback_SkirmishAI_getTeamId(int skirmishAIId) {
@@ -1358,10 +1358,6 @@ EXPORT(bool) skirmishAiCallback_DataDirs_Roots_locatePath(int UNUSED_skirmishAII
 	return aiInterfaceCallback_DataDirs_Roots_locatePath(-1, path, pathMaxSize, relPath, writeable, create, dir);
 }
 
-EXPORT(char*) skirmishAiCallback_DataDirs_Roots_allocatePath(int UNUSED_skirmishAIId, const char* const relPath, bool writeable, bool create, bool dir) {
-	return aiInterfaceCallback_DataDirs_Roots_allocatePath(-1, relPath, writeable, create, dir);
-}
-
 EXPORT(const char*) skirmishAiCallback_DataDirs_getConfigDir(int skirmishAIId) {
 	CheckSkirmishAIId(skirmishAIId, __func__);
 
@@ -1393,22 +1389,6 @@ EXPORT(bool) skirmishAiCallback_DataDirs_locatePath(
 	aiRelPath += (ps + std::string(relPath));
 
 	return skirmishAiCallback_DataDirs_Roots_locatePath(skirmishAIId, path, pathMaxSize, aiRelPath.c_str(), writeable, create, dir);
-}
-
-EXPORT(char*) skirmishAiCallback_DataDirs_allocatePath(
-	int skirmishAIId,
-	const char* const relPath,
-	bool writeable,
-	bool create,
-	bool dir,
-	bool common
-) {
-	static char path[2048];
-
-	if (!skirmishAiCallback_DataDirs_locatePath(skirmishAIId, &path[0], sizeof(path), relPath, writeable, create, dir, common))
-		path[0] = 0;
-
-	return &path[0];
 }
 
 
@@ -1722,19 +1702,6 @@ EXPORT(float) skirmishAiCallback_Game_getRulesParamFloat(int skirmishAIId, const
 EXPORT(const char*) skirmishAiCallback_Game_getRulesParamString(int skirmishAIId, const char* rulesParamName, const char* defaultValue) {
 	return getRulesParamStringValueByName(CSplitLuaHandle::GetGameParams(), gameModParamLosMask(), rulesParamName, defaultValue);
 }
-
-
-EXPORT(float) skirmishAiCallback_Gui_getViewRange(int skirmishAIId) { return 0.0f; }
-EXPORT(float) skirmishAiCallback_Gui_getScreenX(int skirmishAIId) { return 0.0f; }
-EXPORT(float) skirmishAiCallback_Gui_getScreenY(int skirmishAIId) { return 0.0f; }
-
-EXPORT(void) skirmishAiCallback_Gui_Camera_getDirection(int skirmishAIId, float* dir) {} // DEPRECATED
-EXPORT(void) skirmishAiCallback_Gui_Camera_getPosition(int skirmishAIId, float* pos) {} // DEPRECATED
-
-
-
-
-
 
 
 //########### BEGINN Mod
@@ -4014,7 +3981,7 @@ EXPORT(int) skirmishAiCallback_getEnemyTeams(int skirmishAIId, int* teamIds, int
 	return a;
 }
 
-EXPORT(int) skirmishAiCallback_getAllyTeams(int skirmishAIId, int* teamIds, int teamIdsMaxSize) {
+EXPORT(int) skirmishAiCallback_getAlliedTeams(int skirmishAIId, int* teamIds, int teamIdsMaxSize) {
 	int a = 0;
 
 	const int teamId = AI_TEAM_IDS[skirmishAIId];
@@ -5085,9 +5052,9 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->Engine_Version_getNormal = &skirmishAiCallback_Engine_Version_getNormal;
 	callback->Engine_Version_getSync = &skirmishAiCallback_Engine_Version_getSync;
 	callback->Engine_Version_getFull = &skirmishAiCallback_Engine_Version_getFull;
-	callback->Teams_getSize = &skirmishAiCallback_Teams_getSize;
-	callback->SkirmishAIs_getSize = &skirmishAiCallback_SkirmishAIs_getSize;
-	callback->SkirmishAIs_getMax = &skirmishAiCallback_SkirmishAIs_getMax;
+	callback->getNumTeams = &skirmishAiCallback_getNumTeams;
+	callback->getNumSkirmishAIs = &skirmishAiCallback_getNumSkirmishAIs;
+	callback->getMaxSkirmishAIs = &skirmishAiCallback_getMaxSkirmishAIs;
 	callback->SkirmishAI_getTeamId = &skirmishAiCallback_SkirmishAI_getTeamId;
 	callback->SkirmishAI_Info_getSize = &skirmishAiCallback_SkirmishAI_Info_getSize;
 	callback->SkirmishAI_Info_getKey = &skirmishAiCallback_SkirmishAI_Info_getKey;
@@ -5104,11 +5071,9 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->DataDirs_getConfigDir = &skirmishAiCallback_DataDirs_getConfigDir;
 	callback->DataDirs_getWriteableDir = &skirmishAiCallback_DataDirs_getWriteableDir;
 	callback->DataDirs_locatePath = &skirmishAiCallback_DataDirs_locatePath;
-	callback->DataDirs_allocatePath = &skirmishAiCallback_DataDirs_allocatePath;
 	callback->DataDirs_Roots_getSize = &skirmishAiCallback_DataDirs_Roots_getSize;
 	callback->DataDirs_Roots_getDir = &skirmishAiCallback_DataDirs_Roots_getDir;
 	callback->DataDirs_Roots_locatePath = &skirmishAiCallback_DataDirs_Roots_locatePath;
-	callback->DataDirs_Roots_allocatePath = &skirmishAiCallback_DataDirs_Roots_allocatePath;
 	callback->Game_getCurrentFrame = &skirmishAiCallback_Game_getCurrentFrame;
 	callback->Game_getAiInterfaceVersion = &skirmishAiCallback_Game_getAiInterfaceVersion;
 	callback->Game_getMyTeam = &skirmishAiCallback_Game_getMyTeam;
@@ -5138,11 +5103,6 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->Game_getCategoryName = &skirmishAiCallback_Game_getCategoryName;
 	callback->Game_getRulesParamFloat = &skirmishAiCallback_Game_getRulesParamFloat;
 	callback->Game_getRulesParamString = &skirmishAiCallback_Game_getRulesParamString;
-	callback->Gui_getViewRange = &skirmishAiCallback_Gui_getViewRange;
-	callback->Gui_getScreenX = &skirmishAiCallback_Gui_getScreenX;
-	callback->Gui_getScreenY = &skirmishAiCallback_Gui_getScreenY;
-	callback->Gui_Camera_getDirection = &skirmishAiCallback_Gui_Camera_getDirection;
-	callback->Gui_Camera_getPosition = &skirmishAiCallback_Gui_Camera_getPosition;
 	callback->Cheats_isEnabled = &skirmishAiCallback_Cheats_isEnabled;
 	callback->Cheats_setEnabled = &skirmishAiCallback_Cheats_setEnabled;
 	callback->Cheats_setEventsEnabled = &skirmishAiCallback_Cheats_setEventsEnabled;
@@ -5417,7 +5377,7 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->Unit_getWeapon = &skirmishAiCallback_Unit_getWeapon;
 	callback->Team_hasAIController = &skirmishAiCallback_Team_hasAIController;
 	callback->getEnemyTeams = &skirmishAiCallback_getEnemyTeams;
-	callback->getAllyTeams = &skirmishAiCallback_getAllyTeams;
+	callback->getAlliedTeams = &skirmishAiCallback_getAlliedTeams;
 	callback->Team_getRulesParamFloat = &skirmishAiCallback_Team_getRulesParamFloat;
 	callback->Team_getRulesParamString = &skirmishAiCallback_Team_getRulesParamString;
 	callback->getGroups = &skirmishAiCallback_getGroups;

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.h
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.h
@@ -44,11 +44,11 @@ EXPORT(const char*      ) skirmishAiCallback_Engine_Version_getSync(int skirmish
 EXPORT(const char*      ) skirmishAiCallback_Engine_Version_getFull(int skirmishAIId);
 
 
-EXPORT(int              ) skirmishAiCallback_Teams_getSize(int skirmishAIId);
+EXPORT(int              ) skirmishAiCallback_getNumTeams(int skirmishAIId);
 
-EXPORT(int              ) skirmishAiCallback_SkirmishAIs_getSize(int skirmishAIId);
+EXPORT(int              ) skirmishAiCallback_getNumSkirmishAIs(int skirmishAIId);
 
-EXPORT(int              ) skirmishAiCallback_SkirmishAIs_getMax(int skirmishAIId);
+EXPORT(int              ) skirmishAiCallback_getMaxSkirmishAIs(int skirmishAIId);
 
 EXPORT(int              ) skirmishAiCallback_SkirmishAI_getTeamId(int skirmishAIId);
 
@@ -82,13 +82,9 @@ EXPORT(bool             ) skirmishAiCallback_DataDirs_Roots_getDir(int UNUSED_sk
 
 EXPORT(bool             ) skirmishAiCallback_DataDirs_Roots_locatePath(int UNUSED_skirmishAIId, char* path, int path_sizeMax, const char* const relPath, bool writeable, bool create, bool dir);
 
-EXPORT(char*            ) skirmishAiCallback_DataDirs_Roots_allocatePath(int UNUSED_skirmishAIId, const char* const relPath, bool writeable, bool create, bool dir);
-
 EXPORT(const char*      ) skirmishAiCallback_DataDirs_getConfigDir(int skirmishAIId);
 
 EXPORT(bool             ) skirmishAiCallback_DataDirs_locatePath(int skirmishAIId, char* path, int path_sizeMax, const char* const relPath, bool writeable, bool create, bool dir, bool common);
-
-EXPORT(char*            ) skirmishAiCallback_DataDirs_allocatePath(int skirmishAIId, const char* const relPath, bool writeable, bool create, bool dir, bool common);
 
 EXPORT(const char*      ) skirmishAiCallback_DataDirs_getWriteableDir(int skirmishAIId);
 
@@ -148,20 +144,6 @@ EXPORT(float            ) skirmishAiCallback_Game_getRulesParamFloat(int skirmis
 EXPORT(const char*      ) skirmishAiCallback_Game_getRulesParamString(int skirmishAIId, const char* rulesParamName, const char* defaultValue);
 
 // END misc callback functions
-
-
-// BEGINN Visualization related callback functions
-EXPORT(float            ) skirmishAiCallback_Gui_getViewRange(int skirmishAIId);
-
-EXPORT(float            ) skirmishAiCallback_Gui_getScreenX(int skirmishAIId);
-
-EXPORT(float            ) skirmishAiCallback_Gui_getScreenY(int skirmishAIId);
-
-EXPORT(void             ) skirmishAiCallback_Gui_Camera_getDirection(int skirmishAIId, float* return_posF3_out);
-
-EXPORT(void             ) skirmishAiCallback_Gui_Camera_getPosition(int skirmishAIId, float* return_posF3_out);
-
-// END Visualization related callback functions
 
 
 // BEGINN OBJECT Cheats
@@ -250,8 +232,6 @@ EXPORT(float            ) skirmishAiCallback_UnitDef_getWindResourceGenerator(in
 EXPORT(float            ) skirmishAiCallback_UnitDef_getTidalResourceGenerator(int skirmishAIId, int unitDefId, int resourceId);
 
 EXPORT(float            ) skirmishAiCallback_UnitDef_getStorage(int skirmishAIId, int unitDefId, int resourceId);
-
-EXPORT(bool             ) skirmishAiCallback_UnitDef_isSquareResourceExtractor(int skirmishAIId, int unitDefId, int resourceId);
 
 EXPORT(float            ) skirmishAiCallback_UnitDef_getBuildTime(int skirmishAIId, int unitDefId);
 
@@ -359,8 +339,6 @@ EXPORT(float            ) skirmishAiCallback_UnitDef_FlankingBonus_getMobilityAd
 
 EXPORT(float            ) skirmishAiCallback_UnitDef_getMaxWeaponRange(int skirmishAIId, int unitDefId);
 
-EXPORT(const char*      ) skirmishAiCallback_UnitDef_getType(int skirmishAIId, int unitDefId);
-
 EXPORT(const char*      ) skirmishAiCallback_UnitDef_getTooltip(int skirmishAIId, int unitDefId);
 
 EXPORT(const char*      ) skirmishAiCallback_UnitDef_getWreckName(int skirmishAIId, int unitDefId);
@@ -431,8 +409,6 @@ EXPORT(float            ) skirmishAiCallback_UnitDef_getWingDrag(int skirmishAII
 
 EXPORT(float            ) skirmishAiCallback_UnitDef_getWingAngle(int skirmishAIId, int unitDefId);
 
-EXPORT(float            ) skirmishAiCallback_UnitDef_getDrag(int skirmishAIId, int unitDefId);
-
 EXPORT(float            ) skirmishAiCallback_UnitDef_getFrontToSpeed(int skirmishAIId, int unitDefId);
 
 EXPORT(float            ) skirmishAiCallback_UnitDef_getSpeedToFront(int skirmishAIId, int unitDefId);
@@ -472,8 +448,6 @@ EXPORT(int              ) skirmishAiCallback_UnitDef_getYardMap(int skirmishAIId
 EXPORT(int              ) skirmishAiCallback_UnitDef_getXSize(int skirmishAIId, int unitDefId);
 
 EXPORT(int              ) skirmishAiCallback_UnitDef_getZSize(int skirmishAIId, int unitDefId);
-
-EXPORT(int              ) skirmishAiCallback_UnitDef_getBuildAngle(int skirmishAIId, int unitDefId);
 
 EXPORT(float            ) skirmishAiCallback_UnitDef_getLoadingRadius(int skirmishAIId, int unitDefId);
 
@@ -545,18 +519,6 @@ EXPORT(int              ) skirmishAiCallback_UnitDef_getHighTrajectoryType(int s
 
 EXPORT(int              ) skirmishAiCallback_UnitDef_getNoChaseCategory(int skirmishAIId, int unitDefId);
 
-EXPORT(bool             ) skirmishAiCallback_UnitDef_isLeaveTracks(int skirmishAIId, int unitDefId);
-
-EXPORT(float            ) skirmishAiCallback_UnitDef_getTrackWidth(int skirmishAIId, int unitDefId);
-
-EXPORT(float            ) skirmishAiCallback_UnitDef_getTrackOffset(int skirmishAIId, int unitDefId);
-
-EXPORT(float            ) skirmishAiCallback_UnitDef_getTrackStrength(int skirmishAIId, int unitDefId);
-
-EXPORT(float            ) skirmishAiCallback_UnitDef_getTrackStretch(int skirmishAIId, int unitDefId);
-
-EXPORT(int              ) skirmishAiCallback_UnitDef_getTrackType(int skirmishAIId, int unitDefId);
-
 EXPORT(bool             ) skirmishAiCallback_UnitDef_isAbleToDropFlare(int skirmishAIId, int unitDefId);
 
 EXPORT(float            ) skirmishAiCallback_UnitDef_getFlareReloadTime(int skirmishAIId, int unitDefId);
@@ -592,8 +554,6 @@ EXPORT(int              ) skirmishAiCallback_UnitDef_getBuildOptions(int skirmis
 EXPORT(int              ) skirmishAiCallback_UnitDef_getCustomParams(int skirmishAIId, int unitDefId, const char** keys, const char** values);
 
 EXPORT(bool             ) skirmishAiCallback_UnitDef_isMoveDataAvailable(int skirmishAIId, int unitDefId);
-
-EXPORT(int              ) skirmishAiCallback_UnitDef_MoveData_getMoveType(int skirmishAIId, int unitDefId);
 
 EXPORT(int              ) skirmishAiCallback_UnitDef_MoveData_getSpeedModClass(int skirmishAIId, int unitDefId);
 
@@ -671,8 +631,6 @@ EXPORT(const char*      ) skirmishAiCallback_Unit_getRulesParamString(int skirmi
 EXPORT(int              ) skirmishAiCallback_Unit_getTeam(int skirmishAIId, int unitId);
 
 EXPORT(int              ) skirmishAiCallback_Unit_getAllyTeam(int skirmishAIId, int unitId);
-
-EXPORT(int              ) skirmishAiCallback_Unit_getAiHint(int skirmishAIId, int unitId);
 
 EXPORT(int              ) skirmishAiCallback_Unit_getStockpile(int skirmishAIId, int unitId);
 
@@ -764,7 +722,7 @@ EXPORT(bool             ) skirmishAiCallback_Team_hasAIController(int skirmishAI
 
 EXPORT(int              ) skirmishAiCallback_getEnemyTeams(int skirmishAIId, int* teamIds, int teamIds_sizeMax);
 
-EXPORT(int              ) skirmishAiCallback_getAllyTeams(int skirmishAIId, int* teamIds, int teamIds_sizeMax);
+EXPORT(int              ) skirmishAiCallback_getAlliedTeams(int skirmishAIId, int* teamIds, int teamIds_sizeMax);
 
 EXPORT(float            ) skirmishAiCallback_Team_getRulesParamFloat(int skirmishAIId, int teamId, const char* rulesParamName, float defaultValue);
 
@@ -1017,8 +975,6 @@ EXPORT(bool             ) skirmishAiCallback_FeatureDef_isNoSelect(int skirmishA
 
 EXPORT(bool             ) skirmishAiCallback_FeatureDef_isGeoThermal(int skirmishAIId, int featureDefId);
 
-EXPORT(const char*      ) skirmishAiCallback_FeatureDef_getDeathFeature(int skirmishAIId, int featureDefId);
-
 EXPORT(int              ) skirmishAiCallback_FeatureDef_getXSize(int skirmishAIId, int featureDefId);
 
 EXPORT(int              ) skirmishAiCallback_FeatureDef_getZSize(int skirmishAIId, int featureDefId);
@@ -1248,12 +1204,6 @@ EXPORT(float            ) skirmishAiCallback_WeaponDef_Shield_getPowerRegenResou
 EXPORT(float            ) skirmishAiCallback_WeaponDef_Shield_getStartingPower(int skirmishAIId, int weaponDefId);
 
 EXPORT(int              ) skirmishAiCallback_WeaponDef_Shield_getRechargeDelay(int skirmishAIId, int weaponDefId);
-
-EXPORT(void             ) skirmishAiCallback_WeaponDef_Shield_getGoodColor(int skirmishAIId, int weaponDefId, short* return_colorS3_out);
-
-EXPORT(void             ) skirmishAiCallback_WeaponDef_Shield_getBadColor(int skirmishAIId, int weaponDefId, short* return_colorS3_out);
-
-EXPORT(short            ) skirmishAiCallback_WeaponDef_Shield_getAlpha(int skirmishAIId, int weaponDefId);
 
 EXPORT(int              ) skirmishAiCallback_WeaponDef_Shield_getInterceptType(int skirmishAIId, int weaponDefId);
 


### PR DESCRIPTION
Delete dangling declarations:
```
EXPORT(const char*      ) skirmishAiCallback_FeatureDef_getDeathFeature(int skirmishAIId, int featureDefId);
EXPORT(bool             ) skirmishAiCallback_UnitDef_isSquareResourceExtractor(int skirmishAIId, int unitDefId, int resourceId);
EXPORT(const char*      ) skirmishAiCallback_UnitDef_getType(int skirmishAIId, int unitDefId);
EXPORT(float            ) skirmishAiCallback_UnitDef_getDrag(int skirmishAIId, int unitDefId);
EXPORT(int              ) skirmishAiCallback_UnitDef_getBuildAngle(int skirmishAIId, int unitDefId);
EXPORT(bool             ) skirmishAiCallback_UnitDef_isLeaveTracks(int skirmishAIId, int unitDefId);
EXPORT(float            ) skirmishAiCallback_UnitDef_getTrackWidth(int skirmishAIId, int unitDefId);
EXPORT(float            ) skirmishAiCallback_UnitDef_getTrackOffset(int skirmishAIId, int unitDefId);
EXPORT(float            ) skirmishAiCallback_UnitDef_getTrackStrength(int skirmishAIId, int unitDefId);
EXPORT(float            ) skirmishAiCallback_UnitDef_getTrackStretch(int skirmishAIId, int unitDefId);
EXPORT(int              ) skirmishAiCallback_UnitDef_getTrackType(int skirmishAIId, int unitDefId);
EXPORT(int              ) skirmishAiCallback_UnitDef_MoveData_getMoveType(int skirmishAIId, int unitDefId);
EXPORT(void             ) skirmishAiCallback_WeaponDef_Shield_getGoodColor(int skirmishAIId, int weaponDefId, short* return_colorS3_out);
EXPORT(void             ) skirmishAiCallback_WeaponDef_Shield_getBadColor(int skirmishAIId, int weaponDefId, short* return_colorS3_out);
EXPORT(short            ) skirmishAiCallback_WeaponDef_Shield_getAlpha(int skirmishAIId, int weaponDefId);
EXPORT(int              ) skirmishAiCallback_Unit_getAiHint(int skirmishAIId, int unitId);
```
Delete deprecated functions:
```
EXPORT(float) skirmishAiCallback_Gui_getViewRange(int skirmishAIId) { return 0.0f; }
EXPORT(float) skirmishAiCallback_Gui_getScreenX(int skirmishAIId) { return 0.0f; }
EXPORT(float) skirmishAiCallback_Gui_getScreenY(int skirmishAIId) { return 0.0f; }
EXPORT(void) skirmishAiCallback_Gui_Camera_getDirection(int skirmishAIId, float* dir) {} // DEPRECATED
EXPORT(void) skirmishAiCallback_Gui_Camera_getPosition(int skirmishAIId, float* pos) {} // DEPRECATED
```
Rename functions to avoid polluting objects:
```
skirmishAiCallback_getAllyTeams => skirmishAiCallback_getAlliedTeams
skirmishAiCallback_Teams_getSize => skirmishAiCallback_getNumTeams
skirmishAiCallback_SkirmishAIs_getSize => skirmishAiCallback_getNumSkirmishAIs
skirmishAiCallback_SkirmishAIs_getMax => skirmishAiCallback_getMaxSkirmishAIs
aiInterfaceCallback_Teams_getSize => aiInterfaceCallback_getNumTeams
aiInterfaceCallback_SkirmishAIs_getSize => aiInterfaceCallback_getNumSkirmishAIs
aiInterfaceCallback_SkirmishAIs_getMax => aiInterfaceCallback_getMaxSkirmishAIs
```
Fix `DebugDrawer_addOverlayTexture`: now returns `OverlayTexture` object

*.awk and *.c changes related to removal of `DataDirs_allocatePath`, duplicate of `DataDirs_locatePath`

NB: Unit::getTeam() still returns id instead of Team object, can't justify memory allocation
```int (CALLING_CONV *Unit_getTeam)(int skirmishAIId, int unitId); //$ REF:RETURN->Team```