### PR TITLE
Add `Spring.Get{Team,Projectile}AllyTeamID`

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -45,6 +45,9 @@ Lua:
    since the last sim frame.
  - Added Spring.KeyMapChanged callin for when the user switches keyboard
    layouts, for example switching input method language.
+ - Added Spring.GetTeamAllyTeamID(), returns the team's allyTeamID.
+   Same as the 4th arg from GetTeamInfo, just more idiomatic.
+ - Added Spring.GetProjectileAllyTeamID(), ditto.
 
 Maps:
  - New bumpwater params, most of these were just hard-coded values:

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -139,6 +139,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetAIInfo);
 
 	REGISTER_LUA_CFUNC(GetTeamInfo);
+	REGISTER_LUA_CFUNC(GetTeamAllyTeamID);
 	REGISTER_LUA_CFUNC(GetTeamResources);
 	REGISTER_LUA_CFUNC(GetTeamUnitStats);
 	REGISTER_LUA_CFUNC(GetTeamResourceStats);
@@ -300,6 +301,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetProjectileTimeToLive);
 	REGISTER_LUA_CFUNC(GetProjectileOwnerID);
 	REGISTER_LUA_CFUNC(GetProjectileTeamID);
+	REGISTER_LUA_CFUNC(GetProjectileAllyTeamID);
 	REGISTER_LUA_CFUNC(GetProjectileType);
 	REGISTER_LUA_CFUNC(GetProjectileDefID);
 	REGISTER_LUA_CFUNC(GetProjectileName);
@@ -1137,6 +1139,19 @@ int LuaSyncedRead::GetTeamInfo(lua_State* L)
 	return 7 + getTeamOpts;
 }
 
+int LuaSyncedRead::GetTeamAllyTeamID(lua_State* L)
+{
+	const int teamID = luaL_checkint(L, 1);
+	if (!teamHandler.IsValidTeam(teamID))
+		return 0;
+
+	const CTeam* const team = teamHandler.Team(teamID);
+	if (team == nullptr)
+		return 0;
+
+	lua_pushnumber(L, teamHandler.AllyTeam(team->teamNum));
+	return 1;
+}
 
 int LuaSyncedRead::GetTeamResources(lua_State* L)
 {
@@ -5030,6 +5045,20 @@ int LuaSyncedRead::GetProjectileTeamID(lua_State* L)
 		return 0;
 
 	lua_pushnumber(L, pro->GetTeamID());
+	return 1;
+}
+
+int LuaSyncedRead::GetProjectileAllyTeamID(lua_State* L)
+{
+	const CProjectile* const pro = ParseProjectile(L, __func__, 1);
+	if (pro == nullptr)
+		return 0;
+
+	const auto allyTeamID = pro->GetAllyteamID();
+	if (!teamHandler.IsValidAllyTeam(allyTeamID))
+		return 0;
+
+	lua_pushnumber(L, allyTeamID);
 	return 1;
 }
 

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -68,6 +68,7 @@ class LuaSyncedRead {
 		static int GetTeamLuaAI(lua_State* L);
 
 		static int GetAllyTeamInfo(lua_State* L);
+		static int GetTeamAllyTeamID(lua_State* L);
 		static int AreTeamsAllied(lua_State* L);
 		static int ArePlayersAllied(lua_State* L);
 
@@ -219,6 +220,7 @@ class LuaSyncedRead {
 		static int GetProjectileTimeToLive(lua_State* L);
 		static int GetProjectileOwnerID(lua_State* L);
 		static int GetProjectileTeamID(lua_State* L);
+		static int GetProjectileAllyTeamID(lua_State* L);
 		static int GetProjectileType(lua_State* L);
 		static int GetProjectileDefID(lua_State* L);
 		static int GetProjectileDamages(lua_State* L);


### PR DESCRIPTION
Convenience functions for getting the allyTeamID. Interfaces to get these values already existed, but were bad. Compare:

```lua
-- ugly
local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(teamID)
foo(allyTeamID)

-- less performant, somewhat magic
foo(select(6, Spring.GetTeamInfo(teamID)))

-- nice new possibility
foo(Spring.GetTeamAllyTeamID(teamID))
```

Similar for projectiles (you could get the teamID from `Spring.GetProjectileTeamID` and then do the above).