### PR TITLE
WeaponDefs: Refactor indexing from 0 to 1-index

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -5,6 +5,11 @@ Spring changelog
 -- BAR105 --------------------------------------------------------
 
 BREAKING CHANGES & HOW TO GET BACK OLD BEHAVIOURS:
+ ! WeaponDefs now uses the same indexing as Unit and Feature Defs, i.e.:
+   WeaponDefs[0] == nil and WeaponDefs size was increased by 1.
+   This avoids a category of bugs due to game developers assuming a sane and
+   consistent indexing (for i=1, #WeaponDefs should work as expected now).
+
  ! Add movetilt and movereset for previously hardcoded ALT and CTRL camera bindings.
    To get back old behaviour, make sure to rebind them (remember "Any+", as in "Any+Alt")
 

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -253,6 +253,7 @@ static inline const MoveDef* getUnitDefMoveDefById(int skirmishAIId, int unitDef
 }
 
 static inline const WeaponDef* getWeaponDefById(int skirmishAIId, int weaponDefId) {
+	assert(weaponDefId > 0); // transitory assert for 0-index to 1-index weaponDefs change
 	return (weaponDefHandler->GetWeaponDefByID(weaponDefId));
 }
 

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -363,9 +363,9 @@ bool CSyncedLuaHandle::Init(const std::string& code, const std::string& file)
 
 	watchUnitDefs.resize(unitDefHandler->NumUnitDefs() + 1, false);
 	watchFeatureDefs.resize(featureDefHandler->NumFeatureDefs() + 1, false);
-	watchExplosionDefs.resize(weaponDefHandler->NumWeaponDefs(), false);
-	watchProjectileDefs.resize(weaponDefHandler->NumWeaponDefs() + 1, false); // last bit controls piece-projectiles
-	watchAllowTargetDefs.resize(weaponDefHandler->NumWeaponDefs(), false);
+	watchExplosionDefs.resize(weaponDefHandler->NumWeaponDefs() + 1, false);
+	watchProjectileDefs.resize((weaponDefHandler->NumWeaponDefs() + 1) + 1, false); // last bit controls piece-projectiles
+	watchAllowTargetDefs.resize(weaponDefHandler->NumWeaponDefs() + 1, false);
 
 	// load the standard libraries
 	SPRING_LUA_OPEN_LIB(L, luaopen_base);

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -4693,7 +4693,10 @@ int LuaSyncedCtrl::SpawnProjectile(lua_State* L)
 {
 	ProjectileParams params;
 
-	if ((params.weaponDef = weaponDefHandler->GetWeaponDefByID(luaL_checkint(L, 1))) == nullptr)
+	const int weaponDefId = luaL_checkint(L, 1);
+	assert(weaponDefId > 0); // transitory assert for 0-index to 1-index weaponDefs change
+
+	if ((params.weaponDef = weaponDefHandler->GetWeaponDefByID(weaponDefId)) == nullptr)
 		return 0;
 
 	if (!ParseProjectileParams(L, params, 2, __func__))
@@ -4770,7 +4773,9 @@ static int SetExplosionParam(lua_State* L, CExplosionParams& params, DamageArray
 			}
 		} break;
 		case hashString("weaponDef"): {
-			params.weaponDef = weaponDefHandler->GetWeaponDefByID(lua_tofloat(L, index + 1));
+			const int weaponDefId = lua_tofloat(L, index + 1);
+			assert(weaponDefId > 0); // transitory assert for 0-index to 1-index weaponDefs change
+			params.weaponDef = weaponDefHandler->GetWeaponDefByID(weaponDefId);
 		} break;
 		case hashString("owner"): {
 			params.owner = ParseUnit(L, __func__, index + 1);

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -490,6 +490,8 @@ void CProjectileDrawer::LoadWeaponTextures() {
 	// post-process the synced weapon-defs to set unsynced fields
 	// (this requires CWeaponDefHandler to have been initialized)
 	for (WeaponDef& wd: const_cast<std::vector<WeaponDef>&>(weaponDefHandler->GetWeaponDefsVec())) {
+		assert(wd.id > 0); // transitory assert for 0-index to 1-index weaponDefs change
+
 		wd.visuals.texture1 = nullptr;
 		wd.visuals.texture2 = nullptr;
 		wd.visuals.texture3 = nullptr;

--- a/rts/Sim/Features/FeatureDefHandler.cpp
+++ b/rts/Sim/Features/FeatureDefHandler.cpp
@@ -25,9 +25,8 @@ void CFeatureDefHandler::Init(LuaParser* defsParser)
 	std::vector<std::string> keys;
 	rootTable.GetKeys(keys);
 
-	// FeatureDef ID's start with 1
 	featureDefIDs.reserve(keys.size());
-	featureDefsVector.reserve(keys.size());
+	featureDefsVector.reserve(keys.size() + 1); // FeatureDef ID's start with 1
 	featureDefsVector.emplace_back();
 
 	for (unsigned int i = 0; i < keys.size(); i++) {

--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -255,6 +255,7 @@ void CCobInstance::HitByWeapon(const float3& hitDir, int weaponDefId, float& ino
 	callinArgs[2] = int(hitDir.x);
 
 	if (HasFunction(COBFN_HitByWeaponId)) {
+		assert(weaponDefId > 0); // transitory assert for 0-index to 1-index weaponDefs change
 		const WeaponDef* wd = weaponDefHandler->GetWeaponDefByID(weaponDefId);
 
 		callinArgs[0] = 4;

--- a/rts/Sim/Units/UnitDefHandler.cpp
+++ b/rts/Sim/Units/UnitDefHandler.cpp
@@ -38,8 +38,8 @@ void CUnitDefHandler::Init(LuaParser* defsParser)
 	std::vector<std::string> unitDefNames;
 	rootTable.GetKeys(unitDefNames);
 
-	unitDefIDs.reserve(unitDefNames.size() + 1);
-	unitDefsVector.reserve(unitDefNames.size() + 1);
+	unitDefIDs.reserve(unitDefNames.size());
+	unitDefsVector.reserve(unitDefNames.size() + 1); // UnitDef ID's start with 1
 	unitDefsVector.emplace_back();
 
 	for (unsigned int a = 0; a < unitDefNames.size(); ++a) {

--- a/rts/Sim/Weapons/WeaponDefHandler.cpp
+++ b/rts/Sim/Weapons/WeaponDefHandler.cpp
@@ -27,11 +27,13 @@ void CWeaponDefHandler::Init(LuaParser* defsParser)
 	std::vector<std::string> weaponNames;
 	rootTable.GetKeys(weaponNames);
 
-	weaponDefsVector.reserve(weaponNames.size());
 	weaponDefIDs.reserve(weaponNames.size());
+	weaponDefsVector.reserve(weaponNames.size() + 1); // WeaponDef ID's start with 1
+	weaponDefsVector.emplace_back();
 
-	for (int wid = 0; wid < weaponNames.size(); wid++) {
-		const std::string& name = weaponNames[wid];
+	for (int nid = 0; nid < weaponNames.size(); nid++) {
+		const int wid = nid + 1;
+		const std::string& name = weaponNames[nid];
 		const LuaTable wdTable = rootTable.SubTable(name);
 		weaponDefsVector.emplace_back(wdTable, name, wid);
 		weaponDefIDs[name] = wid;

--- a/rts/Sim/Weapons/WeaponDefHandler.h
+++ b/rts/Sim/Weapons/WeaponDefHandler.h
@@ -24,11 +24,11 @@ public:
 	}
 
 	bool IsValidWeaponDefID(const int id) const {
-		return (id >= 0) && (static_cast<size_t>(id) < weaponDefsVector.size());
+		return (id > 0) && (static_cast<size_t>(id) < weaponDefsVector.size());
 	}
 
-	// id=0 *is* a valid WeaponDef, hence no -1
-	unsigned int NumWeaponDefs() const { return (weaponDefsVector.size()); }
+	// id=0 is not a valid WeaponDef, hence the -1
+	unsigned int NumWeaponDefs() const { return (weaponDefsVector.size() - 1); }
 
 	// NOTE: safe with unordered_map after Init
 	const WeaponDef* GetWeaponDef(std::string wdName) const;


### PR DESCRIPTION
Too often game developers are unaware of this tricky behavior, as in Unit and Feature defs can be iterated via `for 1, #tablesize` while that's not the case with WeaponDefs.