### PR TITLE
MouseHandler: Update mouse cursor dir

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1366,6 +1366,7 @@ bool CGame::UpdateUnsynced(const spring_time currentTime)
 		unitTracker.SetCam();
 
 	camera->Update();
+	mouse->UpdateCursorCameraDir(); // make sure mouse->dir is in sync with camera
 	shadowHandler.Update();
 
 	//Update per-drawFrame UBO

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -3721,14 +3721,13 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 
 		if (buildeeDef != nullptr) {
 			if ((rayTraceDist = CGround::LineGroundWaterCol(tracePos, traceDir, maxTraceDist, buildeeDef->floatOnWater, false)) > 0.0f) {
-				const CMouseHandler::ButtonPressEvt& bp = mouse->buttons[SDL_BUTTON_LEFT];
-				const float bpDist = CGround::LineGroundWaterCol(bp.camPos, bp.dir, maxTraceDist, buildeeDef->floatOnWater, false);
-
 				// get the build information
 				const float3 cPos = tracePos + traceDir * rayTraceDist;
-				const float3 bPos = bp.camPos + bp.dir * bpDist;
 
+				const CMouseHandler::ButtonPressEvt& bp = mouse->buttons[SDL_BUTTON_LEFT];
 				if (GetQueueKeystate() && bp.pressed) {
+					const float bpDist = CGround::LineGroundWaterCol(bp.camPos, bp.dir, maxTraceDist, buildeeDef->floatOnWater, false);
+					const float3 bPos = bp.camPos + bp.dir * bpDist;
 					const BuildInfo cInfo = BuildInfo(buildeeDef, cPos, buildFacing);
 					const BuildInfo bInfo = BuildInfo(buildeeDef, bPos, buildFacing);
 

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -363,8 +363,13 @@ bool CMouseHandler::GetSelectionBoxVertices(float3& bl, float3& br, float3& tl, 
 	if (gu->fpsMode)
 		return false;
 
+	if (inMapDrawer != nullptr && inMapDrawer->IsDrawMode())
+		return false;
+
 	const ButtonPressEvt& bp = buttons[SDL_BUTTON_LEFT];
 
+	if (!bp.pressed)
+		return false;
 	if (bp.chorded)
 		return false;
 	if (bp.movement <= dragSelectionThreshold)
@@ -552,14 +557,6 @@ void CMouseHandler::DrawSelectionBox() const
 	float3 btLeft, btRight, tpLeft, tpRight;
 
 	if (activeReceiver != nullptr)
-		return;
-
-	if (inMapDrawer != nullptr && inMapDrawer->IsDrawMode())
-		return;
-
-	const ButtonPressEvt& bp = buttons[SDL_BUTTON_LEFT];
-
-	if (!bp.pressed)
 		return;
 
 	if (!GetSelectionBoxVertices(btLeft, btRight, tpLeft, tpRight))

--- a/rts/Game/UI/MouseHandler.h
+++ b/rts/Game/UI/MouseHandler.h
@@ -36,6 +36,7 @@ public:
 
 	void Update();
 	void UpdateCursors();
+	void UpdateCursorCameraDir();
 
 	void HideMouse();
 	void ShowMouse();
@@ -43,7 +44,7 @@ public:
 	void CancelButtonMovement(int button) { buttons[button].movement = 0; }
 	void WarpMouse(int x, int y);
 
-	void DrawSelectionBox(); /// draw mousebox (selection box)
+	void DrawSelectionBox() const; /// draw mousebox (selection box)
 	void DrawCursor();
 
 	void MouseRelease(int x, int y, int button);


### PR DESCRIPTION
Previously it was only updated during mouse events and on DrawSelectionBox.

On https://github.com/beyond-all-reason/spring/commit/c4027a21885537a00ad9fac5763b2c954e60200e we stopped updating cursor dir in DrawSelectionBox unless we wanted to draw it.

This PR makes sure mousedir is synced _before_ places in guihandler that need it (`GuiHandler::SetCursorIcon`/`EventClient::Update` listeners)  and after camera transitions are updated.

This PR includes a commit to further simplify `DrawSelectionBox`.