### PR TITLE
Resurrect: don't set health to 5%

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -93,6 +93,15 @@ Sim:
  - Multi-threaded GroundMoveType heading and accelaration planning
  - GroundMoveType checks whether waypoints have changed before updating synced waypoint vars.
    This avoids unnecessary expensive checksum updates.
+ - Resurrecting units no longer overrides their health to 5%. To get back the old behaviour:
+ 
+   ```
+   function gadget:UnitCreated(unitID, unitDefID, teamID, builderID)
+     if builderID and Spring.GetUnitCurrentCommand(builderID) == CMD.RESURRECT then
+       Spring.SetUnitHealth(unitID, Spring.GetUnitHealth(unitID) * 0.05)
+     end
+   end
+   ```
 
 System:
  - Improved spinlocks by reducing their impact on the CPU, changed implementation from a

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -437,9 +437,6 @@ bool CBuilder::UpdateResurrect(const Command& fCommand)
 		resurrectee->SetSoloBuilder(this, resurrecteeDef);
 		resurrectee->SetHeading(curResurrectee->heading, !resurrectee->upright && resurrectee->IsOnGround(), false, 0.0f);
 
-		// TODO: make configurable if this should happen
-		resurrectee->health *= 0.05f;
-
 		for (const int resurrecterID: cai->resurrecters) {
 			CBuilder* resurrecter = static_cast<CBuilder*>(unitHandler.GetUnit(resurrecterID));
 			CCommandAI* resurrecterCAI = resurrecter->commandAI;


### PR DESCRIPTION
Currently the 5% overrides whatever gets set in UnitCreated, requiring any changes to get queued until the next frame. It's also arbitrary.

Games can easily replicate the old behaviour:

```lua
function gadget:UnitCreated(unitID, unitDefID, teamID, builderID)
  if builderID and Spring.GetUnitCurrentCommand(builderID) == CMD.RESURRECT then
    Spring.SetUnitHealth(unitID, Spring.GetUnitHealth(unitID) * 0.05)
  end
end
```