### PR TITLE
DualScreenMode: Final adjustments

### DIFF
--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -259,10 +259,10 @@ void CCamera::UpdateViewPort(int px, int py, int sx, int sy)
 	viewport[3] = sy;
 }
 
-void CCamera::UpdateLoadViewPort(int px, int py, int sx, int sy)
+void CCamera::UpdateLoadViewport(int px, int py, int sx, int sy)
 {
 	UpdateViewPort(px, py, sx, sy);
-	LoadViewPort();
+	LoadViewport();
 }
 
 
@@ -275,7 +275,7 @@ void CCamera::LoadMatrices() const
 	glLoadMatrixf(&viewMatrix.m[0]);
 }
 
-void CCamera::LoadViewPort() const
+void CCamera::LoadViewport() const
 {
 	glViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
 }

--- a/rts/Game/Camera.h
+++ b/rts/Game/Camera.h
@@ -165,8 +165,8 @@ public:
 	const float3& GetFrustumEdge (unsigned int i) const { return frustum.edges [i]; }
 
 	void LoadMatrices() const;
-	void LoadViewPort() const;
-	void UpdateLoadViewPort(int px, int py, int sx, int sy);
+	void LoadViewport() const;
+	void UpdateLoadViewport(int px, int py, int sx, int sy);
 
 	void SetVFOV(float angle);
 	void SetAspectRatio(float ar) { aspectRatio = ar; }

--- a/rts/Game/UI/MiniMap.h
+++ b/rts/Game/UI/MiniMap.h
@@ -86,9 +86,15 @@ public:
 	void ApplyConstraintsMatrix() const;
 
 protected:
+	enum MINIMAP_POSITION { MINIMAP_POSITION_LEFT, MINIMAP_POSITION_RIGHT, MINIMAP_POSITION_CENTER };
+
 	void ParseGeometry(const std::string& geostr);
 	void ToggleMaximized(bool maxspect);
 	void SetMaximizedGeometry();
+	void SetAspectRatioGeometry(const float& viewSizeX, const float& viewSizeY,
+                              const float& viewPosX = 0, const float& viewPosY = 0,
+                              const MINIMAP_POSITION position = MINIMAP_POSITION_CENTER);
+	void LoadDualViewport() const;
 
 	void ConfigUpdate();
 
@@ -135,6 +141,7 @@ protected:
 	float unitSelectRadius = 0.0f;
 
 	bool minimapCanFlip = false;
+	bool aspectRatio = false;
 	bool fullProxy = false;
 	bool proxyMode = false;
 	bool selecting = false;

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -113,6 +113,7 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(GetNumDisplays);
 	REGISTER_LUA_CFUNC(GetViewGeometry);
+	REGISTER_LUA_CFUNC(GetDualViewGeometry);
 	REGISTER_LUA_CFUNC(GetWindowGeometry);
 	REGISTER_LUA_CFUNC(GetScreenGeometry);
 	REGISTER_LUA_CFUNC(GetMiniMapGeometry);
@@ -521,6 +522,16 @@ int LuaUnsyncedRead::GetViewGeometry(lua_State* L)
 	lua_pushnumber(L, globalRendering->viewSizeY);
 	lua_pushnumber(L, globalRendering->viewPosX);
 	lua_pushnumber(L, globalRendering->viewPosY);
+	return 4;
+}
+
+
+int LuaUnsyncedRead::GetDualViewGeometry(lua_State* L)
+{
+	lua_pushnumber(L, globalRendering->dualViewSizeX);
+	lua_pushnumber(L, globalRendering->dualViewSizeY);
+	lua_pushnumber(L, globalRendering->dualViewPosX);
+	lua_pushnumber(L, globalRendering->dualViewPosY);
 	return 4;
 }
 

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -32,6 +32,7 @@ class LuaUnsyncedRead {
 
 		static int GetNumDisplays(lua_State* L);
 		static int GetViewGeometry(lua_State* L);
+		static int GetDualViewGeometry(lua_State* L);
 		static int GetWindowGeometry(lua_State* L);
 		static int GetScreenGeometry(lua_State* L);
 		static int GetMiniMapGeometry(lua_State* L);

--- a/rts/Map/SMF/SMFGroundDrawer.cpp
+++ b/rts/Map/SMF/SMFGroundDrawer.cpp
@@ -200,6 +200,8 @@ void CSMFGroundDrawer::DrawDeferredPass(const DrawPass::e& drawPass, bool alphaT
 	if (!SelectRenderState(DrawPass::TerrainDeferred)->CanDrawDeferred())
 		return;
 
+	GL::GeometryBuffer::LoadViewport();
+
 	{
 		geomBuffer.Bind();
 		geomBuffer.SetDepthRange(1.0f, 0.0f);
@@ -231,6 +233,8 @@ void CSMFGroundDrawer::DrawDeferredPass(const DrawPass::e& drawPass, bool alphaT
 		geomBuffer.SetDepthRange(0.0f, 1.0f);
 		geomBuffer.UnBind();
 	}
+
+	globalRendering->LoadViewport();
 
 	#if 0
 	geomBuffer.DrawDebug(geomBuffer.GetBufferTexture(GL::GeometryBuffer::ATTACHMENT_NORMTEX));

--- a/rts/Rendering/Env/AdvWater.cpp
+++ b/rts/Rendering/Env/AdvWater.cpp
@@ -334,14 +334,14 @@ void CAdvWater::UpdateWater(const CGame* game)
 
 	{
 		curCam->CopyStateReflect(prvCam);
-		curCam->UpdateLoadViewPort(0, 0, 512, 512);
+		curCam->UpdateLoadViewport(0, 0, 512, 512);
 
 		DrawReflections(&clipPlaneEqs[0], true, true);
 	}
 
 	CCameraHandler::SetActiveCamera(prvCam->GetCamType());
 	prvCam->Update();
-	prvCam->LoadViewPort();
+	prvCam->LoadViewport();
 
 	FBO::Unbind();
 

--- a/rts/Rendering/Env/BumpWater.cpp
+++ b/rts/Rendering/Env/BumpWater.cpp
@@ -577,7 +577,7 @@ void CBumpWater::UpdateWater(const CGame* game)
 	if (reflection > 0) DrawReflection(game);
 	if (reflection || refraction) {
 		FBO::Unbind();
-		glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+		globalRendering->LoadViewport();
 	}
 	glPopAttrib();
 }
@@ -803,7 +803,7 @@ void CBumpWater::UpdateCoastmap(const bool initialize)
 	glDeleteTextures(1, &coastUpdateTexture);
 	coastmapAtlasRects.clear();
 
-	glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 	glActiveTexture(GL_TEXTURE0);
 }
 
@@ -881,7 +881,7 @@ void CBumpWater::UpdateDynWaves(const bool initialize)
 		glPopMatrix();
 	glMatrixMode(GL_MODELVIEW);
 		glPopMatrix();
-	glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 
 	glPopAttrib();
 	dynWavesFBO.Unbind();
@@ -994,7 +994,7 @@ void CBumpWater::DrawRefraction(const CGame* game)
 
 	camera->Update();
 
-	glViewport(0, 0, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 	const auto& sky = ISky::GetSky();
 	glClearColor(sky->fogColor.x, sky->fogColor.y, sky->fogColor.z, 0);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -1038,7 +1038,7 @@ void CBumpWater::DrawReflection(const CGame* game)
 
 	{
 		curCam->CopyStateReflect(prvCam);
-		curCam->UpdateLoadViewPort(0, 0, reflTexSize, reflTexSize);
+		curCam->UpdateLoadViewport(0, 0, reflTexSize, reflTexSize);
 
 		DrawReflections(&clipPlaneEqs[0], reflection > 1, true);
 	}

--- a/rts/Rendering/Env/CubeMapHandler.cpp
+++ b/rts/Rendering/Env/CubeMapHandler.cpp
@@ -213,7 +213,7 @@ void CubeMapHandler::CreateReflectionFace(unsigned int glFace, bool skyOnly)
 		curCam->SetAspectRatio(1.0f);
 		curCam->SetPos(prvCam->GetPos());
 
-		curCam->UpdateLoadViewPort(0, 0, reflTexSize, reflTexSize);
+		curCam->UpdateLoadViewport(0, 0, reflTexSize, reflTexSize);
 		curCam->UpdateViewRange();
 		curCam->UpdateMatrices(globalRendering->viewSizeX, globalRendering->viewSizeY, curCam->GetAspectRatio());
 		curCam->UpdateFrustum();

--- a/rts/Rendering/Env/DynWater.cpp
+++ b/rts/Rendering/Env/DynWater.cpp
@@ -467,7 +467,7 @@ void CDynWater::DrawReflection(const CGame* game)
 
 	{
 		curCam->CopyStateReflect(prvCam);
-		curCam->UpdateLoadViewPort(0, 0, 512, 512);
+		curCam->UpdateLoadViewport(0, 0, 512, 512);
 
 		reflectRight   = curCam->GetRight();
 		reflectUp      = curCam->GetUp();
@@ -479,7 +479,7 @@ void CDynWater::DrawReflection(const CGame* game)
 	CCameraHandler::SetActiveCamera(prvCam->GetCamType());
 
 	prvCam->Update();
-	prvCam->LoadViewPort();
+	prvCam->LoadViewport();
 }
 
 void CDynWater::DrawRefraction(const CGame* game)
@@ -511,7 +511,7 @@ void CDynWater::DrawRefraction(const CGame* game)
 
 	DrawRefractions(&clipPlaneEqs[0], true, true);
 
-	glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 	glClearColor(sky->fogColor.x, sky->fogColor.y, sky->fogColor.z, 1);
 
 	sunLighting->modelDiffuseColor = oldsun;

--- a/rts/Rendering/Env/GrassDrawer.cpp
+++ b/rts/Rendering/Env/GrassDrawer.cpp
@@ -1004,7 +1004,7 @@ void CGrassDrawer::CreateFarTex()
 		glGenerateMipmap(GL_TEXTURE_2D);
 	}
 
-	glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 	glMatrixMode(GL_PROJECTION);
 	glPopMatrix();
 	glMatrixMode(GL_MODELVIEW);

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -404,9 +404,6 @@ void CProjectileDrawer::ViewResize()
 	glDrawBuffer(GL_NONE);
 	depthFBO->CheckStatus("PROJECTILE-DRAWER-DEPTHFBO");
 	depthFBO->Unbind();
-
-	fxShaders[1]->Enable();
-	fxShaders[1]->Disable();
 }
 
 bool CProjectileDrawer::CheckSoftenExt()
@@ -1137,7 +1134,7 @@ void CProjectileDrawer::UpdatePerlin() {
 	}
 
 	perlinFB.Unbind();
-	glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glEnable(GL_DEPTH_TEST);

--- a/rts/Rendering/GL/GeometryBuffer.cpp
+++ b/rts/Rendering/GL/GeometryBuffer.cpp
@@ -190,3 +190,7 @@ int2 GL::GeometryBuffer::GetWantedSize(bool allowed) const {
 	return {globalRendering->viewSizeX * allowed, globalRendering->viewSizeY * allowed};
 }
 
+void GL::GeometryBuffer::LoadViewport()
+{
+	glViewport(0, 0, globalRendering->viewSizeX, globalRendering->viewSizeY);
+}

--- a/rts/Rendering/GL/GeometryBuffer.h
+++ b/rts/Rendering/GL/GeometryBuffer.h
@@ -30,6 +30,8 @@ namespace GL {
 		void DrawDebug(const unsigned int texID, const float2 texMins, const float2 texMaxs) const;
 		void DrawDebug(const unsigned int texID) const { DrawDebug(texID, float2(0.0f, 0.0f), float2(1.0f, 1.0f)); }
 
+		static void LoadViewport();
+
 		bool HasAttachments() const { return (bufferTextureIDs[0] != 0); }
 		bool Valid() const { return (buffer.IsValid()); }
 		bool Create(const int2 size);

--- a/rts/Rendering/GlobalRendering.h
+++ b/rts/Rendering/GlobalRendering.h
@@ -93,6 +93,9 @@ public:
 	void UpdateGLGeometry();
 	void UpdateScreenMatrices();
 
+	void LoadViewport();
+	void LoadDualViewport();
+
 	void UpdateWindowBorders(SDL_Window* window) const;
 
 	int2 GetMaxWinRes() const;
@@ -185,6 +188,7 @@ public:
 
 	/// Some settings got changed need to adjust the way window is
 	unsigned int winChgFrame;
+	unsigned int gmeChgFrame;
 
 	/// screen {View,Proj} matrices for rendering in pixel coordinates
 	CMatrix44f screenViewMatrix;

--- a/rts/Rendering/LuaObjectDrawer.cpp
+++ b/rts/Rendering/LuaObjectDrawer.cpp
@@ -493,6 +493,7 @@ void LuaObjectDrawer::DrawDeferredPass(LuaObjType objType)
 
 	// note: should also set this during the map pass (in SMFGD)
 	game->SetDrawMode(CGame::gameDeferredDraw);
+	GL::GeometryBuffer::LoadViewport();
 	geomBuffer->Bind();
 	geomBuffer->SetDepthRange(1.0f, 0.0f);
 
@@ -532,6 +533,8 @@ void LuaObjectDrawer::DrawDeferredPass(LuaObjType objType)
 		assert(eventFuncs[objType] != nullptr);
 		CALL_FUNC_NA(&eventHandler, eventFuncs[objType]);
 	}
+
+	globalRendering->LoadViewport();
 }
 
 

--- a/rts/Rendering/Map/InfoTexture/Modern/AirLos.cpp
+++ b/rts/Rendering/Map/InfoTexture/Modern/AirLos.cpp
@@ -128,10 +128,10 @@ void CAirLosTexture::Update()
 
 	if (losHandler->GetGlobalLOS(gu->myAllyTeam)) {
 		fbo.Bind();
-		glViewport(0,0, texSize.x, texSize.y);
+		glViewport(0, 0, texSize.x, texSize.y);
 		glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
-		glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+		globalRendering->LoadViewport();
 		FBO::Unbind();
 
 		glBindTexture(GL_TEXTURE_2D, texture);
@@ -155,7 +155,7 @@ void CAirLosTexture::Update()
 
 	// do post-processing on the gpu (los-checking & scaling)
 	fbo.Bind();
-	glViewport(0,0, texSize.x, texSize.y);
+	glViewport(0, 0, texSize.x, texSize.y);
 	shader->Enable();
 	glDisable(GL_BLEND);
 	glBegin(GL_QUADS);
@@ -165,7 +165,7 @@ void CAirLosTexture::Update()
 		glVertex2f(+1.f, -1.f);
 	glEnd();
 	shader->Disable();
-	glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 	FBO::Unbind();
 
 	// generate mipmaps

--- a/rts/Rendering/Map/InfoTexture/Modern/Combiner.cpp
+++ b/rts/Rendering/Map/InfoTexture/Modern/Combiner.cpp
@@ -134,7 +134,7 @@ void CInfoTextureCombiner::Update()
 		glTexCoord2f(1.f, 0.f); glVertex2f(+isx, -1.f);
 	glEnd();
 
-	glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	FBO::Unbind();
 	shader->Disable();

--- a/rts/Rendering/Map/InfoTexture/Modern/Height.cpp
+++ b/rts/Rendering/Map/InfoTexture/Modern/Height.cpp
@@ -160,7 +160,7 @@ void CHeightTexture::Update()
 		glVertex2f(1.f, 0.f);
 	glEnd();
 	shader->Disable();
-	glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 	FBO::Unbind();
 
 	// cleanup

--- a/rts/Rendering/Map/InfoTexture/Modern/Los.cpp
+++ b/rts/Rendering/Map/InfoTexture/Modern/Los.cpp
@@ -130,10 +130,10 @@ void CLosTexture::Update()
 
 	if (losHandler->GetGlobalLOS(gu->myAllyTeam)) {
 		fbo.Bind();
-		glViewport(0,0, texSize.x, texSize.y);
+		glViewport(0, 0, texSize.x, texSize.y);
 		glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
-		glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+		globalRendering->LoadViewport();
 		FBO::Unbind();
 
 		glBindTexture(GL_TEXTURE_2D, texture);
@@ -157,7 +157,7 @@ void CLosTexture::Update()
 
 	// do post-processing on the gpu (los-checking & scaling)
 	fbo.Bind();
-	glViewport(0,0, texSize.x, texSize.y);
+	glViewport(0, 0, texSize.x, texSize.y);
 	shader->Enable();
 	glDisable(GL_BLEND);
 	glBegin(GL_QUADS);
@@ -167,7 +167,7 @@ void CLosTexture::Update()
 		glVertex2f(+1.f, -1.f);
 	glEnd();
 	shader->Disable();
-	glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 	FBO::Unbind();
 
 	// generate mipmaps

--- a/rts/Rendering/Map/InfoTexture/Modern/MetalExtraction.cpp
+++ b/rts/Rendering/Map/InfoTexture/Modern/MetalExtraction.cpp
@@ -112,7 +112,7 @@ void CMetalExtractionTexture::Update()
 	// do post-processing on the gpu (los-checking & scaling)
 	fbo.Bind();
 	shader->Enable();
-	glViewport(0,0, texSize.x, texSize.y);
+	glViewport(0, 0, texSize.x, texSize.y);
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_ZERO, GL_SRC_COLOR);
 	glBindTexture(GL_TEXTURE_2D, infoTex->GetTexture());
@@ -124,7 +124,7 @@ void CMetalExtractionTexture::Update()
 	glEnd();
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	//glDisable(GL_BLEND);
-	glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 	shader->Disable();
 	FBO::Unbind();
 }

--- a/rts/Rendering/Map/InfoTexture/Modern/Path.cpp
+++ b/rts/Rendering/Map/InfoTexture/Modern/Path.cpp
@@ -199,10 +199,10 @@ void CPathTexture::Update()
 		isCleared = true;
 		updateProcess = 0;
 		fbo.Bind();
-		glViewport(0,0, texSize.x, texSize.y);
+		glViewport(0, 0, texSize.x, texSize.y);
 		glClearColor(1.0f, 0.0f, 0.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
-		glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+		globalRendering->LoadViewport();
 		FBO::Unbind();
 		return;
 	}

--- a/rts/Rendering/Map/InfoTexture/Modern/Radar.cpp
+++ b/rts/Rendering/Map/InfoTexture/Modern/Radar.cpp
@@ -164,10 +164,10 @@ void CRadarTexture::Update()
 
 	if (losHandler->GetGlobalLOS(gu->myAllyTeam)) {
 		fbo.Bind();
-		glViewport(0,0, texSize.x, texSize.y);
+		glViewport(0, 0, texSize.x, texSize.y);
 		glClearColor(1.0f, 0.0f, 0.0f, 0.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
-		glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+		globalRendering->LoadViewport();
 		FBO::Unbind();
 
 		glBindTexture(GL_TEXTURE_2D, texture);
@@ -202,7 +202,7 @@ void CRadarTexture::Update()
 
 	// do post-processing on the gpu (los-checking & scaling)
 	fbo.Bind();
-	glViewport(0,0, texSize.x, texSize.y);
+	glViewport(0, 0, texSize.x, texSize.y);
 	shader->Enable();
 	glDisable(GL_BLEND);
 	glActiveTexture(GL_TEXTURE2);
@@ -215,7 +215,7 @@ void CRadarTexture::Update()
 		glVertex2f(+1.f, -1.f);
 	glEnd();
 	shader->Disable();
-	glViewport(globalRendering->viewPosX, globalRendering->viewPosY, globalRendering->viewSizeX, globalRendering->viewSizeY);
+	globalRendering->LoadViewport();
 	FBO::Unbind();
 
 	// cleanup

--- a/rts/Rendering/ShadowHandler.cpp
+++ b/rts/Rendering/ShadowHandler.cpp
@@ -455,7 +455,7 @@ void CShadowHandler::SetShadowCamera(CCamera* shadowCam)
 	// convert xy-diameter to radius
 	shadowCam->SetFrustumScales(shadowProjScales * float4(0.5f, 0.5f, 1.0f, 1.0f));
 	shadowCam->UpdateFrustum();
-	shadowCam->UpdateLoadViewPort(0, 0, shadowMapSize, shadowMapSize);
+	shadowCam->UpdateLoadViewport(0, 0, shadowMapSize, shadowMapSize);
 	// load matrices into gl_{ModelView,Projection}Matrix
 	shadowCam->Update({false, false, false, false, false});
 

--- a/rts/Rendering/WorldDrawer.cpp
+++ b/rts/Rendering/WorldDrawer.cpp
@@ -273,7 +273,7 @@ void CWorldDrawer::GenerateIBLTextures() const
 		FBO::Unbind();
 
 	// restore the normal active camera's VP
-	camera->LoadViewPort();
+	camera->LoadViewport();
 }
 
 void CWorldDrawer::ResetMVPMatrices() const


### PR DESCRIPTION
- Listen to and adjust internal state on DualScreenMode and DualScreenMiniMapOnLeft changes
- Add DualScreenMiniMapAspectRatio = [1]|0 to keep the map aspect ratio instead of stretching along the dual view
- Add `vsx, vsy, vpx, vpy = Spring.GetDualViewGeometry()`
- Perform fixes for proper viewport on:
  - GroundDrawer
  - BumpWater
  - ProjectileDrawer softening (copy source texture with proper geometry)
  - LuaObjectDrawer (deferred pass on models)