### PR TITLE
KeyBindings: Allow key{,re}load commands in uikeys

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -106,6 +106,8 @@ UI:
    7th argument
  - Allow minimap to receive MouseWheelPress events, controlled by
    MiniMapMouseWheel = [0]|1
+ - Accept keyreload and keyload commands in uikeys, accept arguments for
+   keyload, keyreload and keysave for the filename. Add keydefaults command
  - Add `group unset` action to unassign any groups from selected units
  - Allow drawlabel events inside minimap and add MiniMapCanDraw to enable
    drawing lines via cursor over minimap

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -685,6 +685,7 @@ void CGame::LoadInterface()
 	cmdColors.LoadConfigFromFile("cmdcolors.txt");
 
 	keyBindings.Init();
+	keyBindings.LoadDefaults();
 	keyBindings.Load("uikeys.txt");
 
 	{

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -686,7 +686,7 @@ void CGame::LoadInterface()
 
 	keyBindings.Init();
 	keyBindings.LoadDefaults();
-	keyBindings.Load("uikeys.txt");
+	keyBindings.Load();
 
 	{
 		ScopedOnceTimer timer("Game::LoadInterface (Console)");

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -806,9 +806,9 @@ void CKeyBindings::PushAction(const Action& action)
 {
 	if (action.command == "keysave") {
 		const std::vector<std::string> args = CSimpleParser::Tokenize(action.extra, 2);
-		const std::string filename = args.empty() ? "uikeys.tmp" : args[0];
+		const std::string filename = args.empty() ? "uikeys.tmp" : args[0]; // tmp, not txt
 
-		if (Save(filename)) {  // tmp, not txt
+		if (Save(filename)) {
 			LOG("Saved active keybindings at %s", filename.c_str());
 		} else {
 			LOG_L(L_WARNING, "Could not save %s", filename.c_str());

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -53,6 +53,7 @@ static const CKeyBindings::ActionComparison compareActionByBindingOrder = [](con
   return (a.bindingIndex < b.bindingIndex);
 };
 
+const std::string CKeyBindings::DEFAULT_FILENAME = "uikeys.txt";
 
 static const DefaultBinding defaultBindings[] = {
 	{            "esc", "quitmessage" },
@@ -805,8 +806,10 @@ void CKeyBindings::LoadDefaults()
 void CKeyBindings::PushAction(const Action& action)
 {
 	if (action.command == "keysave") {
+		static const std::string defaultOutFilename = "uikeys.tmp"; // tmp, not txt
+
 		const std::vector<std::string> args = CSimpleParser::Tokenize(action.extra, 2);
-		const std::string filename = args.empty() ? "uikeys.tmp" : args[0]; // tmp, not txt
+		const std::string& filename = args.empty() ? defaultOutFilename : args[0];
 
 		if (Save(filename)) {
 			LOG("Saved active keybindings at %s", filename.c_str());
@@ -847,7 +850,7 @@ bool CKeyBindings::ExecuteCommand(const std::string& line)
 		}
 	}
 	else if (command == "keyload") {
-		const std::string filename = words.size() > 1 ? words[1] : "uikeys.txt";
+		const std::string& filename = words.size() > 1 ? words[1] : DEFAULT_FILENAME;
 
 		if (debugEnabled)
 			LOG("[CKeyBindings::%s] line=%s", __func__, line.c_str());
@@ -859,7 +862,7 @@ bool CKeyBindings::ExecuteCommand(const std::string& line)
 		Load(filename);
 	}
 	else if (command == "keyreload") {
-		const std::string filename = words.size() > 1 ? words[1] : "uikeys.txt";
+		const std::string& filename = words.size() > 1 ? words[1] : DEFAULT_FILENAME;
 
 		if (debugEnabled)
 			LOG("[CKeyBindings::%s] line=%s", __func__, line.c_str());
@@ -919,6 +922,7 @@ bool CKeyBindings::Load(const std::string& filename)
 {
 	if (std::find(loadStack.begin(), loadStack.end(), filename) != loadStack.end()) {
 		LOG_L(L_WARNING, "[CKeyBindings::%s] Cyclic keys file inclusion: %s, load stack:", __func__, filename.c_str());
+		LOG_L(L_WARNING, " !-> %s", filename.c_str());
 		for (auto it = loadStack.rbegin(); it != loadStack.rend(); ++it)
 			LOG_L(L_WARNING, "  -> %s", (*it).c_str());
 

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -852,6 +852,7 @@ bool CKeyBindings::ExecuteCommand(const std::string& line)
 		if (debugEnabled)
 			LOG("[CKeyBindings::%s] line=%s", __func__, line.c_str());
 
+		// Backward-compatibility from before `/keydefaults` existed
 		if (loadStack.empty() && words.size() == 1)
 			LoadDefaults();
 

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -1,6 +1,7 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include <cstdio>
+#include <algorithm>
 
 #include "KeyBindings.h"
 #include "KeyCodes.h"
@@ -308,6 +309,7 @@ void CKeyBindings::Kill()
 	codeBindings.clear();
 	scanBindings.clear();
 	hotkeys.clear();
+	loadStack.clear();
 	statefulCommands.clear();
 
 	configHandler->RemoveObserver(this);
@@ -613,7 +615,7 @@ void CKeyBindings::AddActionToKeyMap(KeyMap& bindings, Action& action)
 bool CKeyBindings::Bind(const std::string& keystr, const std::string& line)
 {
 	if (debugEnabled)
-		LOG("[CKeyBindings::Bind] index=%i keystr=%s line=%s", bindingsCount + 1, keystr.c_str(), line.c_str());
+		LOG("[CKeyBindings::%s] index=%i keystr=%s line=%s", __func__, bindingsCount + 1, keystr.c_str(), line.c_str());
 
 	Action action(line);
 	action.boundWith = keystr;
@@ -647,6 +649,9 @@ bool CKeyBindings::UnBind(const std::string& keystr, const std::string& command)
 		return false;
 	}
 
+	if (debugEnabled)
+		LOG("[CKeyBindings::%s] keystr=%s command=%s", __func__, keystr.c_str(), command.c_str());
+
 	KeyMap& bindings = ks.IsKeyCode() ? codeBindings : scanBindings;
 	const auto it = bindings.find(ks);
 
@@ -665,6 +670,9 @@ bool CKeyBindings::UnBind(const std::string& keystr, const std::string& command)
 
 bool CKeyBindings::UnBindKeyset(const std::string& keystr)
 {
+	if (debugEnabled)
+		LOG("[CKeyBindings::%s] keystr=%s", __func__, keystr.c_str());
+
 	CKeySet ks;
 	if (!ks.Parse(keystr)) {
 		LOG_L(L_WARNING, "UnBindKeyset: could not parse key: %s", keystr.c_str());
@@ -708,6 +716,8 @@ bool CKeyBindings::RemoveActionFromKeyMap(const std::string& command, KeyMap& bi
 
 bool CKeyBindings::UnBindAction(const std::string& command)
 {
+	if (debugEnabled)
+		LOG("[CKeyBindings::%s] command=%s", __func__, command.c_str());
 	return RemoveActionFromKeyMap(command, codeBindings) || RemoveActionFromKeyMap(command, scanBindings);
 }
 
@@ -772,32 +782,36 @@ void CKeyBindings::ConfigNotify(const std::string& key, const std::string& value
 }
 
 
-/******************************************************************************/
-
 void CKeyBindings::LoadDefaults()
 {
+	const bool tmpBuildHotkeyMap = buildHotkeyMap;
+	buildHotkeyMap = false;
+
+	if (debugEnabled)
+		LOG("[CKeyBindings::%s]", __func__);
+
 	SetFakeMetaKey("space");
 
 	for (const auto& b: defaultBindings) {
 		Bind(b.key, b.action);
 	}
+
+	buildHotkeyMap = tmpBuildHotkeyMap;
 }
+
+
+/******************************************************************************/
 
 void CKeyBindings::PushAction(const Action& action)
 {
-	if (action.command == "keyload") {
-		Load("uikeys.txt");
-	}
-	else if (action.command == "keyreload") {
-		ExecuteCommand("unbindall");
-		ExecuteCommand("unbind enter chat");
-		Load("uikeys.txt");
-	}
-	else if (action.command == "keysave") {
-		if (Save("uikeys.tmp")) {  // tmp, not txt
-			LOG("Saved uikeys.tmp");
+	if (action.command == "keysave") {
+		const std::vector<std::string> args = CSimpleParser::Tokenize(action.extra, 2);
+		const std::string filename = args.empty() ? "uikeys.tmp" : args[0];
+
+		if (Save(filename)) {  // tmp, not txt
+			LOG("Saved active keybindings at %s", filename.c_str());
 		} else {
-			LOG_L(L_WARNING, "Could not save uikeys.tmp");
+			LOG_L(L_WARNING, "Could not save %s", filename.c_str());
 		}
 	}
 	else if (action.command == "keyprint") {
@@ -832,6 +846,34 @@ bool CKeyBindings::ExecuteCommand(const std::string& line)
 			debugEnabled = atoi(words[1].c_str());
 		}
 	}
+	else if (command == "keyload") {
+		const std::string filename = words.size() > 1 ? words[1] : "uikeys.txt";
+
+		if (debugEnabled)
+			LOG("[CKeyBindings::%s] line=%s", __func__, line.c_str());
+
+		if (loadStack.empty() && words.size() == 1)
+			LoadDefaults();
+
+		Load(filename);
+	}
+	else if (command == "keyreload") {
+		const std::string filename = words.size() > 1 ? words[1] : "uikeys.txt";
+
+		if (debugEnabled)
+			LOG("[CKeyBindings::%s] line=%s", __func__, line.c_str());
+
+		ExecuteCommand("unbindall");
+		ExecuteCommand("unbind enter chat");
+
+		if (loadStack.empty() && words.size() == 1)
+			LoadDefaults();
+
+		Load(filename);
+	}
+	else if (command == "keydefaults") {
+		LoadDefaults();
+	}
 	else if ((command == "fakemeta") && (words.size() > 1)) {
 		if (!SetFakeMetaKey(words[1])) { return false; }
 	}
@@ -857,6 +899,9 @@ bool CKeyBindings::ExecuteCommand(const std::string& line)
 		scanCodes.Reset();
 		bindingsCount = 0;
 		Bind("enter", "chat"); // bare minimum
+
+		if (debugEnabled)
+			LOG("[CKeyBindings::%s] line=%s", __func__, line.c_str());
 	}
 	else {
 		return false;
@@ -871,23 +916,45 @@ bool CKeyBindings::ExecuteCommand(const std::string& line)
 
 bool CKeyBindings::Load(const std::string& filename)
 {
+	if (std::find(loadStack.begin(), loadStack.end(), filename) != loadStack.end()) {
+		LOG_L(L_WARNING, "[CKeyBindings::%s] Cyclic keys file inclusion: %s, load stack:", __func__, filename.c_str());
+		for (auto it = loadStack.rbegin(); it != loadStack.rend(); ++it)
+			LOG_L(L_WARNING, "  -> %s", (*it).c_str());
+
+		return false;
+	}
+
+	const bool tmpBuildHotkeyMap = buildHotkeyMap;
+	buildHotkeyMap = false;
+
+	if (debugEnabled) {
+		LOG("[CKeyBindings::%s] filename=%s%s", __func__, filename.c_str(), loadStack.empty() ? "" : ", load stack:");
+		for (auto it = loadStack.rbegin(); it != loadStack.rend(); ++it)
+			LOG("  -> %s", (*it).c_str());
+	}
+
+	loadStack.push_back(filename);
+
 	CFileHandler ifs(filename);
 	CSimpleParser parser(ifs);
-	buildHotkeyMap = false; // temporarily disable BuildHotkeyMap() calls
-	LoadDefaults();
 
 	while (!parser.Eof()) {
 		ExecuteCommand(parser.GetCleanLine());
 	}
 
-	BuildHotkeyMap();
-	buildHotkeyMap = true; // re-enable BuildHotkeyMap() calls
+	loadStack.pop_back();
+
+	buildHotkeyMap = tmpBuildHotkeyMap;
+
 	return true;
 }
 
 
 void CKeyBindings::BuildHotkeyMap()
 {
+	if (debugEnabled)
+		LOG("[CKeyBindings::%s]", __func__);
+
 	// create reverse map of bindings ([action] -> key shortcuts)
 	hotkeys.clear();
 

--- a/rts/Game/UI/KeyBindings.h
+++ b/rts/Game/UI/KeyBindings.h
@@ -36,6 +36,7 @@ class CKeyBindings : public CommandReceiver
 		bool Load(const std::string& filename);
 		bool Save(const std::string& filename) const;
 		void Print() const;
+		void LoadDefaults();
 
 		ActionList GetActionList() const;
 		ActionList GetActionList(int keyCode, int scanCode) const;
@@ -54,7 +55,6 @@ class CKeyBindings : public CommandReceiver
 		int GetKeyChainTimeout() const { return keyChainTimeout; }
 
 	protected:
-		void LoadDefaults();
 		void BuildHotkeyMap();
 		void DebugActionList(const ActionList& actionList) const;
 
@@ -78,6 +78,7 @@ class CKeyBindings : public CommandReceiver
 		KeyMap codeBindings;
 		KeyMap scanBindings;
 		ActionMap hotkeys;
+		std::vector<std::string> loadStack;
 		int bindingsCount;
 
 		// commands that use both Up and Down key presses

--- a/rts/Game/UI/KeyBindings.h
+++ b/rts/Game/UI/KeyBindings.h
@@ -30,10 +30,12 @@ class CKeyBindings : public CommandReceiver
 		typedef spring::unsynced_map<std::string, HotkeyList> ActionMap; // action to keyset
 
 	public:
+		static const std::string DEFAULT_FILENAME;
+
 		void Init();
 		void Kill();
 
-		bool Load(const std::string& filename);
+		bool Load(const std::string& filename = DEFAULT_FILENAME);
 		bool Save(const std::string& filename) const;
 		void Print() const;
 		void LoadDefaults();


### PR DESCRIPTION
Accept arguments and allow keyload/keyreload commands in uikeys. This allows players and games to use base uikeys files and keep changes minimal and scoped.