### PR TITLE
Bar105 tk smooth out pathing updates

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -464,6 +464,7 @@ void CGame::Load(const std::string& mapFileName)
 			}
 			LEAVE_SYNCED_CODE();
 		}
+		// Update height bounds and pathing after pregame or a saved game load.
 		{
 			ENTER_SYNCED_CODE();
 			//needed in case pre-game terraform changed the map

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -462,7 +462,10 @@ void CGame::Load(const std::string& mapFileName)
 				eventHandler.CollectGarbage(true);
 				Watchdog::ClearTimer(WDT_LOAD);
 			}
-
+			LEAVE_SYNCED_CODE();
+		}
+		{
+			ENTER_SYNCED_CODE();
 			//needed in case pre-game terraform changed the map
 			readMap->UpdateHeightBounds();
 			Watchdog::ClearTimer(WDT_LOAD);

--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -1166,7 +1166,8 @@ CGameHelper::BuildSquareStatus CGameHelper::TestUnitBuildSquare(
 	std::vector<float3>* canbuildpos,
 	std::vector<float3>* featurepos,
 	std::vector<float3>* nobuildpos,
-	const std::vector<Command>* commands
+	const std::vector<Command>* commands,
+	int threadOwner
 ) {
 	feature = nullptr;
 
@@ -1182,7 +1183,6 @@ CGameHelper::BuildSquareStatus CGameHelper::TestUnitBuildSquare(
 	const int2 zrange = int2(z1, z2);
 
 	const MoveDef* moveDef = (buildInfo.def->pathType != -1U) ? moveDefHandler.GetMoveDefByPathType(buildInfo.def->pathType) : nullptr;
-	/*const S3DModel* model =*/ buildInfo.def->LoadModel();
 
 	// const float buildHeight = GetBuildHeight(testPos, buildInfo.def, synced);
 	// const float modelHeight = (model != nullptr) ? math::fabs(model->height) : 10.0f;
@@ -1195,6 +1195,7 @@ CGameHelper::BuildSquareStatus CGameHelper::TestUnitBuildSquare(
 		testStatus = BUILDSQUARE_BLOCKED;
 
 		QuadFieldQuery qfQuery;
+		qfQuery.threadOwner = threadOwner;
 		quadField.GetFeaturesExact(qfQuery, testPos, std::max(xsize, zsize) * 6);
 
 		const int mindx = xsize * (SQUARE_SIZE >> 1) - (SQUARE_SIZE >> 1);

--- a/rts/Game/GameHelper.h
+++ b/rts/Game/GameHelper.h
@@ -114,7 +114,8 @@ public:
 		std::vector<float3>* canbuildpos = nullptr,
 		std::vector<float3>* featurepos = nullptr,
 		std::vector<float3>* nobuildpos = nullptr,
-		const std::vector<Command>* commands = nullptr
+		const std::vector<Command>* commands = nullptr,
+		int threadOwner = 0
 	);
 	static float GetBuildHeight(const float3& pos, const UnitDef* unitdef, bool synced = true);
 	static Command GetBuildCommand(const float3& pos, const float3& dir);

--- a/rts/Game/GameSetup.cpp
+++ b/rts/Game/GameSetup.cpp
@@ -599,7 +599,7 @@ bool CGameSetup::Init(const std::string& buf)
 	file.GetDef(ghostedBuildings,    "1", "GAME\\ModOptions\\GhostedBuildings");
 
 	file.GetDef(maxSpeed, "20.", "GAME\\ModOptions\\MaxSpeed");
-	file.GetDef(minSpeed, "0.3", "GAME\\ModOptions\\MinSpeed");
+	file.GetDef(minSpeed, "0.1", "GAME\\ModOptions\\MinSpeed");
 
 	file.GetDef(fixedAllies, "1", "GAME\\ModOptions\\FixedAllies");
 

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -108,6 +108,7 @@ void CModInfo::ResetState()
 		pathFinderSystem = NOPFS_TYPE;
 		pfRawDistMult    = 1.25f;
 		pfUpdateRate     = 0.007f;
+		pfUpdateRateScale = 1.f;
 		pfForceSingleThreaded = false;
 		pfForceUpdateSingleThreaded = false;
 
@@ -152,6 +153,7 @@ void CModInfo::Init(const std::string& modFileName)
 		pathFinderSystem = Clamp(system.GetInt("pathFinderSystem", HAPFS_TYPE), int(NOPFS_TYPE), int(PFS_TYPE_MAX));
 		pfRawDistMult = system.GetFloat("pathFinderRawDistMult", pfRawDistMult);
 		pfUpdateRate = system.GetFloat("pathFinderUpdateRate", pfUpdateRate);
+		pfUpdateRateScale = system.GetFloat("pathFinderUpdateRateScale", pfUpdateRateScale);
 		pfForceSingleThreaded = system.GetBool("pfForceSingleThreaded", pfForceSingleThreaded);
 		pfForceUpdateSingleThreaded = system.GetBool("pfForceUpdateSingleThreaded", pfForceUpdateSingleThreaded);
 

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -192,7 +192,8 @@ public:
 	bool pfForceUpdateSingleThreaded;
 
 	float pfRawDistMult;
-	float pfUpdateRate;
+	float pfUpdateRate; // remove if Default PFS gets replaced/removed.
+	float pfUpdateRateScale;
 
 	bool enableSmoothMesh;
 

--- a/rts/Sim/Path/Default/PathDataTypes.h
+++ b/rts/Sim/Path/Default/PathDataTypes.h
@@ -86,6 +86,7 @@ struct PathNodeStateBuffer {
 		gCost = std::move(pnsb.gCost);
 
 		nodeMask = std::move(pnsb.nodeMask);
+		nodeLinksObsoleteFlags = std::move(pnsb.nodeLinksObsoleteFlags);
 		peNodeOffsets = std::move(pnsb.peNodeOffsets);
 
 		extraCosts[ true] = std::move(pnsb.extraCosts[ true]);
@@ -121,6 +122,7 @@ struct PathNodeStateBuffer {
 		fCost.resize(br.x * br.y, PATHCOST_INFINITY);
 		gCost.resize(br.x * br.y, PATHCOST_INFINITY);
 		nodeMask.resize(br.x * br.y, 0);
+		nodeLinksObsoleteFlags.resize(br.x * br.y, 0);
 
 		// created on-demand
 		// extraCosts[ true].resize(br.x * br.y, 0.0f);
@@ -138,6 +140,7 @@ struct PathNodeStateBuffer {
 		gCost.clear();
 
 		nodeMask.clear();
+		nodeLinksObsoleteFlags.clear();
 		peNodeOffsets.clear();
 
 		extraCosts[ true].clear();
@@ -174,6 +177,7 @@ struct PathNodeStateBuffer {
 			memFootPrint += (peNodeOffsets.size() * (sizeof(std::vector<short2>) + peNodeOffsets[0].size() * sizeof(short2)));
 
 		memFootPrint += (nodeMask.size() * sizeof(std::uint8_t));
+		memFootPrint += (nodeLinksObsoleteFlags.size() * sizeof(std::uint8_t));
 		memFootPrint += ((fCost.size() + gCost.size()) * sizeof(float));
 		memFootPrint += ((extraCosts[true].size() + extraCosts[false].size()) * sizeof(float));
 
@@ -227,6 +231,9 @@ public:
 
 	/// bitmask of PATHOPT_{OPEN, ..., OBSOLETE} flags
 	std::vector<std::uint8_t> nodeMask;
+
+	/// Flag certain node directions as obsolete
+	std::vector<std::uint8_t> nodeLinksObsoleteFlags;
 
 	/// for the PE, maintains an array of the best accessible
 	/// offset (from a block's center position) per path-type

--- a/rts/Sim/Path/TKPFS/PathConstants.h
+++ b/rts/Sim/Path/TKPFS/PathConstants.h
@@ -62,6 +62,8 @@ static constexpr unsigned int PATHDIR_RIGHT_DOWN_MASK = 0x20; // -x-z
 static constexpr unsigned int PATHDIR_DOWN_MASK       = 0x40; // -z (DOWN *TO* UP)
 static constexpr unsigned int PATHDIR_LEFT_DOWN_MASK  = 0x80; // +x-z
 static constexpr unsigned int PATH_DIRECTIONS_MASK    = 0xff;
+
+// This mask covers the 4 directions used by path block updates.
 static constexpr unsigned int PATH_DIRECTIONS_HALF_MASK = 0x0f;
 
 

--- a/rts/Sim/Path/TKPFS/PathConstants.h
+++ b/rts/Sim/Path/TKPFS/PathConstants.h
@@ -63,7 +63,11 @@ static constexpr unsigned int PATHDIR_DOWN_MASK       = 0x40; // -z (DOWN *TO* U
 static constexpr unsigned int PATHDIR_LEFT_DOWN_MASK  = 0x80; // +x-z
 static constexpr unsigned int PATH_DIRECTIONS_MASK    = 0xff;
 
-// This mask covers the 4 directions used by path block updates.
+// see GetBlockVertexOffset(); costs are bi-directional and only
+// calculated for *half* the outgoing edges (while costs for the
+// other four directions are stored at the adjacent vertices)
+// This mask covers the four outgoing edges any given block will
+// update during block vertex cost calculations.
 static constexpr unsigned int PATH_DIRECTIONS_HALF_MASK = 0x0f;
 
 

--- a/rts/Sim/Path/TKPFS/PathConstants.h
+++ b/rts/Sim/Path/TKPFS/PathConstants.h
@@ -52,6 +52,19 @@ static constexpr unsigned int PATHDIR_LEFT_DOWN  = 7; // +x-z
 static constexpr unsigned int PATH_DIRECTIONS    = 8;
 
 
+// Directional flags for direction masking
+static constexpr unsigned int PATHDIR_LEFT_MASK       = 0x01; // +x (LEFT *TO* RIGHT)
+static constexpr unsigned int PATHDIR_LEFT_UP_MASK    = 0x02; // +x+z
+static constexpr unsigned int PATHDIR_UP_MASK         = 0x04; // +z (UP *TO* DOWN)
+static constexpr unsigned int PATHDIR_RIGHT_UP_MASK   = 0x08; // -x+z
+static constexpr unsigned int PATHDIR_RIGHT_MASK      = 0x10; // -x (RIGHT *TO* LEFT)
+static constexpr unsigned int PATHDIR_RIGHT_DOWN_MASK = 0x20; // -x-z
+static constexpr unsigned int PATHDIR_DOWN_MASK       = 0x40; // -z (DOWN *TO* UP)
+static constexpr unsigned int PATHDIR_LEFT_DOWN_MASK  = 0x80; // +x-z
+static constexpr unsigned int PATH_DIRECTIONS_MASK    = 0xff;
+static constexpr unsigned int PATH_DIRECTIONS_HALF_MASK = 0x0f;
+
+
 static constexpr unsigned int PATHDIR_CARDINALS[4] = {PATHDIR_LEFT, PATHDIR_RIGHT, PATHDIR_UP, PATHDIR_DOWN};
 static constexpr unsigned int PATH_DIRECTION_VERTICES = PATH_DIRECTIONS >> 1;
 static constexpr unsigned int PATH_NODE_SPACING = 2;

--- a/rts/Sim/Path/TKPFS/PathManager.cpp
+++ b/rts/Sim/Path/TKPFS/PathManager.cpp
@@ -79,8 +79,6 @@ CPathManager::CPathManager()
 
 void CPathManager::InitStatic()
 {
-	assert(ThreadPool::GetNumThreads() != 1);
-
 	pathFinderGroups = ThreadPool::GetNumThreads();
 
 	LOG("TK CPathManager::InitStatic: %d threads available (MT requests=%d, MT updates=%d)", pathFinderGroups, SupportsMultiThreadedRequests(), !modInfo.pfForceUpdateSingleThreaded);

--- a/rts/Sim/Path/TKPFS/PathManager.cpp
+++ b/rts/Sim/Path/TKPFS/PathManager.cpp
@@ -793,8 +793,31 @@ void CPathManager::Update()
 	auto medResPE = &pathingStates[PATH_MED_RES];
 	auto lowResPE = &pathingStates[PATH_LOW_RES];
 
-	medResPE->Update();
-	lowResPE->Update();
+	if (gs->frameNum >= frameNumToRefreshPathStateWorkloadRatio) {
+		const auto medResUpdatesCount = std::max(0.01f, float(medResPE->getCountOfUpdates()));
+		const auto lowResUpdatesCount = std::max(0.01f, float(lowResPE->getCountOfUpdates()));
+		const auto ratio = medResUpdatesCount / lowResUpdatesCount;
+
+		if (ratio < 1.f) {
+			highPriorityResPS = lowResPE;
+			lowPriorityResPS = medResPE;
+			pathStateWorkloadRatio = Clamp(int(1.f/ratio + .5f)+1, 1, GAME_SPEED+1);
+		} else {
+			highPriorityResPS = medResPE;
+			lowPriorityResPS = lowResPE;
+			pathStateWorkloadRatio = Clamp(int(ratio + .5f)+1, 1, GAME_SPEED+1);
+		}
+
+		// LOG("PATH medResUpdatesCount=%f lowResUpdatesCount=%f ratio=%f pathStateWorkloadRatio=%d"
+		// 		, medResUpdatesCount, lowResUpdatesCount, ratio, pathStateWorkloadRatio);
+
+		frameNumToRefreshPathStateWorkloadRatio = gs->frameNum + GAME_SPEED;
+	}
+
+	if (gs->frameNum % pathStateWorkloadRatio)
+		highPriorityResPS->Update();
+	else
+		lowPriorityResPS->Update();
 }
 
 // used to deposit heat on the heat-map as a unit moves along its path

--- a/rts/Sim/Path/TKPFS/PathManager.cpp
+++ b/rts/Sim/Path/TKPFS/PathManager.cpp
@@ -777,12 +777,6 @@ void CPathManager::TerrainChange(unsigned int x1, unsigned int z1, unsigned int 
 	auto lowResPE = &pathingStates[PATH_LOW_RES];
 
 	medResPE->MapChanged(x1, z1, x2, z2);
-
-	// low-res PE will be informed via (medRes)PE::Update
-	// if (true && medResPE->nextPathEstimator != nullptr)
-	if (medResPE->nextPathState != nullptr)
-		return;
-
 	lowResPE->MapChanged(x1, z1, x2, z2);
 }
 

--- a/rts/Sim/Path/TKPFS/PathManager.h
+++ b/rts/Sim/Path/TKPFS/PathManager.h
@@ -261,8 +261,13 @@ private:
 
 	unsigned int nextPathID;
 
+	std::int32_t frameNumToRefreshPathStateWorkloadRatio = 0;
+	std::uint32_t pathStateWorkloadRatio = 0;
+
 	int pathFinderGroups = 0;
 
+	PathingState* highPriorityResPS;
+	PathingState* lowPriorityResPS;
 	CPathEstimator* medResPEs;
 	CPathEstimator* lowResPEs;
 	CPathFinder* maxResPFs;

--- a/rts/Sim/Path/TKPFS/PathingState.cpp
+++ b/rts/Sim/Path/TKPFS/PathingState.cpp
@@ -643,13 +643,14 @@ void PathingState::Update()
 	// determine how many blocks we should update
 	int blocksToUpdate = 0;
 	{
-		const int progressiveUpdates = updatedBlocks.size() * (1.f / (BLOCKS_TO_UPDATE<<2)); // * numMoveDefs * modInfo.pfUpdateRate;
+		const int progressiveUpdates = updatedBlocks.size() * (1.f / (BLOCKS_TO_UPDATE<<2)) * modInfo.pfUpdateRateScale;
 		const int MIN_BLOCKS_TO_UPDATE = 1;
 		const int MAX_BLOCKS_TO_UPDATE = std::max<int>(BLOCKS_TO_UPDATE >> 1, MIN_BLOCKS_TO_UPDATE);
 
-		blocksToUpdate = Clamp(progressiveUpdates, MIN_BLOCKS_TO_UPDATE, MAX_BLOCKS_TO_UPDATE) * numMoveDefs;// * rateAdjust(progressiveUpdates);
+		blocksToUpdate = Clamp(progressiveUpdates, MIN_BLOCKS_TO_UPDATE, MAX_BLOCKS_TO_UPDATE) * numMoveDefs;
 	
-		// LOG("[%d] blocksToUpdate=%d progressiveUpdates=%d", BLOCK_SIZE, blocksToUpdate, progressiveUpdates);
+		// LOG("[%d] blocksToUpdate=%d progressiveUpdates=%d [%f]"
+		// 		, BLOCK_SIZE, blocksToUpdate, progressiveUpdates, modInfo.pfUpdateRateScale);
 	}
 
 	//LOG("PathingState::Update blocksToUpdate %d", blocksToUpdate);

--- a/rts/Sim/Path/TKPFS/PathingState.cpp
+++ b/rts/Sim/Path/TKPFS/PathingState.cpp
@@ -703,14 +703,6 @@ void PathingState::UpdateVertexPathCosts(int blocksToUpdate)
 			//LOG("TK PathingState::Update: moveDef = %d %p (%p)", consumedBlocks.size(), &consumedBlocks.back(), consumedBlocks.back().moveDef);
 		}
 
-		// inform dependent estimator that costs were updated and it should do the same
-		// FIXME?
-		//   adjacent med-res PE blocks will cause a low-res block to be updated twice
-		//   (in addition to the overlap that already exists because MapChanged() adds
-		//   boundary blocks)
-		if (true && nextPathState != nullptr)
-			nextPathState->MapChanged(pos.x * BLOCK_SIZE, pos.y * BLOCK_SIZE, pos.x * BLOCK_SIZE, pos.y * BLOCK_SIZE);
-
 		updatedBlocks.pop_front(); // must happen _after_ last usage of the `pos` reference!
 		blockStates.nodeMask[idx] &= ~PATHOPT_OBSOLETE;
 	}
@@ -884,7 +876,7 @@ void PathingState::AddCache(const IPath::Path* path, const IPath::SearchResult r
 
 void PathingState::AddPathForCurrentFrame(const IPath::Path* path, const IPath::SearchResult result, const int2 strtBlock, const int2 goalBlock, float goalRadius, int pathType, const bool synced)
 {
-	const std::lock_guard<std::mutex> lock(cacheAccessLock);
+	//const std::lock_guard<std::mutex> lock(cacheAccessLock);
 	//pathCache[synced]->AddPathForCurrentFrame(path, result, strtBlock, goalBlock, goalRadius, pathType);
 }
 

--- a/rts/Sim/Path/TKPFS/PathingState.cpp
+++ b/rts/Sim/Path/TKPFS/PathingState.cpp
@@ -637,26 +637,19 @@ void PathingState::Update()
 	if (numMoveDefs == 0)
 		return;
 
-	// determine how many blocks we should update
-	int blocksToUpdate = 0;
 	if (updatedBlocks.empty())
 		return;
 
+	// determine how many blocks we should update
+	int blocksToUpdate = 0;
 	{
-		auto rateAdjust{ [this](int progressiveUpdates){
-				if ((BLOCK_SIZE == 32) && (progressiveUpdates <= BLOCKS_TO_UPDATE<<3))
-					return int((gs->frameNum % 2) == 1);
-
-				return 1;
-			}
-		};
-
-		const float scaleMultiplier = 1.f - (float(BLOCK_SIZE == 32)*.5f);
-		const int progressiveUpdates = updatedBlocks.size() * (1.f / (BLOCKS_TO_UPDATE<<3)) * scaleMultiplier; // * numMoveDefs * modInfo.pfUpdateRate;
-		const int MIN_BLOCKS_TO_UPDATE = 1; //std::max<int>(BLOCKS_TO_UPDATE >> 4, 1U);
+		const int progressiveUpdates = updatedBlocks.size() * (1.f / (BLOCKS_TO_UPDATE<<2)); // * numMoveDefs * modInfo.pfUpdateRate;
+		const int MIN_BLOCKS_TO_UPDATE = 1;
 		const int MAX_BLOCKS_TO_UPDATE = std::max<int>(BLOCKS_TO_UPDATE >> 1, MIN_BLOCKS_TO_UPDATE);
 
-		blocksToUpdate = Clamp(progressiveUpdates, MIN_BLOCKS_TO_UPDATE, MAX_BLOCKS_TO_UPDATE) * numMoveDefs * rateAdjust(progressiveUpdates);
+		blocksToUpdate = Clamp(progressiveUpdates, MIN_BLOCKS_TO_UPDATE, MAX_BLOCKS_TO_UPDATE) * numMoveDefs;// * rateAdjust(progressiveUpdates);
+	
+		// LOG("[%d] blocksToUpdate=%d progressiveUpdates=%d", BLOCK_SIZE, blocksToUpdate, progressiveUpdates);
 	}
 
 	//LOG("PathingState::Update blocksToUpdate %d", blocksToUpdate);

--- a/rts/Sim/Path/TKPFS/PathingState.h
+++ b/rts/Sim/Path/TKPFS/PathingState.h
@@ -171,9 +171,7 @@ private:
     int2 mapDimensionsInBlocks = {0, 0};
 	int2 nbrOfBlocks;
 
-    //IPathFinder* pathFinders = nullptr;
     std::vector<IPathFinder*> pathFinders; // InitEstimator helpers
-    //std::vector<spring::thread> threads;
 
     std::vector<float> maxSpeedMods;
     std::vector<float> vertexCosts;
@@ -189,9 +187,6 @@ private:
 
     std::vector<SingleBlock> consumedBlocks;
 	std::vector<SOffsetBlock> offsetBlocksSortedByCost;
-
-	// int updatedBlocksDelayTimeout = (-1);
-	// bool updatedBlocksDelayActive = false;
 };
 
 }

--- a/rts/Sim/Path/TKPFS/PathingState.h
+++ b/rts/Sim/Path/TKPFS/PathingState.h
@@ -141,6 +141,8 @@ private:
 	bool ReadFile(const std::string& peFileName, const std::string& mapFileName);
 	bool WriteFile(const std::string& peFileName, const std::string& mapFileName);
 
+	std::size_t getCountOfUpdates() const { return updatedBlocks.size(); }
+
 private:
 	friend class TKPFS::CPathEstimator;
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -326,10 +326,12 @@ bool CWeapon::CheckAimingAngle() const
 
 
 bool CWeapon::CanCallAimingScript(bool validAngle) const {
-	bool ret = (gs->frameNum >= (lastAimedFrame + reaimTime));
+	constexpr float maxAimOffset = 0.93969262078590838405410927732473; // math::cos(20.0f * math::DEG_TO_RAD);
+
+	bool ret = (gs->frameNum >= (lastAimedFrame + reaimTime));math::cos(20.0f * math::DEG_TO_RAD);
 
 	ret |= (wantedDir.dot(lastRequestedDir) <= weaponDef->maxFireAngle);
-	ret |= (wantedDir.dot(lastRequestedDir) <= math::cos(20.0f * math::DEG_TO_RAD));
+	ret |= (wantedDir.dot(lastRequestedDir) <= maxAimOffset);
 
 	// NOTE: angleGood checks unit/maindir, not the weapon's current dir
 	// ret |= (!validAngle);


### PR DESCRIPTION
Few vertex re-calculations are done each frame to reduce the impact on a running game. However, evening at maximum settings, the code was not able to keep up with a game with several players. This impacted the ability of the path finder to find optimal or possible routes. It double expensive if the path system fails to find a route at a lower res because 1) it has to try more blocks just in case it can reach, and 2) it fails back to other level to find a route, which is effectively another path search in cost.

Increasing the rate at which low-res pathing information is recalculated fixes these problems, but also increases CPU stress. To mitigate this: 1) I've have prevented the updater from adding blocks to the update list that really don't need an update - the original code played it safe and added everything that could possibly be affected. 2) made the updater identify the links between blocks that need to updated rather than assume all should be - each block with try to recalculate 4 directional routes by default, even if only one was impacted by a map change. 3) I have set up the path manager to allow only one of the lower-res data sets to be updated on any particular frame (which it balances based on the amount of outstanding work remaining in each data set)

The update rate is also adjusted based on workload. For example, if the entire map is changed, then the pathing system will update vertex calculations at a higher rate, gradually slowing down as the work load eases. In Plains and Forests map, the old system could take 10 minutes to get through the backlog caused by the trees at the start of the match (the best it could do was about 7 and half minutes via configuration in modrules.) With this change, it took about 22 seconds on default settings.