### PR TITLE
Allow simualtion to work harder to catch up.

### DIFF
--- a/rts/Game/GlobalUnsynced.h
+++ b/rts/Game/GlobalUnsynced.h
@@ -48,8 +48,10 @@ public:
 	 * i.e. it means that 5% of the total
 	 * cpu time is spend for drawing and 95%
 	 * for reconnecting/simulation.
+	 * Note: this isn't necessary because the
+	 * engine enforces minDrawFPS.
 	 */
-	static constexpr float reconnectSimDrawBalance = 0.05f;
+	static constexpr float reconnectSimDrawBalance = 0.00f;
 
 	/**
 	 * @brief simulation frames per second

--- a/rts/Game/GlobalUnsynced.h
+++ b/rts/Game/GlobalUnsynced.h
@@ -45,11 +45,11 @@ public:
 	 * for simulation is minimum spend for
 	 * drawing.
 	 * This is important when reconnecting,
-	 * i.e. it means that 15% of the total
-	 * cpu time is spend for drawing and 85%
+	 * i.e. it means that 5% of the total
+	 * cpu time is spend for drawing and 95%
 	 * for reconnecting/simulation.
 	 */
-	static constexpr float reconnectSimDrawBalance = 0.15f;
+	static constexpr float reconnectSimDrawBalance = 0.05f;
 
 	/**
 	 * @brief simulation frames per second

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -76,12 +76,7 @@ void CGame::SendClientProcUsage()
 
 		if (playing) {
 			const float simProcUsage = (profiler.GetTimePercentage("Sim"));
-
-			// Only consider the draw time for the minimum frames if it exceeds the amount already
-			// forcibly allocated by GetNetMessageProcessingTimeLimit();
-			const float minDrawUsage = (profiler.GetTimePercentage("Draw") / std::max(1.0f, globalRendering->FPS)) * CGlobalUnsynced::minDrawFPS;
-			const float drawProcUsage = std::max(0.f, minDrawUsage - CGlobalUnsynced::reconnectSimDrawBalance);
-
+			const float drawProcUsage = (profiler.GetTimePercentage("Draw") / std::max(1.0f, globalRendering->FPS)) * CGlobalUnsynced::minDrawFPS;
 			const float totalProcUsage = simProcUsage + drawProcUsage;
 
 			// take the minimum drawframes into account, too

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -76,7 +76,12 @@ void CGame::SendClientProcUsage()
 
 		if (playing) {
 			const float simProcUsage = (profiler.GetTimePercentage("Sim"));
-			const float drawProcUsage = (profiler.GetTimePercentage("Draw") / std::max(1.0f, globalRendering->FPS)) * CGlobalUnsynced::minDrawFPS;
+
+			// Only consider the draw time for the minimum frames if it exceeds the amount already
+			// forcibly allocated by GetNetMessageProcessingTimeLimit();
+			const float minDrawUsage = (profiler.GetTimePercentage("Draw") / std::max(1.0f, globalRendering->FPS)) * CGlobalUnsynced::minDrawFPS;
+			const float drawProcUsage = std::max(0.f, minDrawUsage - CGlobalUnsynced::reconnectSimDrawBalance);
+
 			const float totalProcUsage = simProcUsage + drawProcUsage;
 
 			// take the minimum drawframes into account, too


### PR DESCRIPTION
~~There is a certain amount of CPU% always allocated to drawing. If 2 draw frames is the minimum, only the time needed in excess of the forced draw CPU% needs to be considered for adjusting the sim speed.~~ I realize it is needed because it represents the minimum about of work to be done and as min draw time (2 frames) grows then the ability to accurately assess the simulation load is reduced. However, we can put in a change to allow catch up to work harder. It won't stop the min 2 frames, but will allow sim to use upto 100% CPU rather than stop at 85%.