### PR TITLE
Partial (non-AI) fixes for https://github.com/beyond-all-reason/spring/issues/601

### DIFF
--- a/rts/Map/ReadMap.cpp
+++ b/rts/Map/ReadMap.cpp
@@ -192,9 +192,6 @@ void CReadMap::Serialize(creg::ISerializer* s)
 	SerializeMapChangesBeforeMatch(s);
 	SerializeMapChangesDuringMatch(s);
 	SerializeTypeMap(s);
-
-	if (!s->IsWriting())
-		mapDamage->RecalcArea(0, mapDims.mapx, 0, mapDims.mapy);
 }
 
 void CReadMap::SerializeMapChangesBeforeMatch(creg::ISerializer* s)
@@ -413,7 +410,7 @@ void CReadMap::Initialize()
 
 	// not callable here because losHandler is still uninitialized, deferred to Game::PostLoadSim
 	// InitHeightMapDigestVectors();
-	UpdateHeightMapSynced({0, 0, mapDims.mapx, mapDims.mapy}, true);
+	UpdateHeightMapSynced({0, 0, mapDims.mapx, mapDims.mapy});
 
 	// FIXME: sky & skyLight aren't created yet (crashes in SMFReadMap.cpp)
 	// UpdateDraw(true);
@@ -494,7 +491,7 @@ void CReadMap::UpdateDraw(bool firstCall)
 		return;
 
 	//optimize layout
-	unsyncedHeightMapUpdates.Process();
+	unsyncedHeightMapUpdates.Process(firstCall);
 
 	const int N = static_cast<int>(std::min(MAX_UHM_RECTS_PER_FRAME, unsyncedHeightMapUpdates.size()));
 
@@ -512,8 +509,10 @@ void CReadMap::UpdateDraw(bool firstCall)
 }
 
 
-void CReadMap::UpdateHeightMapSynced(const SRectangle& hgtMapRect, bool initialize)
+void CReadMap::UpdateHeightMapSynced(const SRectangle& hgtMapRect)
 {
+	const bool initialize = (hgtMapRect == SRectangle{ 0, 0, mapDims.mapx, mapDims.mapy });
+
 	const int2 mins = {hgtMapRect.x1 - 1, hgtMapRect.z1 - 1};
 	const int2 maxs = {hgtMapRect.x2 + 1, hgtMapRect.z2 + 1};
 

--- a/rts/Map/ReadMap.h
+++ b/rts/Map/ReadMap.h
@@ -101,7 +101,7 @@ public:
 	 * calculates derived heightmap information
 	 * such as normals, centerheightmap and slopemap
 	 */
-	void UpdateHeightMapSynced(const SRectangle& hgtMapRect, bool initialize = false);
+	void UpdateHeightMapSynced(const SRectangle& hgtMapRect);
 	void UpdateLOS(const SRectangle& hgtMapRect);
 	void BecomeSpectator();
 	void UpdateDraw(bool firstCall);

--- a/rts/Rendering/Env/BumpWater.cpp
+++ b/rts/Rendering/Env/BumpWater.cpp
@@ -612,7 +612,7 @@ void CBumpWater::UnsyncedHeightMapUpdate(const SRectangle& rect)
 void CBumpWater::UploadCoastline(const bool forceFull)
 {
 	// optimize update area (merge overlapping areas etc.)
-	heightmapUpdates.Process();
+	heightmapUpdates.Process(forceFull);
 
 	// limit the to be updated areas
 	unsigned int currentPixels = 0;

--- a/rts/System/Misc/RectangleOverlapHandler.cpp
+++ b/rts/System/Misc/RectangleOverlapHandler.cpp
@@ -36,7 +36,7 @@ size_t CRectangleOverlapHandler::GetTotalArea() const
 }
 
 
-void CRectangleOverlapHandler::Process()
+void CRectangleOverlapHandler::Process(bool noSplit)
 {
 	if (!needsUpdate)
 		return;
@@ -44,14 +44,28 @@ void CRectangleOverlapHandler::Process()
 	// FIXME: any rectangles left from the last update will be counted twice
 	statsTotalSize += GetTotalArea();
 
+	StageDedup();
 	StageMerge();
 	StageOverlap();
 	StageMerge();
-	StageSplitTooLarge();
+	if (!noSplit)
+		StageSplitTooLarge();
 
 	statsOptimSize += GetTotalArea();
 
 	needsUpdate = false;
+}
+
+void CRectangleOverlapHandler::StageDedup()
+{
+	for (size_t i = frontIdx, n = rectangles.size(); i < n; i++) {
+		for (size_t j = i + 1; j < n; j++) {
+			if (rectangles[i] == rectangles[j]) {
+				rectangles[j] = {};
+			}
+		}
+	}
+	RemoveEmptyRects();
 }
 
 void CRectangleOverlapHandler::StageMerge()

--- a/rts/System/Misc/RectangleOverlapHandler.h
+++ b/rts/System/Misc/RectangleOverlapHandler.h
@@ -23,7 +23,7 @@ public:
 	CRectangleOverlapHandler() { clear(); }
 	~CRectangleOverlapHandler();
 
-	void Process();
+	void Process(bool noSplit);
 
 	size_t GetTotalArea() const;
 
@@ -87,6 +87,7 @@ public:
 	iterator end() { return (rectangles.end()); }
 
 private:
+	void StageDedup();
 	void StageMerge();
 	void StageOverlap();
 	void StageSplitTooLarge();

--- a/rts/System/Rectangle.h
+++ b/rts/System/Rectangle.h
@@ -66,6 +66,10 @@ struct SRectangle {
 		return (x1 < other.x1);
 	}
 
+	bool operator == (const SRectangle& other) const {
+		return x1 == other.x1 && z1 == other.z1 && x2 == other.x2 && z2 == other.z2;
+	}
+
 	template<typename T>
 	SRectangle operator* (const T v) const {
 		return SRectangle(


### PR DESCRIPTION
1) Do not run "mapDamage->RecalcArea(0, mapDims.mapx, 0, mapDims.mapy);" twice during the load

2) mapDamage->RecalcArea() run for a full map is no longer split in sub-rectangles and run with no pacing instead. This removes lags upon loading of a savegame for first N synced frames.
Respectively CReadMap::UpdateHeightMapSynced() lost "bool initialize" parameter, which instead is recreated based on the hgtMapRect coordinates

3) CRectangleOverlapHandler got new StageDedup() which removes duplicated rectangles

4) CRectangleOverlapHandler::StageSplitTooLarge() can now be turned off with CRectangleOverlapHandler::Process(bool noSplit = true), useful if splitting makes no sense (like in case of full map-wide update)