### PR TITLE
Avoid rebuilding actionlists, fix keychains

### DIFF
--- a/cont/LuaUI/main.lua
+++ b/cont/LuaUI/main.lua
@@ -109,12 +109,12 @@ function KeyMapChanged()
   return widgetHandler:KeyMapChanged()
 end
 
-function KeyPress(key, mods, isRepeat, label, unicode, scanCode)
-  return widgetHandler:KeyPress(key, mods, isRepeat, label, unicode, scanCode)
+function KeyPress(key, mods, isRepeat, label, unicode, scanCode, actions)
+  return widgetHandler:KeyPress(key, mods, isRepeat, label, unicode, scanCode, actions)
 end
 
-function KeyRelease(key, mods, label, unicode, scanCode)
-  return widgetHandler:KeyRelease(key, mods, label, unicode, scanCode)
+function KeyRelease(key, mods, label, unicode, scanCode, actions)
+  return widgetHandler:KeyRelease(key, mods, label, unicode, scanCode, actions)
 end
 
 function MouseMove(x, y, dx, dy, button)

--- a/cont/LuaUI/widgets.lua
+++ b/cont/LuaUI/widgets.lua
@@ -1406,22 +1406,22 @@ function widgetHandler:KeyMapChanged()
   return false
 end
 
-function widgetHandler:KeyPress(key, mods, isRepeat, label, unicode, scanCode)
+function widgetHandler:KeyPress(key, mods, isRepeat, label, unicode, scanCode, actions)
   if (self.tweakMode) then
     self.tweakKeys[key] = true
     local mo = self.mouseOwner
     if (mo and mo.TweakKeyPress) then
-      mo:TweakKeyPress(key, mods, isRepeat, label, unicode, scanCode)
+      mo:TweakKeyPress(key, mods, isRepeat, label, unicode, scanCode, actions)
     end
     return true
   end
 
-  if (self.actionHandler:KeyAction(true, key, mods, isRepeat, scanCode)) then
+  if (self.actionHandler:KeyAction(true, key, mods, isRepeat, scanCode, actions)) then
     return true
   end
 
   for _,w in ipairs(self.KeyPressList) do
-    if (w:KeyPress(key, mods, isRepeat, label, unicode, scanCode)) then
+    if (w:KeyPress(key, mods, isRepeat, label, unicode, scanCode, actions)) then
       return true
     end
   end
@@ -1429,11 +1429,11 @@ function widgetHandler:KeyPress(key, mods, isRepeat, label, unicode, scanCode)
 end
 
 
-function widgetHandler:KeyRelease(key, mods, label, unicode, scanCode)
+function widgetHandler:KeyRelease(key, mods, label, unicode, scanCode, actions)
   if (self.tweakMode and self.tweakKeys[key] ~= nil) then
     local mo = self.mouseOwner
     if (mo and mo.TweakKeyRelease) then
-      mo:TweakKeyRelease(key, mods, label, unicode, scanCode)
+      mo:TweakKeyRelease(key, mods, label, unicode, scanCode, actions)
     elseif (key == KEYSYMS.ESCAPE) then
       Spring.Log(section, LOG.INFO, "LuaUI TweakMode: OFF")
       self.tweakMode = false
@@ -1441,12 +1441,12 @@ function widgetHandler:KeyRelease(key, mods, label, unicode, scanCode)
     return true
   end
 
-  if (self.actionHandler:KeyAction(false, key, mods, false, scanCode)) then
+  if (self.actionHandler:KeyAction(false, key, mods, false, scanCode, actions)) then
     return true
   end
 
   for _,w in ipairs(self.KeyReleaseList) do
-    if (w:KeyRelease(key, mods, label, unicode, scanCode)) then
+    if (w:KeyRelease(key, mods, label, unicode, scanCode, actions)) then
       return true
     end
   end

--- a/cont/base/springcontent/LuaHandler/Utilities/specialCallinHandlers.lua
+++ b/cont/base/springcontent/LuaHandler/Utilities/specialCallinHandlers.lua
@@ -123,13 +123,13 @@ end
 --------------------------------------------------------------------------------
 --  Keyboard call-ins
 
-function hHookFuncs.KeyPress(key, mods, isRepeat, label, unicode, scanCode)
-	if (actionHandler.KeyAction(true, key, mods, isRepeat, scanCode)) then
+function hHookFuncs.KeyPress(key, mods, isRepeat, label, unicode, scanCode, actions)
+	if (actionHandler.KeyAction(true, key, mods, isRepeat, scanCode, actions)) then
 		return true
 	end
 
 	for _,f in hCallInLists.KeyPress:iter() do
-		if f(key, mods, isRepeat, label, unicode, scanCode) then
+		if f(key, mods, isRepeat, label, unicode, scanCode, actions) then
 			return true
 		end
 	end
@@ -138,13 +138,13 @@ function hHookFuncs.KeyPress(key, mods, isRepeat, label, unicode, scanCode)
 end
 
 
-function hHookFuncs.KeyRelease(key, mods, label, unicode, scanCode)
-	if (actionHandler.KeyAction(false, key, mods, false, scanCode)) then
+function hHookFuncs.KeyRelease(key, mods, label, unicode, scanCode, actions)
+	if (actionHandler.KeyAction(false, key, mods, false, scanCode, actions)) then
 		return true
 	end
 
 	for _,f in hCallInLists.KeyRelease:iter() do
-		if f(key, mods, label, unicode, scanCode) then
+		if f(key, mods, label, unicode, scanCode, actions) then
 			return true
 		end
 	end

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -101,13 +101,17 @@ System:
  - Windows Vista is now longer supported, Windows 7 is now the minimum required Windows OS
 
 UI:
+ - KeyPress and KeyRelease callins receive an additional actions
+   7th argument
+ - Allow minimap to receive MouseWheelPress events, controlled by
+   MiniMapMouseWheel = [0]|1
  - Add `group unset` action to unassign any groups from selected units
- - Allow drawlabel events inside minimap and add MiniMapCanDraw to enable drawing lines via
-   cursor over minimap
+ - Allow drawlabel events inside minimap and add MiniMapCanDraw to enable
+   drawing lines via cursor over minimap
  - Minimap can flip if camera rotation is between 90 and 270 degrees. Can be
    turned on via spring setting `MiniMapCanFlip = [0]|1`
  - KeyPress and KeyRelease callins receive an additional scanCode
-   argument
+   6th argument
  - sc_<k> keysets are introduced for scancodes and handled in conjunction
    with keycode bindings preserving the order on which the actions where
    bound. Can also be bound via `sc_0x<hexvalue>`
@@ -115,6 +119,8 @@ UI:
  - Add GetScanSymbol(int scanCode)
 
 Fixes:
+ - Fix KeyChains not being respected for GuiHandler actions and allow games to
+   handle them with new actions argument on KeyPress/KeyRelease
  - openAL-soft/SDL audio bugfix: finally making dynamic audio device changes, 
    i.e. unplug/replug USB headset or swtich between builtin soundcard to 
    monitor soundcard (HDMI), seamlessly possible without requiring a program restart

--- a/rts/Game/Game.h
+++ b/rts/Game/Game.h
@@ -10,6 +10,7 @@
 #include "GameController.h"
 #include "GameJobDispatcher.h"
 #include "Game/UI/KeySet.h"
+#include "Game/Action.h"
 #include "Rendering/WorldDrawer.h"
 #include "System/UnorderedMap.hpp"
 #include "System/creg/creg_cond.h"
@@ -17,7 +18,6 @@
 
 class LuaParser;
 class ILoadSaveHandler;
-class Action;
 class ChatMessage;
 
 
@@ -165,6 +165,8 @@ public:
 	spring_time lastSimFrameNetPacketTime;
 	spring_time lastUnsyncedUpdateTime;
 	spring_time skipLastDrawTime;
+
+	ActionList lastActionList;
 
 	float updateDeltaSeconds = 0.0f;
 	/// Time in seconds, stops at game end

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -1833,7 +1833,7 @@ bool CGuiHandler::KeyPressed(int keyCode, int scanCode, bool isRepeat)
 		}
 	}
 
-	const ActionList& al = keyBindings.GetActionList(keyCode, scanCode);
+	const ActionList& al = game->lastActionList;
 	for (int ali = 0; ali < (int)al.size(); ++ali) {
 		const int actionIndex = (ali + tmpActionOffset) % (int)al.size(); //????
 		const Action& action = al[actionIndex];


### PR DESCRIPTION
This change:

- Avoids rebuilding actionList 3 times per keypress on the worst scenarios
- Fixes KeyChains for all engine-defined actions
- Allows games to handle KeyChains in lua actions