### PR TITLE
Adapt pr-downloader cmake rewrite and switch to pkg-config for linux.

### DIFF
--- a/docker-build/scripts/02_configure.sh
+++ b/docker-build/scripts/02_configure.sh
@@ -7,11 +7,8 @@ mkdir -p "${BUILD_DIR}/bin-dir"
 
 EXTRA_CMAKE_ARGS=()
 if [ "${PLATFORM}" == "linux-64" ]; then
-    WORKDIR=${LIBS_DIR}
-    LIBDIR=$WORKDIR/lib
-    INCLUDEDIR=$WORKDIR/include
-
     EXTRA_CMAKE_ARGS+=(
+        -DCMAKE_SYSTEM_PREFIX_PATH="${LIBS_DIR}"
         -DPREFER_STATIC_LIBS:BOOL=1
         -DCMAKE_USE_RELATIVE_PATHS:BOOL=1
         -DBINDIR:PATH=./
@@ -19,45 +16,9 @@ if [ "${PLATFORM}" == "linux-64" ]; then
         -DDATADIR:PATH=./
         -DMANDIR:PATH=share/man
         -DDOCDIR:PATH=doc
-        -DOGG_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DOGG_LIBRARY=${LIBDIR}/libogg.a
-        -DMINIZIP_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DMINIZIP_LIBRARY=${LIBDIR}/libminizip.a
-        -DLZMA_LIBRARY=${LIBDIR}/liblzma.a
-        -DLIBUUID_LIBRARY=${LIBDIR}/libuuid.a
-        -DVORBIS_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DVORBISENC_LIBRARY=${LIBDIR}/libvorbisenc.a
-        -DVORBISFILE_LIBRARY=${LIBDIR}/libvorbisfile.a
-        -DVORBIS_LIBRARY=${LIBDIR}/libvorbis.a
-        -DIL_IL_HEADER:PATH=${INCLUDEDIR}/IL/il.h
-        -DIL_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DIL_IL_LIBRARY:PATH=${LIBDIR}/libIL.a
-        -DIL_LIBRARIES:PATH=${LIBDIR}/libIL.a
-        -DILU_LIBRARIES:PATH=${LIBDIR}/libILU.a
-        -DGIF_LIBRARY:PATH=${LIBDIR}/libgif.a
-        -DGIF_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DPNG_PNG_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DPNG_LIBRARY_RELEASE:PATH=${LIBDIR}/libpng.a
-        -DJPEG_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DJPEG_LIBRARY:PATH=${LIBDIR}/libjpeg.a
-        -DTIFF_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DTIFF_LIBRARY_RELEASE:PATH=${LIBDIR}/libtiff.a
-        -DZLIB_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DZLIB_LIBRARY_RELEASE:PATH=${LIBDIR}/libz.a
-        -DGLEW_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DGLEW_LIBRARIES:PATH=${LIBDIR}/libGLEW.a
-        -DLIBUNWIND_INCLUDE_DIRS:PATH=${INCLUDEDIR}
-        -DLIBUNWIND_LIBRARY:PATH=${LIBDIR}/libunwind.a
-        -DCURL_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DCURL_LIBRARY:PATH="${LIBDIR}/libcurl.a;${LIBDIR}/libnghttp2.a"
-        -DOPENSSL_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DOPENSSL_SSL_LIBRARY:PATH=${LIBDIR}/libssl.a
-        -DOPENSSL_CRYPTO_LIBRARY:PATH=${LIBDIR}/libcrypto.a
-        -DVORBIS_INCLUDE_DIR:PATH=${INCLUDEDIR}
-        -DVORBISENC_LIBRARY:PATH=${LIBDIR}/libvorbisenc.a
-        -DVORBISFILE_LIBRARY:PATH=${LIBDIR}/libvorbisfile.a
-        -DVORBIS_LIBRARY:PATH=${LIBDIR}/libvorbis.a
     )
+    export PKG_CONFIG_LIBDIR=${LIBS_DIR}/lib/pkgconfig
+    export PKG_CONFIG="pkg-config --define-prefix --static"
 elif [ "${PLATFORM}" == "windows-64" ]; then
     EXTRA_CMAKE_ARGS+=(
         -DMINGWLIBS=${LIBS_DIR}

--- a/rts/builds/headless/CMakeLists.txt
+++ b/rts/builds/headless/CMakeLists.txt
@@ -26,7 +26,7 @@ list(APPEND engineHeadlessLibraries ${engineCommonLibraries})
 #list(APPEND engineHeadlessLibraries engineaGui)
 list(APPEND engineHeadlessLibraries no-sound)
 list(APPEND engineHeadlessLibraries engineSim)
-list(APPEND engineHeadlessLibraries pr-downloader_static)
+list(APPEND engineHeadlessLibraries pr-downloader)
 
 include_directories(${ENGINE_SRC_ROOT_DIR}/lib/assimp/include)
 include_directories(${ENGINE_SRC_ROOT_DIR}/lib/asio/include)

--- a/rts/builds/legacy/CMakeLists.txt
+++ b/rts/builds/legacy/CMakeLists.txt
@@ -69,7 +69,7 @@ list(APPEND engineLibraries ${engineCommonLibraries})
 #list(APPEND engineLibraries engineaGui)
 list(APPEND engineLibraries ${SPRING_SIM_LIBRARIES})
 list(APPEND engineLibraries engineSim)
-list(APPEND engineLibraries pr-downloader_static)
+list(APPEND engineLibraries pr-downloader)
 
 ### Assemble external incude dirs
 list(APPEND engineIncludes ${OPENAL_INCLUDE_DIR})

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,18 +10,32 @@ if    (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/pr-downloader/CMakeLists.txt")
 	message(FATAL_ERROR "${CMAKE_CURRENT_SOURCE_DIR}/pr-downloader/ is missing, please run\n git submodule init && git submodule update")
 endif ()
 
-set(CMAKE_BUILD_TYPE "RELEASE")
-set(CLEAR_COMPILER_FLAGS true)
-set(PRD_TESTS OFF CACHE BOOL "" FORCE)
-set(PRD_BINDIR ${BINDIR} CACHE PATH "" FORCE)
-set(PRD_LIBDIR ${LIBDIR} CACHE PATH "" FORCE)
-add_subdirectory(pr-downloader)
-# add install-pr-downloader target
-set(myInstallDeps pr-downloader)
-set(myInstallDirs "tools/pr-downloader")
-create_install_target("pr-downloader" myInstallDeps myInstallDirs)
-
 # This is not part of the official source package
 if    (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dirchange)
 	add_subdirectory(dirchange)
 endif (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dirchange)
+
+# TODO: Clean this mess up together with other CMake refactoring.
+set(CMAKE_CXX_FLAGS "")
+set(CMAKE_C_FLAGS "")
+set(CMAKE_MODULE_LINKER_FLAGS "")
+set(CMAKE_SHARED_LINKER_FLAGS "")
+set(CMAKE_EXE_LINKER_FLAGS "")
+# This block is needed only because we need to clean global compile flags above
+# for pr-downloader as we don't want to inherit everything that engine uses.
+if(PREFER_STATIC_LIBS)
+	check_cxx_accepts_flag("-static-libgcc" HAVE_STATIC_LIBGCC_FLAG)
+	if(HAVE_STATIC_LIBGCC_FLAG)
+		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc")
+	endif (HAVE_STATIC_LIBGCC_FLAG)
+	check_cxx_accepts_flag("-static-libstdc++" HAVE_STATIC_LIBSTDCXX_FLAG)
+	if(HAVE_STATIC_LIBSTDCXX_FLAG)
+		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++")
+	endif (HAVE_STATIC_LIBSTDCXX_FLAG)
+endif()
+add_subdirectory(pr-downloader)
+
+# add install-pr-downloader target
+set(myInstallDeps pr-downloader)
+set(myInstallDirs "tools/pr-downloader")
+create_install_target("pr-downloader" myInstallDeps myInstallDirs)


### PR DESCRIPTION
The pkg-config based packages resoltion simplifies the configuration and allows for better automatic resolution of indirect dependencies of libraries needed for static linking.