### PR TITLE
chore(site): Add glossary

### DIFF
--- a/doc/site/Gemfile
+++ b/doc/site/Gemfile
@@ -22,6 +22,8 @@ gem 'jekyll'
 group :jekyll_plugins do
   gem 'jekyll-feed', '~> 0.12'
   gem 'jekyll-github-metadata'
+  gem 'jekyll-glossary_tooltip'
+  gem 'jekyll-liquify'
   gem 'jekyll-remote-theme'
   gem 'jekyll-sitemap'
 end

--- a/doc/site/Gemfile.lock
+++ b/doc/site/Gemfile.lock
@@ -40,6 +40,11 @@ GEM
     jekyll-github-metadata (2.15.0)
       jekyll (>= 3.4, < 5.0)
       octokit (~> 4.0, != 4.4.0)
+    jekyll-glossary_tooltip (1.5.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-liquify (0.0.2)
+      liquid (>= 2.5, < 5.0)
+      redcarpet (~> 3.1)
     jekyll-remote-theme (0.4.3)
       addressable (~> 2.0)
       jekyll (>= 3.5, < 5.0)
@@ -76,6 +81,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.6.0)
     rexml (3.2.5)
     rouge (4.0.1)
     ruby2_keywords (0.0.5)
@@ -99,6 +105,8 @@ DEPENDENCIES
   jekyll
   jekyll-feed (~> 0.12)
   jekyll-github-metadata
+  jekyll-glossary_tooltip
+  jekyll-liquify
   jekyll-remote-theme
   jekyll-sitemap
   just-the-docs

--- a/doc/site/_config.yml
+++ b/doc/site/_config.yml
@@ -36,6 +36,7 @@ remote_theme: just-the-docs/just-the-docs
 plugins:
   - jekyll-feed
   - jekyll-github-metadata
+  - jekyll-glossary_tooltip
   - jekyll-remote-theme
   - jekyll-sitemap
   - jekyll-seo-tag

--- a/doc/site/_data/glossary.yml
+++ b/doc/site/_data/glossary.yml
@@ -1,0 +1,38 @@
+- term: Allyteam
+  definition: >
+    What most people would naturally call a team is called an “allyteam” in
+    Recoil terminology.
+  url: >
+    {% link articles/team-terminology.markdown %}#allyteam-vs-team
+- term: Team
+  definition: A team is generally controlled by a player or an AI.
+  url: >
+    {% link articles/team-terminology.markdown %}#team-vs-player
+- term: Spectator
+  definition: Spectators are players not controlling any team.
+  url: >
+    {% link articles/team-terminology.markdown %}#regular-player-vs-spectator
+- term: AI
+  definition: >
+    An AI fulfils a similar role to a player, being there to control a team.
+  url: >
+    {% link articles/team-terminology.markdown %}#player-vs-ai
+- term: Lua AI
+  definition: >
+    A Lua AI generally has two components: a piece of game mechanics, and the
+    AI instance itself which is just a handle to tell game mechanics which teams
+    are legal to control.
+  url: >
+    {% link articles/team-terminology.markdown %}#lua-ai-vs-skirmish-ai
+- term: Skirmish AI
+  definition: >
+    A “skirmish” AI is hosted by one of the players and generally acts very
+    similar to a player.
+  url: >
+    {% link articles/team-terminology.markdown %}#lua-ai-vs-skirmish-ai
+- term: Gaia
+  definition: >
+    Gaia is a special team that is always present, uncontrolled, and is always
+    in its own allyteam.
+  url: >
+    {% link articles/team-terminology.markdown %}#gaia

--- a/doc/site/_sass/custom/custom.scss
+++ b/doc/site/_sass/custom/custom.scss
@@ -1,0 +1,59 @@
+/* vendored from https://raw.githubusercontent.com/erikw/jekyll-glossary_tooltip/main/lib/jekyll-glossary_tooltip/jekyll-glossary_tooltip.css */
+.jekyll-glossary {
+  position: relative;
+  display: inline-block;
+  border-bottom: 2px dotted #0074bd;
+  cursor: help;
+}
+
+.jekyll-glossary .jekyll-glossary-tooltip {
+  visibility: hidden;
+  width: 120px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  font-size: 0.5em;
+  padding: 5px;
+  border-radius: 6px;
+
+  /* Position the tooltip text - see examples below! */
+  position: absolute;
+  z-index: 1;
+
+  width: 160px;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -80px; /* Use half of the width to center the tooltip */
+
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.jekyll-glossary:hover .jekyll-glossary-tooltip {
+  visibility: visible;
+}
+
+/* Style the source link (if there is one provided in the glossary entry). */
+.jekyll-glossary-source-link:before {
+  content: "[source]";  // "(reference)", "<link>" or whatever you want.
+}
+
+/* Arrow created with borders. */
+.jekyll-glossary .jekyll-glossary-tooltip::after {
+  content: " ";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: black transparent transparent transparent;
+}
+
+/* Animation from invisible to visible on hover. */
+.jekyll-glossary .jekyll-glossary-tooltip {
+  opacity: 0;
+  transition: opacity 1s;
+}
+.jekyll-glossary:hover .jekyll-glossary-tooltip {
+  opacity: 1;
+}

--- a/doc/site/articles/team-terminology.markdown
+++ b/doc/site/articles/team-terminology.markdown
@@ -13,7 +13,7 @@ This article aims to explain Recoil's somewhat confusing terminology behind the 
 ### Allyteam vs team
 
 What most people would naturally call a team is called an *"allyteam"* in Recoil terminology.
-A *"team"* is a single element of an *"allyteam"*. *Teams* are pemanently bound to an *allyteam*.
+A *"team"* is a single element of an *"allyteam"*. *Teams* are permanently bound to an *allyteam*.
 
 For example, NATO would be an *allyteam* while USA and UK would be *teams*, because they are separate entities but are in the same alliance.
 For modders coming from Supreme Commander, the *team* is what SupCom calls an "army".

--- a/doc/site/guides/glossary.markdown
+++ b/doc/site/guides/glossary.markdown
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Glossary
+parent: Guides
+permalink: /guides/glossary/
+---
+
+{% assign ordered_items = site.data.glossary | sort: 'term' %}
+
+<dl>
+{% for item in ordered_items %}
+  <dt><a href="{{item.url | liquify}}" target="_blank">{{item.term}}</a></dt>
+  <dd>{{item.definition}}</dd>
+{% endfor %}
+</dl>


### PR DESCRIPTION
Inspired by @sprunk article on team terminology I incorporated a glossary plugin.

You can reference glossary terms with `{% glossary Term %}`, see [in action](https://erikw.github.io/jekyll-glossary_tooltip/) and [documentation](https://github.com/erikw/jekyll-glossary_tooltip#tag-usage).

![2023-02-11T19:32:09,076792445-03:00](https://user-images.githubusercontent.com/347552/218284026-0eedb17e-0966-4a98-b4c5-1e1f3d06d46f.png)