### PR TITLE
Add md5 checksum file to published engine archives

### DIFF
--- a/docker-build/scripts/00_setup.sh
+++ b/docker-build/scripts/00_setup.sh
@@ -6,6 +6,7 @@ DUMMY=
 ENABLE_CCACHE=1
 DEBUG_CCACHE=
 STRIP_SYMBOLS=1
+PUBLISH_ARTIFACTS=
 
 MYARCHTUNE=""
 MYCFLAGS=""
@@ -38,11 +39,12 @@ function print_usage() {
     echo "  -l      local build"
     echo "  -w      suppress outdated container warning"
     echo "  -o      disable headless and dedicated builds"
+    echo "  -k      pack and publish artifacts"
     echo "  -h      print this help"
     exit 1
 }
 
-while getopts :b:u:a:p:dc:ht:r:f:s:z:e:lwo flag
+while getopts :b:u:a:p:dc:ht:r:f:s:z:e:lwok flag
 do
     case "${flag}" in
         b) BRANCH_NAME=${OPTARG};;
@@ -61,6 +63,7 @@ do
         l) LOCAL_BUILD=true;;
         w) SUPPRESS_OUTDATED=true;;
         o) ONLY_LEGACY=true;;
+        k) PUBLISH_ARTIFACTS=true;;
         \:) printf "argument missing from -%s option\n" $OPTARG >&2
             exit 2
             ;;
@@ -88,6 +91,9 @@ if [ ${LOCAL_BUILD} ]; then
 
     BUILD_DIR="${BUILD_DIR}-${PLATFORM}-${MYBUILDTYPE}"
     INSTALL_DIR="${BUILD_DIR}/install"
+    PUBLISH_DIR="${BUILD_DIR}/publish"
+else
+    PUBLISH_ARTIFACTS=true
 fi
 
 if [ -z ${MYBUILDTYPEFLAGS+x} ]; then

--- a/docker-build/scripts/07_pack_build_artifacts.sh
+++ b/docker-build/scripts/07_pack_build_artifacts.sh
@@ -7,6 +7,12 @@ dbg_name=spring_bar_$tag_name-minimal-symbols.tgz
 ccache_dbg_name=ccache_dbg.tgz
 
 cd "${INSTALL_DIR}"
+
+# Compute md5 hashes of all files in archive. We additionally gzip it as gzip adds
+# checksum to the list itself. To validate just `zcat files.md5.gz | md5sum -c -`
+find . -type f ! -name '*.dbg' ! -name files.md5.gz -exec md5sum {} \; | gzip > files.md5.gz
+
+rm -f ../$bin_name
 7z a -t7z -m0=lzma -mx=9 -mfb=64 -md=32m -ms=on ../$bin_name ./* -xr\!*.dbg
 # export github output variables
 echo "::set-output name=bin_name::${bin_name}"

--- a/docker-build/scripts/07_pack_build_artifacts.sh
+++ b/docker-build/scripts/07_pack_build_artifacts.sh
@@ -24,7 +24,7 @@ if [ -d /ccache_dbg ]; then
     echo "Packing ccache debug data..."
 
     echo "::set-output name=ccache_dbg::${ccache_dbg_name}"
-    tar cvfz "/publish/${ccache_dbg_name}" -C /ccache_dbg /ccache_dbg > /dev/null 2>&1
+    tar cvfz "${PUBLISH_DIR}/${ccache_dbg_name}" -C /ccache_dbg /ccache_dbg > /dev/null 2>&1
 else
     echo "No ccache debug data, so skipping packing it..."
 fi

--- a/docker-build/scripts/08_copy_to_publish_dir.sh
+++ b/docker-build/scripts/08_copy_to_publish_dir.sh
@@ -1,3 +1,4 @@
 echo "Copying artficats to publish dir: '${PUBLISH_DIR}'..."
 
+mkdir -p "${PUBLISH_DIR}"
 cp "${BUILD_DIR}/${bin_name}" "${BUILD_DIR}/${dbg_name}" "${BUILD_DIR}/${FILENAME_BUILDOPTIONS}" "${PUBLISH_DIR}"

--- a/docker-build/scripts/build.sh
+++ b/docker-build/scripts/build.sh
@@ -31,7 +31,7 @@ echo "---------------------------------"
 . /scripts/03_compile.sh
 . /scripts/04_install.sh
 
-if [ ! ${LOCAL_BUILD} ]; then
+if [ ${PUBLISH_ARTIFACTS} ]; then
     if [ "${STRIP_SYMBOLS}" == "1" ]; then
         . /scripts/05_fill_debugsymbol_dir.sh
     fi


### PR DESCRIPTION
This allow to verify corruption in engine files after the engine is unpacked in the target installation directory. Also add -k option to build script to be able to easily create archives from local builds and test those scripts.

cc @Damgam