### PR TITLE
Update luaconf.h

### DIFF
--- a/rts/lib/lua/include/luaconf.h
+++ b/rts/lib/lua/include/luaconf.h
@@ -208,7 +208,7 @@
 @* of a function in debug information.
 ** CHANGE it if you want a different size.
 */
-#define LUA_IDSIZE	60
+#define LUA_IDSIZE	200
 
 
 /*


### PR DESCRIPTION
Fix truncation on long path names

I have long been irritated by filenames and other things being truncated in infolog. I'm assuming I'm not the only one. Could this be increased to something like 200 or so to make truncation exceedingly rare?