### PR TITLE
Piece projectiles collide with units again

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -156,6 +156,7 @@ UI:
  - Add GetScanSymbol(int scanCode)
 
 Fixes:
+ - Fix piece projectiles (flying parts from dead units) not colliding with units
  - Fix KeyChains not being respected for GuiHandler actions and allow games to
    handle them with new actions argument on KeyPress/KeyRelease
  - openAL-soft/SDL audio bugfix: finally making dynamic audio device changes, 

--- a/rts/Sim/Projectiles/ProjectileHandler.cpp
+++ b/rts/Sim/Projectiles/ProjectileHandler.cpp
@@ -371,7 +371,7 @@ static bool CheckProjectileCollisionFlags(const CProjectile* p, const CUnit* u)
 
 	// only weapon-projectiles can have non-zero flags
 	if (collFlags == 0)
-		return false;
+		return true;
 
 	// disregard everything else when this bit is set
 	// (ground and feature flags are tested elsewhere)


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/beyond-all-reason/spring/commit/83e08eeb5f05bbf936d75804d0a531ef0052c601 (104.0.1-1182)

Non-weapon projectiles, which includes piece projectiles (explosive shards flying from dying units), have 0 flags. So before that commit they just skipped all the conditions and went to the 'true' at the end of the function. After that commit they short-circuit to 'false'. This means they only collide with features and ground (which are handled in other functions).