### PR TITLE
Manually specify some creg type sizes, where they diverge between GCC…

### DIFF
--- a/rts/System/creg/TypeDeduction.h
+++ b/rts/System/creg/TypeDeduction.h
@@ -153,6 +153,7 @@ class DynamicArrayType : public DynamicArrayBaseType
 public:
 	typedef typename VectorT::value_type ElemT;
 
+	DynamicArrayType(size_t sizeOverride) : DynamicArrayBaseType(DeduceType<ElemT>::Get(), sizeOverride) {}
 	DynamicArrayType() : DynamicArrayBaseType(DeduceType<ElemT>::Get(), sizeof(VectorT)) {}
 	~DynamicArrayType() {}
 
@@ -196,6 +197,7 @@ class BitArrayType : public DynamicArrayBaseType
 public:
 	typedef typename T::value_type ElemT;
 
+	BitArrayType(size_t sizeOverride) : DynamicArrayBaseType(DeduceType<ElemT>::Get(), sizeOverride) { }
 	BitArrayType() : DynamicArrayBaseType(DeduceType<ElemT>::Get(), sizeof(T)) { }
 	~BitArrayType() { }
 
@@ -226,8 +228,12 @@ public:
 template<>
 struct DeduceType<std::vector<bool>> {
 	static std::unique_ptr<IType> Get() {
-		return std::unique_ptr<IType>(new BitArrayType<std::vector<bool> >());
+		#ifndef _MSC_VER
+		static_assert(sizeof(std::vector<bool>) == GCC_VECTOR_BOOL_SIZE);
+		#endif
+		return std::unique_ptr<IType>(new BitArrayType<std::vector<bool>>(GCC_VECTOR_BOOL_SIZE));
 	}
+	static constexpr size_t GCC_VECTOR_BOOL_SIZE = 40;
 };
 
 // String type

--- a/rts/System/creg/VarTypes.h
+++ b/rts/System/creg/VarTypes.h
@@ -26,8 +26,15 @@ namespace creg
 	class StringType : public DynamicArrayType<std::string>
 	{
 	public:
-		StringType() { }
+		StringType()
+			: DynamicArrayType<std::string>(GCC_STRING_SIZE)
+		{
+			#ifndef _MSC_VER
+			static_assert(sizeof(std::string) == GCC_STRING_SIZE);
+			#endif
+		}
 		std::string GetName() const;
+		static constexpr size_t GCC_STRING_SIZE = 32;
 	};
 
 }

--- a/rts/System/creg/creg.cpp
+++ b/rts/System/creg/creg.cpp
@@ -13,6 +13,7 @@
 #include "System/UnorderedMap.hpp"
 #include "System/StringUtil.h"
 #include "System/Sync/HsiehHash.h"
+#include "System/Log/ILog.h"
 
 
 using namespace creg;
@@ -222,6 +223,10 @@ void Class::DeleteInstance(void* inst)
 void Class::CalculateChecksum(unsigned int& checksum)
 {
 	for (Member& m: members) {
+		if (m.type->GetName() == "ignored")
+			continue;
+
+		//LOG("[Class::CalculateChecksum] name=%s cs=%i, flg=%i size=%i", m.name, checksum, m.flags, int(m.type->GetSize()));
 		checksum += m.flags;
 		checksum = HsiehHash(m.name, strlen(m.name), checksum);
 		checksum = HsiehHash(m.type->GetName().data(), m.type->GetName().size(), checksum);


### PR DESCRIPTION
… and MSVC. Also ignore CR_IGNORE fields when making  Class::CalculateChecksum()