### PR TITLE
Mex: Fix activation and propagation to neighbors

### DIFF
--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -104,8 +104,8 @@ public:
 	// negative amount=reclaim, return= true -> build power was successfully applied
 	bool AddBuildPower(CUnit* builder, float amount);
 
-	void Activate();
-	void Deactivate();
+	virtual void Activate();
+	virtual void Deactivate();
 
 	void ForcedMove(const float3& newPos);
 

--- a/rts/Sim/Units/UnitTypes/ExtractorBuilding.cpp
+++ b/rts/Sim/Units/UnitTypes/ExtractorBuilding.cpp
@@ -41,6 +41,9 @@ CExtractorBuilding::~CExtractorBuilding()
 /* resets the metalMap and notifies the neighbours */
 void CExtractorBuilding::ResetExtraction()
 {
+	metalExtract = 0;
+	script->ExtractionRateChanged(metalExtract);
+
 	// undo the extraction-area
 	for (auto si = metalAreaOfControl.begin(); si != metalAreaOfControl.end(); ++si) {
 		metalMap.RemoveExtraction(si->x, si->z, si->extractionDepth);
@@ -148,9 +151,11 @@ void CExtractorBuilding::ReCalculateMetalExtraction()
 	for (MetalSquareOfControl& msqr: metalAreaOfControl) {
 		metalMap.RemoveExtraction(msqr.x, msqr.z, msqr.extractionDepth);
 
-		// extraction is done in a cylinder
-		msqr.extractionDepth = metalMap.RequestExtraction(msqr.x, msqr.z, extractionDepth);
-		metalExtract += (msqr.extractionDepth * metalMap.GetMetalAmount(msqr.x, msqr.z));
+		if (activated) {
+			// extraction is done in a cylinder
+			msqr.extractionDepth = metalMap.RequestExtraction(msqr.x, msqr.z, extractionDepth);
+			metalExtract += (msqr.extractionDepth * metalMap.GetMetalAmount(msqr.x, msqr.z));
+		}
 	}
 
 	// set the new rotation-speed
@@ -158,9 +163,24 @@ void CExtractorBuilding::ReCalculateMetalExtraction()
 }
 
 
-/* Finds the amount of metal to extract and sets the rotationspeed when the extractor is built. */
-void CExtractorBuilding::FinishedBuilding(bool postInit)
+void CExtractorBuilding::Activate()
 {
+	if (activated)
+		return;
+
+	CBuilding::Activate();
+
+	/* Finds the amount of metal to extract and sets the rotationspeed when the extractor is built. */
 	SetExtractionRangeAndDepth(unitDef->extractRange, unitDef->extractsMetal);
-	CUnit::FinishedBuilding(postInit);
+}
+
+
+void CExtractorBuilding::Deactivate()
+{
+	if (!activated)
+		return;
+
+	CBuilding::Deactivate();
+
+	ResetExtraction();
 }

--- a/rts/Sim/Units/UnitTypes/ExtractorBuilding.h
+++ b/rts/Sim/Units/UnitTypes/ExtractorBuilding.h
@@ -9,7 +9,7 @@
 
 class CExtractorBuilding : public CBuilding {
 public:
-	CR_DECLARE(CExtractorBuilding)
+	CR_DECLARE_DERIVED(CExtractorBuilding)
 	CR_DECLARE_SUB(MetalSquareOfControl)
 
 	CExtractorBuilding(): CBuilding() {
@@ -28,7 +28,8 @@ public:
 	float GetExtractionRange() const { return extractionRange; }
 	float GetExtractionDepth() const { return extractionDepth; }
 
-	void FinishedBuilding(bool postInit);
+	void Activate() override;
+	void Deactivate() override;
 
 protected:
 	struct MetalSquareOfControl {


### PR DESCRIPTION
Metal Extractors are supposed to only work if they are activated, regardless of onoffable state. If a metal extractor is activated or deactivated, propagate this state to neighbor extractors properly.

Setting extraction during FinishedBuilding is replaced with Activate, since even not ononffable Extractors still require being activated to function (fixes a bug where metal and extraction map is corrupted due to this)