### PR TITLE
Integrate tracy profiler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,3 +18,6 @@
 	path = AI/Skirmish/CircuitAI
 	url = https://github.com/rlcevg/CircuitAI.git
 	branch = zk
+[submodule "rts/lib/tracy"]
+	path = rts/lib/tracy
+	url = https://github.com/wolfpld/tracy.git

--- a/rts/CMakeLists.txt
+++ b/rts/CMakeLists.txt
@@ -85,7 +85,7 @@ endif (UNIX AND NOT MINGW)
 
 find_package_static(ZLIB REQUIRED)
 list(APPEND engineCommonLibraries ${IL_LIBRARIES} ${JPEG_LIBRARY} ${PNG_LIBRARY} ${TIFF_LIBRARY} ${GIF_LIBRARY})
-list(APPEND engineCommonLibraries 7zip prd::jsoncpp ${SPRING_MINIZIP_LIBRARY} ${ZLIB_LIBRARY})
+list(APPEND engineCommonLibraries 7zip prd::jsoncpp ${SPRING_MINIZIP_LIBRARY} ${ZLIB_LIBRARY} Tracy::TracyClient)
 list(APPEND engineCommonLibraries lua luasocket archives assimp gflags)
 if (ENABLE_STREFLOP)
 	list(APPEND engineCommonLibraries streflop)

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1637,7 +1637,7 @@ void CGame::StartPlaying()
 		eventHandler.GameStart();
 }
 
-
+static const char* const tracingSimFrameName = "SimFrame";
 
 void CGame::SimFrame() {
 	ENTER_SYNCED_CODE();
@@ -1646,6 +1646,8 @@ void CGame::SimFrame() {
 	DumpRNG(-1, -1);
 
 	good_fpu_control_registers("CGame::SimFrame");
+
+	FrameMarkStart(tracingSimFrameName);
 
 	// note: starts at -1, first actual frame is 0
 	gs->frameNum += 1;
@@ -1742,6 +1744,8 @@ void CGame::SimFrame() {
 	gu->avgSimFrameTime = std::max(gu->avgSimFrameTime, 0.01f);
 
 	eventHandler.DbgTimingInfo(TIMING_SIM, lastFrameTime, lastSimFrameTime);
+
+	FrameMarkEnd(tracingSimFrameName);
 
 	#ifdef HEADLESS
 	{

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -537,7 +537,7 @@ void CGame::LoadDefs(LuaParser* defsParser)
 	ENTER_SYNCED_CODE();
 
 	{
-		ScopedOnceTimer timer("Game::LoadDefs (GameData)");
+		SCOPED_ONCE_TIMER("Game::LoadDefs (GameData)");
 		loadscreen->SetLoadMessage("Loading GameData Definitions");
 
 		defsParser->SetupLua(true, true);
@@ -581,7 +581,7 @@ void CGame::LoadDefs(LuaParser* defsParser)
 		icon::iconHandler.Init();
 	}
 	{
-		ScopedOnceTimer timer("Game::LoadDefs (Sound)");
+		SCOPED_ONCE_TIMER("Game::LoadDefs (Sound)");
 		loadscreen->SetLoadMessage("Loading Sound Definitions");
 
 		LuaParser soundDefsParser("gamedata/sounds.lua", SPRING_VFS_MOD_BASE, SPRING_VFS_MOD_BASE);
@@ -617,17 +617,17 @@ void CGame::PostLoadSimulation(LuaParser* defsParser)
 	CommonDefHandler::InitStatic();
 
 	{
-		ScopedOnceTimer timer("Game::PostLoadSim (WeaponDefs)");
+		SCOPED_ONCE_TIMER("Game::PostLoadSim (WeaponDefs)");
 		loadscreen->SetLoadMessage("Loading Weapon Definitions");
 		weaponDefHandler->Init(defsParser);
 	}
 	{
-		ScopedOnceTimer timer("Game::PostLoadSim (UnitDefs)");
+		SCOPED_ONCE_TIMER("Game::PostLoadSim (UnitDefs)");
 		loadscreen->SetLoadMessage("Loading Unit Definitions");
 		unitDefHandler->Init(defsParser);
 	}
 	{
-		ScopedOnceTimer timer("Game::PostLoadSim (FeatureDefs)");
+		SCOPED_ONCE_TIMER("Game::PostLoadSim (FeatureDefs)");
 		loadscreen->SetLoadMessage("Loading Feature Definitions");
 		featureDefHandler->Init(defsParser);
 	}
@@ -721,7 +721,7 @@ void CGame::LoadInterface()
 	keyBindings.Load();
 
 	{
-		ScopedOnceTimer timer("Game::LoadInterface (Console)");
+		SCOPED_ONCE_TIMER("Game::LoadInterface (Console)");
 
 		gameConsoleHistory.Init();
 		gameTextInput.ClearInput();
@@ -837,7 +837,7 @@ void CGame::LoadSkirmishAIs()
 	if (localAIs.empty() && !IsSavedGame())
 		return;
 
-	ScopedOnceTimer timer(std::string("Game::") + __func__);
+	SCOPED_ONCE_TIMER("Game::LoadSkirmishAIs");
 	loadscreen->SetLoadMessage("Loading Skirmish AIs");
 
 	for (uint8_t localAI: localAIs)
@@ -1017,7 +1017,7 @@ void CGame::ResizeEvent()
 	LOG("[Game::%s][1]", __func__);
 
 	{
-		ScopedOnceTimer timer("Game::ViewResize");
+		SCOPED_ONCE_TIMER("Game::ViewResize")
 
 		if (minimap != nullptr)
 			minimap->UpdateGeometry();
@@ -1031,7 +1031,7 @@ void CGame::ResizeEvent()
 	LOG("[Game::%s][2]", __func__);
 
 	{
-		ScopedOnceTimer timer("EventHandler::ViewResize");
+		SCOPED_ONCE_TIMER("EventHandler::ViewResize");
 
 		gameTextInput.ViewResize();
 		eventHandler.ViewResize();

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -335,7 +335,7 @@ void CGame::AddTimedJobs()
 		JobDispatcher::Job j;
 
 		j.f = []() -> bool {
-			profiler.Update();
+			CTimeProfiler::GetInstance().Update();
 			return true;
 		};
 
@@ -1792,7 +1792,7 @@ void CGame::GameEnd(const std::vector<unsigned char>& winningAllyTeams, bool tim
 
 	CEndGameBox::Create(winningAllyTeams);
 #ifdef    HEADLESS
-	profiler.PrintProfilingInfo();
+	CTimeProfiler::GetInstance().PrintProfilingInfo();
 #endif // HEADLESS
 
 	CDemoRecorder* record = clientNet->GetDemoRecorder();

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -356,6 +356,8 @@ void CGame::Load(const std::string& mapFileName)
 	Threading::SetGameLoadThread();
 	Watchdog::RegisterThread(WDT_LOAD);
 
+	ZoneScoped;
+
 	auto& globalQuit = gu->globalQuit;
 	bool  forcedQuit = false;
 
@@ -514,6 +516,7 @@ void CGame::LoadMap(const std::string& mapFileName)
 	ENTER_SYNCED_CODE();
 
 	{
+		SCOPED_ONCE_TIMER("Game::LoadMap");
 		loadscreen->SetLoadMessage("Parsing Map Information");
 
 		waterRendering->Init();
@@ -600,6 +603,7 @@ void CGame::LoadDefs(LuaParser* defsParser)
 
 void CGame::PreLoadSimulation(LuaParser* defsParser)
 {
+	ZoneScoped;
 	ENTER_SYNCED_CODE();
 
 	loadscreen->SetLoadMessage("Creating Smooth Height Mesh");
@@ -614,6 +618,7 @@ void CGame::PreLoadSimulation(LuaParser* defsParser)
 
 void CGame::PostLoadSimulation(LuaParser* defsParser)
 {
+	ZoneScoped;
 	CommonDefHandler::InitStatic();
 
 	{
@@ -685,6 +690,7 @@ void CGame::PostLoadSimulation(LuaParser* defsParser)
 
 void CGame::PreLoadRendering()
 {
+	ZoneScoped;
 	auto lock = CLoadLock::GetUniqueLock();
 
 	geometricObjects = new CGeometricObjects();
@@ -696,12 +702,14 @@ void CGame::PreLoadRendering()
 }
 
 void CGame::PostLoadRendering() {
+	ZoneScoped;
 	worldDrawer.InitPost();
 }
 
 
 void CGame::LoadInterface()
 {
+	ZoneScoped;
 	auto lock = CLoadLock::GetUniqueLock();
 
 	camHandler->Init();
@@ -792,6 +800,7 @@ void CGame::LoadInterface()
 
 void CGame::LoadLua(bool dryRun, bool onlyUnsynced)
 {
+	ZoneScoped;
 	assert(!(dryRun && onlyUnsynced));
 	// Lua components
 	ENTER_SYNCED_CODE();
@@ -853,6 +862,7 @@ void CGame::LoadSkirmishAIs()
 
 void CGame::LoadFinalize()
 {
+	ZoneScoped;
 	{
 		loadscreen->SetLoadMessage("[" + std::string(__func__) + "] finalizing PFS");
 

--- a/rts/Game/LoadScreen.cpp
+++ b/rts/Game/LoadScreen.cpp
@@ -41,6 +41,8 @@
 
 #include <vector>
 
+#include <tracy/Tracy.hpp>
+
 CONFIG(int, LoadingMT)
 	.description("Experimental option to load the game in separate thread. Expect visual glitches, crashes and deadlocks")
 	.defaultValue(0)
@@ -246,6 +248,8 @@ int CLoadScreen::KeyReleased(int keyCode, int scanCode)
 
 bool CLoadScreen::Update()
 {
+	ZoneScoped;
+
 	if (luaIntro != nullptr) {
 		// keep checking this while we are the active controller
 		std::lock_guard<spring::recursive_mutex> lck(mutex);

--- a/rts/Game/PreGame.cpp
+++ b/rts/Game/PreGame.cpp
@@ -54,6 +54,8 @@
 	#include "System/Sync/SyncDebugger.h"
 #endif
 
+#include <tracy/Tracy.hpp>
+
 
 CONFIG(bool, DemoFromDemo).defaultValue(false);
 CONFIG(bool, LoadBadSaves).defaultValue(false);
@@ -193,6 +195,7 @@ bool CPreGame::Draw()
 
 bool CPreGame::Update()
 {
+	ZoneScoped;
 	ENTER_SYNCED_CODE();
 	good_fpu_control_registers("CPreGame::Update");
 	UpdateClientNet();

--- a/rts/Game/PreGame.cpp
+++ b/rts/Game/PreGame.cpp
@@ -233,7 +233,7 @@ void CPreGame::AddModArchivesToVFS(const CGameSetup* setup)
 void CPreGame::StartServer(const std::string& setupscript)
 {
 	assert(gameServer == nullptr);
-	ScopedOnceTimer timer("PreGame::StartServer");
+	SCOPED_ONCE_TIMER("PreGame::StartServer");
 
 	std::shared_ptr<GameData> startGameData(new GameData());
 	std::shared_ptr<CGameSetup> startGameSetup(new CGameSetup());
@@ -475,7 +475,7 @@ void CPreGame::StartServerForDemo(const std::string& demoName)
 
 void CPreGame::ReadDataFromDemo(const std::string& demoName)
 {
-	ScopedOnceTimer timer("PreGame::ReadDataFromDemo");
+	SCOPED_ONCE_TIMER("PreGame::ReadDataFromDemo");
 	assert(gameServer == nullptr);
 	LOG("[PreGame::%s] pre-scanning demo file \"%s\" for game data...", __func__, demoName.c_str());
 	CDemoReader scanner(demoName, 0.0f);
@@ -498,7 +498,7 @@ void CPreGame::ReadDataFromDemo(const std::string& demoName)
 
 void CPreGame::GameDataReceived(std::shared_ptr<const netcode::RawPacket> packet)
 {
-	ScopedOnceTimer timer("PreGame::GameDataReceived");
+	SCOPED_ONCE_TIMER("PreGame::GameDataReceived");
 
 	try {
 		// in demos, gameData is first new'ed in ReadDataFromDemo()

--- a/rts/Game/UI/ProfileDrawer.cpp
+++ b/rts/Game/UI/ProfileDrawer.cpp
@@ -65,7 +65,7 @@ void ProfileDrawer::SetEnabled(bool enable)
 	instance = new ProfileDrawer();
 
 	// reset peak indicators each time the drawer is restarted
-	profiler.ResetPeaks();
+	CTimeProfiler::GetInstance().ResetPeaks();
 }
 
 
@@ -188,6 +188,7 @@ static void DrawTimeSlices(
 
 static void DrawThreadBarcode(TypedRenderBuffer<VA_TYPE_C   >& rb)
 {
+	auto& profiler = CTimeProfiler::GetInstance();
 	constexpr SColor    barColor = SColor{0.0f, 0.0f, 0.0f, 0.5f};
 	constexpr SColor feederColor = SColor{1.0f, 0.0f, 0.0f, 1.0f};
 
@@ -316,6 +317,7 @@ static void DrawFrameBarcode(TypedRenderBuffer<VA_TYPE_C   >& rb)
 
 static void DrawProfiler(TypedRenderBuffer<VA_TYPE_C   >& rb)
 {
+	auto& profiler = CTimeProfiler::GetInstance();
 	font->SetTextColor(1.0f, 1.0f, 1.0f, 1.0f);
 
 	// this locks a mutex, so don't call it every frame
@@ -585,6 +587,7 @@ void ProfileDrawer::DrawScreen()
 
 bool ProfileDrawer::MousePress(int x, int y, int button)
 {
+	auto& profiler = CTimeProfiler::GetInstance();
 	if (!IsAbove(x, y))
 		return false;
 
@@ -611,7 +614,7 @@ bool ProfileDrawer::IsAbove(int x, int y)
 	const float my = CInputReceiver::MouseY(y);
 
 	// check if a Timer selection box was hit
-	return (mx >= MIN_X_COOR && mx <= MAX_X_COOR && my >= (MIN_Y_COOR - profiler.GetNumSortedProfiles() * LINE_HEIGHT) && my <= MIN_Y_COOR);
+	return (mx >= MIN_X_COOR && mx <= MAX_X_COOR && my >= (MIN_Y_COOR - CTimeProfiler::GetInstance().GetNumSortedProfiles() * LINE_HEIGHT) && my <= MIN_Y_COOR);
 }
 
 

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -1392,6 +1392,7 @@ public:
 	DebugActionExecutor() : IUnsyncedActionExecutor("Debug", "Enable/Disable debug rendering mode") {}
 
 	bool Execute(const UnsyncedAction& action) const final {
+		auto& profiler = CTimeProfiler::GetInstance();
 		bool drawDebug = false;
 		bool draw4Real = false;
 		bool changeSorting = false;
@@ -3553,7 +3554,7 @@ public:
 				sound->PrintDebugInfo();
 			} break;
 			case hashString("profiling"): {
-				profiler.PrintProfilingInfo();
+				CTimeProfiler::GetInstance().PrintProfilingInfo();
 			} break;
 			case hashString("cmddescrs"): {
 				commandDescriptionCache.Dump(true);

--- a/rts/Lua/LuaConstCOB.cpp
+++ b/rts/Lua/LuaConstCOB.cpp
@@ -184,8 +184,8 @@ bool LuaConstCOB::PushEntries(lua_State* L)
 	PUSH_COB(WEAPON_SPRAY);
 	PUSH_COB(WEAPON_RANGE);
 	PUSH_COB(WEAPON_PROJECTILE_SPEED);
-	PUSH_COB(MIN);
-	PUSH_COB(MAX);
+	LuaPushNamedNumber(L, "MIN", COB_MIN);
+	LuaPushNamedNumber(L, "MAX", COB_MAX);
 	PUSH_COB(ABS);
 	PUSH_COB(GAME_FRAME);
 

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -480,12 +480,13 @@ bool CLuaHandle::RunCallInTraceback(lua_State* L, const LuaHashString& hs, int i
  *
  * @function LoadCode
  */
-bool CLuaHandle::LoadCode(lua_State* L, const string& code, const string& debug)
+bool CLuaHandle::LoadCode(lua_State* L, std::string code, const string& debug)
 {
 	lua_settop(L, 0);
 
 	const LuaUtils::ScopedDebugTraceBack traceBack(L);
 
+	tracy::LuaRemove(code.data());
 	const int error = luaL_loadbuffer(L, code.c_str(), code.size(), debug.c_str());
 
 	if (error != 0) {

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -50,6 +50,8 @@
 #include <SDL_keycode.h>
 #include <SDL_mouse.h>
 
+#include <tracy/Tracy.hpp>
+#include <tracy/TracyLua.hpp>
 
 #include <string>
 
@@ -140,6 +142,9 @@ CLuaHandle::CLuaHandle(const string& _name, int _order, bool _userMode, bool _sy
 
 	// prevent lua from calling c's exit()
 	lua_atpanic(L, handlepanic);
+
+	// register tracy functions in global scope
+	tracy::LuaRegister(L);
 }
 
 

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -294,7 +294,7 @@ class CLuaHandle : public CEventClient
 		static void PushTracebackFuncToRegistry(lua_State* L);
 
 		bool AddBasicCalls(lua_State* L);
-		bool LoadCode(lua_State* L, const std::string& code, const std::string& debug);
+		bool LoadCode(lua_State* L, std::string code, const std::string& debug);
 		static bool AddEntriesToTable(lua_State* L, const char* name, bool (*entriesFunc)(lua_State*));
 
 		/// returns error code and sets traceback on error

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -78,7 +78,7 @@ CUnsyncedLuaHandle::CUnsyncedLuaHandle(CSplitLuaHandle* _base, const std::string
 CUnsyncedLuaHandle::~CUnsyncedLuaHandle() = default;
 
 
-bool CUnsyncedLuaHandle::Init(const std::string& code, const std::string& file)
+bool CUnsyncedLuaHandle::Init(std::string code, const std::string& file)
 {
 	if (!IsValid())
 		return false;
@@ -151,7 +151,7 @@ bool CUnsyncedLuaHandle::Init(const std::string& code, const std::string& file)
 	}
 
 	lua_settop(L, 0);
-	if (!LoadCode(L, code, file)) {
+	if (!LoadCode(L, std::move(code), file)) {
 		KillLua();
 		return false;
 	}
@@ -416,7 +416,7 @@ CSyncedLuaHandle::~CSyncedLuaHandle()
 }
 
 
-bool CSyncedLuaHandle::Init(const std::string& code, const std::string& file)
+bool CSyncedLuaHandle::Init(std::string code, const std::string& file)
 {
 	if (!IsValid())
 		return false;
@@ -525,7 +525,7 @@ bool CSyncedLuaHandle::Init(const std::string& code, const std::string& file)
 	lua_settop(L, 0);
 	creg::AutoRegisterCFunctions(GetName(), L);
 
-	if (!LoadCode(L, code, file)) {
+	if (!LoadCode(L, std::move(code), file)) {
 		KillLua();
 		return false;
 	}
@@ -2124,7 +2124,7 @@ bool CSplitLuaHandle::InitSynced(bool dryRun)
 	}
 
 	auto lock = CLoadLock::GetUniqueLock(); // for loading of models
-	const bool haveSynced = syncedLuaHandle.Init(syncedCode, GetSyncedFileName());
+	const bool haveSynced = syncedLuaHandle.Init(std::move(syncedCode), GetSyncedFileName());
 
 	if (!IsValid() || !haveSynced) {
 		KillLua();
@@ -2143,14 +2143,14 @@ bool CSplitLuaHandle::InitUnsynced()
 		return false;
 	}
 
-	const std::string unsyncedCode = LoadFile(GetUnsyncedFileName(), GetInitFileModes());
+	std::string unsyncedCode = LoadFile(GetUnsyncedFileName(), GetInitFileModes());
 	if (unsyncedCode.empty()) {
 		KillLua();
 		return false;
 	}
 
 	auto lock = CLoadLock::GetUniqueLock();
-	const bool haveUnsynced = unsyncedLuaHandle.Init(unsyncedCode, GetUnsyncedFileName());
+	const bool haveUnsynced = unsyncedLuaHandle.Init(std::move(unsyncedCode), GetUnsyncedFileName());
 
 	if (!IsValid() || !haveUnsynced) {
 		KillLua();

--- a/rts/Lua/LuaHandleSynced.h
+++ b/rts/Lua/LuaHandleSynced.h
@@ -33,7 +33,7 @@ class CUnsyncedLuaHandle : public CLuaHandle
 		CUnsyncedLuaHandle(CSplitLuaHandle* base, const std::string& name, int order);
 		virtual ~CUnsyncedLuaHandle();
 
-		bool Init(const std::string& code, const std::string& file);
+		bool Init(std::string code, const std::string& file);
 
 		static CUnsyncedLuaHandle* GetUnsyncedHandle(lua_State* L) {
 			assert(dynamic_cast<CUnsyncedLuaHandle*>(CLuaHandle::GetHandle(L)) != nullptr);
@@ -123,7 +123,7 @@ class CSyncedLuaHandle : public CLuaHandle
 		CSyncedLuaHandle(CSplitLuaHandle* base, const std::string& name, int order);
 		virtual ~CSyncedLuaHandle();
 
-		bool Init(const std::string& code, const std::string& file);
+		bool Init(std::string code, const std::string& file);
 
 		static CSyncedLuaHandle* GetSyncedHandle(lua_State* L) {
 			assert(dynamic_cast<CSyncedLuaHandle*>(CLuaHandle::GetHandle(L)));

--- a/rts/Lua/LuaIntro.cpp
+++ b/rts/Lua/LuaIntro.cpp
@@ -53,7 +53,7 @@ CLuaIntro::CLuaIntro()
 		return;
 
 	const std::string file = "LuaIntro/main.lua";
-	const string code = LoadFile(file);
+	std::string code = LoadFile(file);
 
 	if (code.empty()) {
 		KillLua();
@@ -123,7 +123,7 @@ CLuaIntro::CLuaIntro()
 	RemoveSomeOpenGLFunctions(L);
 
 	lua_settop(L, 0);
-	if (!LoadCode(L, code, file)) {
+	if (!LoadCode(L, std::move(code), file)) {
 		KillLua();
 		return;
 	}

--- a/rts/Lua/LuaMenu.cpp
+++ b/rts/Lua/LuaMenu.cpp
@@ -56,7 +56,7 @@ CLuaMenu::CLuaMenu()
 
 	const bool luaSocketEnabled = configHandler->GetBool("LuaSocketEnabled");
 	const std::string file = "LuaMenu/main.lua";
-	const std::string code = LoadFile(file);
+	std::string code = LoadFile(file);
 
 	LOG("LuaMenu Entry Point: \"%s\"", file.c_str());
 	//LOG("LuaSocket Enabled: %s", (luaSocketEnabled ? "yes": "no" ));
@@ -130,7 +130,7 @@ CLuaMenu::CLuaMenu()
 
 	lua_settop(L, 0);
 	// note: this also runs the Initialize callin
-	if (!LoadCode(L, code, file)) {
+	if (!LoadCode(L, std::move(code), file)) {
 		KillLua();
 		return;
 	}
@@ -167,7 +167,7 @@ void CLuaMenu::InitLuaSocket(lua_State* L) {
 	LUA_OPEN_LIB(L, luaopen_socket_core);
 
 	if (f.LoadStringData(code)) {
-		LoadCode(L, code, filename);
+		LoadCode(L, std::move(code), filename);
 	} else {
 		LOG_L(L_ERROR, "Error loading %s", filename.c_str());
 	}

--- a/rts/Lua/LuaParser.cpp
+++ b/rts/Lua/LuaParser.cpp
@@ -27,6 +27,9 @@
 #include "System/ScopedFPUSettings.h"
 #include "System/StringUtil.h"
 
+#include <tracy/Tracy.hpp>
+#include <tracy/TracyLua.hpp>
+
 LuaParser* GetLuaParser(lua_State* L) {
 	assert(GetLuaContextData(L)->parser != nullptr);
 	return GetLuaContextData(L)->parser;
@@ -233,6 +236,7 @@ bool LuaParser::Execute()
 	char errorBuf[4096] = {0};
 	int errorNum = 0;
 
+	tracy::LuaRemove(code.data());
 	if ((errorNum = luaL_loadbuffer(L, code.c_str(), code.size(), codeLabel.c_str())) != 0) {
 		SNPRINTF(errorBuf, sizeof(errorBuf), "[loadbuf] error %d (\"%s\") in %s", errorNum, lua_tostring(L, -1), codeLabel.c_str());
 		LUA_CLOSE(&L);
@@ -637,6 +641,7 @@ int LuaParser::Include(lua_State* L)
  		lua_error(L);
 	}
 
+	tracy::LuaRemove(code.data());
 	int error = luaL_loadbuffer(L, code.c_str(), code.size(), filename.c_str());
 	if (error != 0) {
 		char buf[1024];

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -86,7 +86,7 @@ CLuaUI::CLuaUI()
 
 	const std::string mode = (CLuaHandle::GetDevMode()) ? SPRING_VFS_RAW_FIRST : SPRING_VFS_MOD;
 	const std::string file = (CFileHandler::FileExists("luaui.lua", mode) ? "luaui.lua": "LuaUI/main.lua");
-	const std::string code = LoadFile(file, mode);
+	std::string code = LoadFile(file, mode);
 
 	LOG("LuaUI Entry Point: \"%s\"", file.c_str());
 	LOG("LuaSocket Support: %s", (luaSocketEnabled? "enabled": "disabled"));
@@ -165,7 +165,7 @@ CLuaUI::CLuaUI()
 	}
 
 	lua_settop(L, 0);
-	if (!LoadCode(L, code, file)) {
+	if (!LoadCode(L, std::move(code), file)) {
 		KillLua();
 		return;
 	}
@@ -194,7 +194,7 @@ void CLuaUI::InitLuaSocket(lua_State* L) {
 	LUA_OPEN_LIB(L, luaopen_socket_core);
 
 	if (f.LoadStringData(code)) {
-		LoadCode(L, code, filename);
+		LoadCode(L, std::move(code), filename);
 	} else {
 		LOG_L(L_ERROR, "Error loading %s", filename.c_str());
 	}

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -481,7 +481,7 @@ int LuaUnsyncedRead::GetMenuName(lua_State* L)
  */
 int LuaUnsyncedRead::GetProfilerTimeRecord(lua_State* L)
 {
-	const CTimeProfiler::TimeRecord& record = profiler.GetTimeRecord(lua_tostring(L, 1));
+	const CTimeProfiler::TimeRecord& record = CTimeProfiler::GetInstance().GetTimeRecord(lua_tostring(L, 1));
 
 	int numRet = 5;
 	lua_pushnumber(L, record.total.toMilliSecsf());
@@ -510,7 +510,7 @@ int LuaUnsyncedRead::GetProfilerTimeRecord(lua_State* L)
  */
 int LuaUnsyncedRead::GetProfilerRecordNames(lua_State* L)
 {
-	const auto& sortedProfiles = profiler.GetSortedProfiles();
+	const auto& sortedProfiles = CTimeProfiler::GetInstance().GetSortedProfiles();
 
 	lua_createtable(L, sortedProfiles.size(), 0);
 

--- a/rts/Lua/LuaVFS.cpp
+++ b/rts/Lua/LuaVFS.cpp
@@ -21,6 +21,8 @@
 #include "../tools/pr-downloader/src/pr-downloader.h"
 #include "fmt/format.h"
 
+#include <tracy/Tracy.hpp>
+#include <tracy/TracyLua.hpp>
 
 /******************************************************************************
  * Virtual File System
@@ -168,6 +170,7 @@ int LuaVFS::Include(lua_State* L, bool synced)
  		lua_error(L);
 	}
 
+	tracy::LuaRemove(fileData.data());
 	if ((luaError = luaL_loadbuffer(L, fileData.c_str(), fileData.size(), fileName.c_str())) != 0) {
 		const auto buf = fmt::format("[LuaVFS::{}(synced={})][loadbuf] file={} error={} ({}) cenv={} vfsmode={}", __func__, synced, fileName, luaError, lua_tostring(L, -1), hasCustomEnv, mode);
 		lua_pushlstring(L, buf.c_str(), buf.size());

--- a/rts/Map/SMF/SMFGroundTextures.cpp
+++ b/rts/Map/SMF/SMFGroundTextures.cpp
@@ -192,7 +192,7 @@ void CSMFGroundTextures::LoadSquareTextures(const int mipLevel)
 
 void CSMFGroundTextures::ConvolveHeightMap(const int mapWidth, const int mipLevel)
 {
-	ScopedOnceTimer timer("CSMFGroundTextures::ConvolveHeightMap");
+	SCOPED_ONCE_TIMER("CSMFGroundTextures::ConvolveHeightMap");
 
 	const float* hdata = readMap->GetMIPHeightMapSynced(mipLevel);
 	const int mx = mapWidth >> mipLevel;

--- a/rts/Menu/LuaMenuController.cpp
+++ b/rts/Menu/LuaMenuController.cpp
@@ -13,6 +13,8 @@
 #include "System/SafeUtil.h"
 #include "System/Log/ILog.h"
 
+#include <tracy/Tracy.hpp>
+
 CONFIG(std::string, DefaultLuaMenu).defaultValue("").description("Sets the default menu to be used when spring is started.");
 
 CLuaMenuController* luaMenuController = nullptr;
@@ -89,6 +91,8 @@ void CLuaMenuController::ResizeEvent()
 
 bool CLuaMenuController::Update()
 {
+	ZoneScoped;
+
 	// we should not become the active controller unless this holds (see ::Activate)
 	assert(luaMenu != nullptr);
 

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -69,6 +69,7 @@ void CGame::AddTraffic(int playerID, int packetCode, int length)
 
 void CGame::SendClientProcUsage()
 {
+	auto& profiler = CTimeProfiler::GetInstance();
 	static spring_time lastProcUsageUpdateTime = spring_gettime();
 
 	if ((spring_gettime() - lastProcUsageUpdateTime).toMilliSecsf() >= 1000.0f) {

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -377,6 +377,7 @@ void CGame::ClientReadNet()
 			case NETMSG_INTERNAL_SPEED: {
 				ZoneScopedN("Net::InternalSpeed");
 				sound->PitchAdjust(gs->speedFactor = *reinterpret_cast<const float*>(&inbuf[1]));
+				TracyPlot(tracingSpeedFactor, gs->speedFactor);
 				AddTraffic(-1, packetCode, dataLength);
 			} break;
 
@@ -392,6 +393,7 @@ void CGame::ClientReadNet()
 				const char* pName = (playerNum == SERVER_PLAYER)? "server": playerHandler.Player(playerNum)->name.c_str();
 
 				gs->wantedSpeedFactor = *reinterpret_cast<const float*>(&inbuf[2]);
+				TracyPlot(tracingWantedSpeedFactor, gs->wantedSpeedFactor);
 
 				LOG("Speed set to %.1f [%s]", gs->wantedSpeedFactor, pName);
 				AddTraffic(playerNum, packetCode, dataLength);
@@ -579,6 +581,11 @@ void CGame::ClientReadNet()
 			case NETMSG_NEWFRAME: {
 				// This is alredy well covered in SimFrame so not adding scope.
 				// ZoneScopedN("Net::NewFrame");
+
+				// Just a checkpoint for the speed factors plots.
+				TracyPlot(tracingSpeedFactor, gs->speedFactor);
+				TracyPlot(tracingWantedSpeedFactor, gs->wantedSpeedFactor);
+				
 				msgProcTimeLeft -= 1000.0f;
 				lastSimFrameNetPacketTime = spring_gettime();
 

--- a/rts/Rendering/Common/ModelDrawer.h
+++ b/rts/Rendering/Common/ModelDrawer.h
@@ -328,8 +328,8 @@ template<typename TDrawerData, typename TDrawer>
 template<bool legacy, LuaObjType lot>
 inline void CModelDrawerBase<TDrawerData, TDrawer>::DrawImpl(bool drawReflection, bool drawRefraction) const
 {
-	static const std::string methodName = std::string(className) + "::Draw";
-	SCOPED_TIMER(methodName.c_str());
+	constexpr static auto zone_name = spring::Concat(spring::TypeToCharN<TDrawer>().str, "::Draw");
+	SCOPED_TIMER(zone_name.str);
 
 	if constexpr (legacy) {
 		glEnable(GL_ALPHA_TEST);
@@ -357,8 +357,8 @@ template<typename TDrawerData, typename TDrawer>
 template<LuaObjType lot>
 inline void CModelDrawerBase<TDrawerData, TDrawer>::DrawOpaquePassImpl(bool deferredPass, bool drawReflection, bool drawRefraction) const
 {
-	static const std::string methodName = std::string(className) + "::DrawOpaquePass";
-	SCOPED_TIMER(methodName.c_str());
+	constexpr static auto zone_name = spring::Concat(spring::TypeToCharN<TDrawer>().str, "::DrawOpaquePass");
+	SCOPED_TIMER(zone_name.str);
 
 	SetupOpaqueDrawing(deferredPass);
 
@@ -386,8 +386,8 @@ template<typename TDrawerData, typename TDrawer>
 template<LuaObjType lot>
 inline void CModelDrawerBase<TDrawerData, TDrawer>::DrawAlphaPassImpl(bool drawReflection, bool drawRefraction) const
 {
-	static const std::string methodName = std::string(className) + "::DrawAlphaPass";
-	SCOPED_TIMER(methodName.c_str());
+	constexpr static auto zone_name = spring::Concat(spring::TypeToCharN<TDrawer>().str, "::DrawAlphaPass");
+	SCOPED_TIMER(zone_name.str);
 
 	SetupAlphaDrawing(false);
 
@@ -415,8 +415,8 @@ template<typename TDrawerData, typename TDrawer>
 template<bool legacy, LuaObjType lot>
 inline void CModelDrawerBase<TDrawerData, TDrawer>::DrawShadowPassImpl() const
 {
-	static const std::string methodName = std::string(className) + "::DrawShadowPass";
-	SCOPED_TIMER(methodName.c_str());
+	constexpr static auto zone_name = spring::Concat(spring::TypeToCharN<TDrawer>().str, "::DrawShadowPass");
+	SCOPED_TIMER(zone_name.str);
 
 	assert((CCameraHandler::GetActiveCamera())->GetCamType() == CCamera::CAMTYPE_SHADOW);
 

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -108,6 +108,7 @@ public:
 		{
 			std::string msg = fmt::sprintf("%s::FontConfigInit (version %d.%d.%d)", __func__, FC_MAJOR, FC_MINOR, FC_REVISION);
 			ScopedOnceTimer timer(msg);
+			ZoneScopedNC("FtLibraryHandler::FontConfigInit", tracy::Color::Purple);
 
 			try
 			{

--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -1109,6 +1109,7 @@ void CGlobalRendering::ConfigNotify(const std::string& key, const std::string& v
 
 void CGlobalRendering::UpdateWindow()
 {
+	ZoneScoped;
 	if (!spring::QueuedFunction::Empty()) {
 		for (const auto& qf : spring::QueuedFunction::GetQueuedFunctions()) {
 			qf->Execute();

--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -37,6 +37,7 @@
 #include <SDL_syswm.h>
 #include <SDL_rect.h>
 
+#include <tracy/Tracy.hpp>
 
 CONFIG(bool, DebugGL).defaultValue(false).description("Enables GL debug-context and output. (see GL_ARB_debug_output)");
 CONFIG(bool, DebugGLStacktraces).defaultValue(false).description("Create a stacktrace when an OpenGL error occurs");
@@ -656,6 +657,7 @@ void CGlobalRendering::SwapBuffers(bool allowSwapBuffers, bool clearErrors)
 		glBindFramebuffer(GL_READ_FRAMEBUFFER_EXT, 0);
 
 		SDL_GL_SwapWindow(sdlWindow);
+		FrameMark;
 	}
 	// exclude debug from SCOPED_TIMER("Misc::SwapBuffers");
 	eventHandler.DbgTimingInfo(TIMING_SWAP, pre, spring_now());

--- a/rts/Rendering/Models/3DModel.cpp
+++ b/rts/Rendering/Models/3DModel.cpp
@@ -16,6 +16,8 @@
 #include <cctype>
 #include <cstring>
 
+#include <tracy/Tracy.hpp>
+
 CR_BIND(LocalModelPiece, (nullptr))
 CR_REG_METADATA(LocalModelPiece, (
 	CR_MEMBER(pos),
@@ -354,6 +356,7 @@ LocalModelPiece* LocalModel::CreateLocalModelPieces(const S3DModelPiece* mpParen
 
 void LocalModel::UpdateBoundingVolume()
 {
+	ZoneScoped;
 	// bounding-box extrema (local space)
 	float3 bbMins = DEF_MIN_SIZE;
 	float3 bbMaxs = DEF_MAX_SIZE;

--- a/rts/Sim/CMakeLists.txt
+++ b/rts/Sim/CMakeLists.txt
@@ -149,6 +149,7 @@ add_library(engineSim STATIC
 
 target_include_directories(engineSim
 	PRIVATE ${GLEW_INCLUDE_DIR} ${SDL2_INCLUDE_DIR})
+target_link_libraries(engineSim Tracy::TracyClient)
 
 if( CMAKE_COMPILER_IS_GNUCXX)
 	# FIXME: hack to avoid linkers to remove not referenced symbols. required because of

--- a/rts/Sim/Misc/GlobalSynced.cpp
+++ b/rts/Sim/Misc/GlobalSynced.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <common/TracyColor.hpp>
 #include <cstring>
 
 #include "ExternalAI/SkirmishAIHandler.h"
@@ -17,6 +18,8 @@
 	#include "System/Sync/SyncChecker.h"
 #endif
 
+const char* const tracingSpeedFactor = "SpeedFactor";
+const char* const tracingWantedSpeedFactor = "WantedSpeedFactor";
 
 /**
  * @brief global synced
@@ -66,9 +69,13 @@ void CGlobalSynced::ResetState() {
 	// reset checksum
 	CSyncChecker::NewFrame();
 #endif
+	TracyPlotConfig(tracingSpeedFactor, tracy::PlotFormatType::Number, true, false, tracy::Color::Aqua);
+	TracyPlotConfig(tracingWantedSpeedFactor, tracy::PlotFormatType::Number, true, false, tracy::Color::Aqua);
 
 	speedFactor       = 1.0f;
+	TracyPlot(tracingSpeedFactor, speedFactor);
 	wantedSpeedFactor = 1.0f;
+	TracyPlot(tracingWantedSpeedFactor, wantedSpeedFactor);
 
 	paused          = false;
 	cheatEnabled    = false;

--- a/rts/Sim/Misc/GlobalSynced.h
+++ b/rts/Sim/Misc/GlobalSynced.h
@@ -18,6 +18,9 @@ enum {
 	GODMODE_MAX_VAL = GODMODE_ATC_BIT | GODMODE_ETC_BIT, // full team control
 };
 
+extern const char* const tracingSpeedFactor;
+extern const char* const tracingWantedSpeedFactor;
+
 /**
  * @brief Global synced data
  *

--- a/rts/Sim/Misc/SmoothHeightMesh.cpp
+++ b/rts/Sim/Misc/SmoothHeightMesh.cpp
@@ -597,7 +597,7 @@ void SmoothHeightMesh::UpdateSmoothMesh() {
 
 
 void SmoothHeightMesh::MakeSmoothMesh() {
-	ScopedOnceTimer timer("SmoothHeightMesh::MakeSmoothMesh");
+	SCOPED_ONCE_TIMER("SmoothHeightMesh::MakeSmoothMesh");
 
 	// A sliding window is used to reduce computational complexity
 	const int winSize = smoothRadius / resolution;

--- a/rts/Sim/Path/TKPFS/PathManager.cpp
+++ b/rts/Sim/Path/TKPFS/PathManager.cpp
@@ -95,7 +95,7 @@ void CPathManager::InitStatic()
 	const size_t medResPEsOffset = lowResPEsOffset + medLowResMem;
 	const size_t maxResPFsOffset = medResPEsOffset + medLowResMem;
 
-	char* baseAddr = reinterpret_cast<char*>( malloc(totalMem) );
+	char* baseAddr = reinterpret_cast<char*>(::operator new(totalMem));
 	lowResPEs = reinterpret_cast<CPathEstimator*>( baseAddr + lowResPEsOffset );
 	medResPEs = reinterpret_cast<CPathEstimator*>( baseAddr + medResPEsOffset );
 	maxResPFs = reinterpret_cast<CPathFinder*>   ( baseAddr + maxResPFsOffset );
@@ -141,7 +141,7 @@ CPathManager::~CPathManager()
 	pathFinders.clear();
 
 	if (lowResPEs != nullptr) {
-		free(lowResPEs);
+		::operator delete(lowResPEs);
 		lowResPEs = nullptr;
 	}
 

--- a/rts/Sim/Units/Scripts/CobDefines.h
+++ b/rts/Sim/Units/Scripts/CobDefines.h
@@ -105,8 +105,8 @@
 #define WEAPON_SPRAY             128 // get (with fake set)
 #define WEAPON_RANGE             129 // get (with fake set)
 #define WEAPON_PROJECTILE_SPEED  130 // get (with fake set)
-#define MIN                      131 // get
-#define MAX                      132 // get
+#define COB_MIN                  131 // get
+#define COB_MAX                  132 // get
 #define ABS                      133 // get
 #define GAME_FRAME               134 // get
 #define KSIN                     135 // get (kiloSine    : 1024*sin(x))

--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -34,6 +34,7 @@
 #include "System/SpringMath.h"
 #include "System/Sound/ISoundChannels.h"
 
+#include <tracy/Tracy.hpp>
 
 /******************************************************************************/
 /******************************************************************************/
@@ -188,6 +189,7 @@ bool CCobInstance::HasTargetWeight(int weaponNum) const
 
 void CCobInstance::Create()
 {
+	ZoneScoped;
 	// calculate maximum reload-time of the available weapons
 	int maxReloadTime = 0;
 
@@ -206,6 +208,7 @@ void CCobInstance::Create()
 
 void CCobInstance::Killed()
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
@@ -218,6 +221,7 @@ void CCobInstance::Killed()
 
 void CCobInstance::WindChanged(float heading, float speed)
 {
+	ZoneScoped;
 	Call(COBFN_SetSpeed, int(speed * 3000.0f));
 	Call(COBFN_SetDirection, short(heading * RAD2TAANG));
 }
@@ -225,6 +229,7 @@ void CCobInstance::WindChanged(float heading, float speed)
 
 void CCobInstance::ExtractionRateChanged(float speed)
 {
+	ZoneScoped;
 	Call(COBFN_SetSpeed, int(speed * 500.0f));
 
 	if (!unit->activated)
@@ -233,9 +238,14 @@ void CCobInstance::ExtractionRateChanged(float speed)
 	Call(COBFN_Go);
 }
 
+void CCobInstance::WorldRockUnit(const float3& rockDir) 
+{
+	RockUnit(unit->GetObjectSpaceVec(rockDir) * 500.0f);
+}
 
 void CCobInstance::RockUnit(const float3& rockDir)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
@@ -245,9 +255,14 @@ void CCobInstance::RockUnit(const float3& rockDir)
 	Call(COBFN_RockUnit, callinArgs);
 }
 
+void CCobInstance::WorldHitByWeapon(const float3& hitDir, int weaponDefId, float& inoutDamage)
+{
+	HitByWeapon(unit->GetObjectSpaceVec(hitDir) * 500.0f, weaponDefId, inoutDamage);
+}
 
 void CCobInstance::HitByWeapon(const float3& hitDir, int weaponDefId, float& inoutDamage)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
@@ -274,12 +289,14 @@ void CCobInstance::HitByWeapon(const float3& hitDir, int weaponDefId, float& ino
 
 void CCobInstance::SetSFXOccupy(int curTerrainType)
 {
+	ZoneScoped;
 	Call(COBFN_SetSFXOccupy, curTerrainType);
 }
 
 
 void CCobInstance::QueryLandingPads(std::vector<int>& outPieces)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 1;
@@ -307,6 +324,7 @@ void CCobInstance::QueryLandingPads(std::vector<int>& outPieces)
 
 void CCobInstance::BeginTransport(const CUnit* unit)
 {
+	ZoneScoped;
 	// COB uses model height to identify units
 	Call(COBFN_BeginTransport, int(unit->model->height * 65536));
 }
@@ -314,6 +332,7 @@ void CCobInstance::BeginTransport(const CUnit* unit)
 
 int CCobInstance::QueryTransport(const CUnit* unit)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
@@ -327,6 +346,7 @@ int CCobInstance::QueryTransport(const CUnit* unit)
 
 void CCobInstance::TransportPickup(const CUnit* unit)
 {
+	ZoneScoped;
 	// here COB uses unitIDs instead of model height
 	Call(COBFN_TransportPickup, unit->id);
 }
@@ -334,6 +354,7 @@ void CCobInstance::TransportPickup(const CUnit* unit)
 
 void CCobInstance::TransportDrop(const CUnit* unit, const float3& pos)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
@@ -346,6 +367,7 @@ void CCobInstance::TransportDrop(const CUnit* unit, const float3& pos)
 
 void CCobInstance::StartBuilding(float heading, float pitch)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
@@ -358,6 +380,7 @@ void CCobInstance::StartBuilding(float heading, float pitch)
 
 int CCobInstance::QueryNanoPiece()
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] =  1;
@@ -370,6 +393,7 @@ int CCobInstance::QueryNanoPiece()
 
 int CCobInstance::QueryBuildInfo()
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] =  1;
@@ -382,6 +406,7 @@ int CCobInstance::QueryBuildInfo()
 
 int CCobInstance::QueryWeapon(int weaponNum)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] =  1;
@@ -394,6 +419,7 @@ int CCobInstance::QueryWeapon(int weaponNum)
 
 void CCobInstance::AimWeapon(int weaponNum, float heading, float pitch)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
@@ -406,6 +432,7 @@ void CCobInstance::AimWeapon(int weaponNum, float heading, float pitch)
 
 void CCobInstance::AimShieldWeapon(CPlasmaRepulser* weapon)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
@@ -417,6 +444,7 @@ void CCobInstance::AimShieldWeapon(CPlasmaRepulser* weapon)
 
 int CCobInstance::AimFromWeapon(int weaponNum)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] =  1;
@@ -429,12 +457,14 @@ int CCobInstance::AimFromWeapon(int weaponNum)
 
 void CCobInstance::Shot(int weaponNum)
 {
+	ZoneScoped;
 	Call(COBFN_Shot + COBFN_Weapon_Funcs * weaponNum, 0); // why the 0 argument?
 }
 
 
 bool CCobInstance::BlockShot(int weaponNum, const CUnit* targetUnit, bool userTarget)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 3;
@@ -450,6 +480,7 @@ bool CCobInstance::BlockShot(int weaponNum, const CUnit* targetUnit, bool userTa
 
 float CCobInstance::TargetWeight(int weaponNum, const CUnit* targetUnit)
 {
+	ZoneScoped;
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
@@ -463,6 +494,7 @@ float CCobInstance::TargetWeight(int weaponNum, const CUnit* targetUnit)
 
 void CCobInstance::AnimFinished(AnimType type, int piece, int axis)
 {
+	ZoneScoped;
 	for (int threadID: threadIDs) {
 		CCobThread* t = cobEngine->GetThread(threadID);
 		t->AnimFinished(type, piece, axis);
@@ -470,20 +502,20 @@ void CCobInstance::AnimFinished(AnimType type, int piece, int axis)
 }
 
 
-void CCobInstance::Destroy() { Call(COBFN_Destroy); }
-void CCobInstance::StartMoving(bool reversing) { Call(COBFN_StartMoving, reversing); }
-void CCobInstance::StopMoving() { Call(COBFN_StopMoving); }
-void CCobInstance::StartUnload() { Call(COBFN_StartUnload); }
-void CCobInstance::EndTransport() { Call(COBFN_EndTransport); }
-void CCobInstance::StartBuilding() { Call(COBFN_StartBuilding); }
-void CCobInstance::StopBuilding() { Call(COBFN_StopBuilding); }
-void CCobInstance::Falling() { Call(COBFN_Falling); }
-void CCobInstance::Landed() { Call(COBFN_Landed); }
-void CCobInstance::Activate() { Call(COBFN_Activate); }
-void CCobInstance::Deactivate() { Call(COBFN_Deactivate); }
-void CCobInstance::MoveRate(int curRate) { Call(COBFN_MoveRate0 + curRate); }
-void CCobInstance::FireWeapon(int weaponNum) { Call(COBFN_FirePrimary + COBFN_Weapon_Funcs * weaponNum); }
-void CCobInstance::EndBurst(int weaponNum) { Call(COBFN_EndBurst + COBFN_Weapon_Funcs * weaponNum); }
+void CCobInstance::Destroy() { ZoneScoped; Call(COBFN_Destroy); }
+void CCobInstance::StartMoving(bool reversing) { ZoneScoped; Call(COBFN_StartMoving, reversing); }
+void CCobInstance::StopMoving() { ZoneScoped; Call(COBFN_StopMoving); }
+void CCobInstance::StartUnload() { ZoneScoped; Call(COBFN_StartUnload); }
+void CCobInstance::EndTransport() { ZoneScoped; Call(COBFN_EndTransport); }
+void CCobInstance::StartBuilding() { ZoneScoped; Call(COBFN_StartBuilding); }
+void CCobInstance::StopBuilding() { ZoneScoped; Call(COBFN_StopBuilding); }
+void CCobInstance::Falling() { ZoneScoped; Call(COBFN_Falling); }
+void CCobInstance::Landed() { ZoneScoped; Call(COBFN_Landed); }
+void CCobInstance::Activate() { ZoneScoped; Call(COBFN_Activate); }
+void CCobInstance::Deactivate() { ZoneScoped; Call(COBFN_Deactivate); }
+void CCobInstance::MoveRate(int curRate) { ZoneScoped; Call(COBFN_MoveRate0 + curRate); }
+void CCobInstance::FireWeapon(int weaponNum) { ZoneScoped; Call(COBFN_FirePrimary + COBFN_Weapon_Funcs * weaponNum); }
+void CCobInstance::EndBurst(int weaponNum) { ZoneScoped; Call(COBFN_EndBurst + COBFN_Weapon_Funcs * weaponNum); }
 
 
 /******************************************************************************/

--- a/rts/Sim/Units/Scripts/CobInstance.h
+++ b/rts/Sim/Units/Scripts/CobInstance.h
@@ -143,13 +143,9 @@ public:
 	void Killed() override;
 	void WindChanged(float heading, float speed) override;
 	void ExtractionRateChanged(float speed) override;
-	void WorldRockUnit(const float3& rockDir) override {
-		RockUnit(unit->GetObjectSpaceVec(rockDir) * 500.0f);
-	}
+	void WorldRockUnit(const float3& rockDir) override;
 	void RockUnit(const float3& rockDir) override;
-	void WorldHitByWeapon(const float3& hitDir, int weaponDefId, float& inoutDamage) override {
-		HitByWeapon(unit->GetObjectSpaceVec(hitDir) * 500.0f, weaponDefId, inoutDamage);
-	}
+	void WorldHitByWeapon(const float3& hitDir, int weaponDefId, float& inoutDamage) override;
 	void HitByWeapon(const float3& hitDir, int weaponDefId, float& inoutDamage) override;
 	void SetSFXOccupy(int curTerrainType) override;
 	void QueryLandingPads(std::vector<int>& out_pieces) override;

--- a/rts/Sim/Units/Scripts/CobThread.cpp
+++ b/rts/Sim/Units/Scripts/CobThread.cpp
@@ -8,6 +8,8 @@
 #include "Sim/Misc/GlobalConstants.h"
 #include "Sim/Misc/GlobalSynced.h"
 
+#include <tracy/Tracy.hpp>
+
 CR_BIND(CCobThread, )
 
 CR_REG_METADATA(CCobThread, (
@@ -383,6 +385,8 @@ bool CCobThread::Tick()
 
 	if (IsDead())
 		return false;
+
+	ZoneScoped;
 
 	state = Run;
 

--- a/rts/Sim/Units/Scripts/LuaUnitScript.cpp
+++ b/rts/Sim/Units/Scripts/LuaUnitScript.cpp
@@ -1,5 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
+#include <tracy/Tracy.hpp>
 #define LUA_SYNCED_ONLY
 
 #include "LuaUnitScript.h"
@@ -585,6 +586,7 @@ void CLuaUnitScript::Create()
 
 void CLuaUnitScript::Killed()
 {
+	ZoneScoped;
 	const int fn = LUAFN_Killed;
 
 	if (!HasFunction(fn)) {
@@ -626,12 +628,14 @@ void CLuaUnitScript::Killed()
 
 void CLuaUnitScript::WindChanged(float heading, float speed)
 {
+	ZoneScoped;
 	Call(LUAFN_WindChanged, heading, speed);
 }
 
 
 void CLuaUnitScript::ExtractionRateChanged(float speed)
 {
+	ZoneScoped;
 	Call(LUAFN_ExtractionRateChanged, speed);
 }
 
@@ -640,12 +644,15 @@ void CLuaUnitScript::ExtractionRateChanged(float speed)
 void CLuaUnitScript::WorldRockUnit(const float3& rockDir) { RockUnit(unit->GetObjectSpaceVec(rockDir)); }
 void CLuaUnitScript::RockUnit(const float3& rockDir)
 {
+	ZoneScoped;
 	Call(LUAFN_RockUnit, rockDir.x, rockDir.z);
 }
 
 void CLuaUnitScript::WorldHitByWeapon(const float3& hitDir, int weaponDefId, float& inoutDamage) { HitByWeapon(unit->GetObjectSpaceVec(hitDir), weaponDefId, inoutDamage); }
 void CLuaUnitScript::HitByWeapon(const float3& hitDir, int weaponDefId, float& inoutDamage)
 {
+	ZoneScoped;
+
 	const int fn = LUAFN_HitByWeapon;
 
 	if (!HasFunction(fn))
@@ -679,6 +686,7 @@ void CLuaUnitScript::HitByWeapon(const float3& hitDir, int weaponDefId, float& i
 
 void CLuaUnitScript::SetSFXOccupy(int curTerrainType)
 {
+	ZoneScoped;
 	const int fn = LUAFN_SetSFXOccupy;
 
 	if (!HasFunction(fn))
@@ -696,6 +704,7 @@ void CLuaUnitScript::SetSFXOccupy(int curTerrainType)
 
 void CLuaUnitScript::QueryLandingPads(std::vector<int>& out_pieces)
 {
+	ZoneScoped;
 	const int fn = LUAFN_QueryLandingPads;
 
 	if (!HasFunction(fn))
@@ -735,24 +744,28 @@ void CLuaUnitScript::QueryLandingPads(std::vector<int>& out_pieces)
 
 void CLuaUnitScript::BeginTransport(const CUnit* unit)
 {
+	ZoneScoped;
 	Call(LUAFN_BeginTransport, unit->id);
 }
 
 
 int CLuaUnitScript::QueryTransport(const CUnit* unit)
 {
+	ZoneScoped;
 	return RunQueryCallIn(LUAFN_QueryTransport, unit->id);
 }
 
 
 void CLuaUnitScript::TransportPickup(const CUnit* unit)
 {
+	ZoneScoped;
 	Call(LUAFN_TransportPickup, unit->id);
 }
 
 
 void CLuaUnitScript::TransportDrop(const CUnit* unit, const float3& pos)
 {
+	ZoneScoped;
 	const int fn = LUAFN_TransportDrop;
 
 	if (!HasFunction(fn))
@@ -773,48 +786,56 @@ void CLuaUnitScript::TransportDrop(const CUnit* unit, const float3& pos)
 
 void CLuaUnitScript::StartBuilding(float heading, float pitch)
 {
+	ZoneScoped;
 	Call(LUAFN_StartBuilding, heading, pitch);
 }
 
 
 int CLuaUnitScript::QueryNanoPiece()
 {
+	ZoneScoped;
 	return RunQueryCallIn(LUAFN_QueryNanoPiece);
 }
 
 
 int CLuaUnitScript::QueryBuildInfo()
 {
+	ZoneScoped;
 	return RunQueryCallIn(LUAFN_QueryBuildInfo);
 }
 
 
 int CLuaUnitScript::QueryWeapon(int weaponNum)
 {
+	ZoneScoped;
 	return RunQueryCallIn(LUAFN_QueryWeapon, weaponNum + LUA_WEAPON_BASE_INDEX);
 }
 
 
 void CLuaUnitScript::AimWeapon(int weaponNum, float heading, float pitch)
 {
+	ZoneScoped;
 	Call(LUAFN_AimWeapon, weaponNum + LUA_WEAPON_BASE_INDEX, heading, pitch);
 }
 
 
 void  CLuaUnitScript::AimShieldWeapon(CPlasmaRepulser* weapon)
 {
+	ZoneScoped;
 	Call(LUAFN_AimShield, weapon->weaponNum + LUA_WEAPON_BASE_INDEX);
 }
 
 
 int CLuaUnitScript::AimFromWeapon(int weaponNum)
 {
+	ZoneScoped;
 	return RunQueryCallIn(LUAFN_AimFromWeapon, weaponNum + LUA_WEAPON_BASE_INDEX);
 }
 
 
 void CLuaUnitScript::Shot(int weaponNum)
 {
+	ZoneScoped;
 	// FIXME: pass projectileID?
 	Call(LUAFN_Shot, weaponNum + LUA_WEAPON_BASE_INDEX);
 }
@@ -822,6 +843,7 @@ void CLuaUnitScript::Shot(int weaponNum)
 
 bool CLuaUnitScript::BlockShot(int weaponNum, const CUnit* targetUnit, bool userTarget)
 {
+	ZoneScoped;
 	const int fn = LUAFN_BlockShot;
 
 	if (!HasFunction(fn))
@@ -844,6 +866,7 @@ bool CLuaUnitScript::BlockShot(int weaponNum, const CUnit* targetUnit, bool user
 
 float CLuaUnitScript::TargetWeight(int weaponNum, const CUnit* targetUnit)
 {
+	ZoneScoped;
 	const int fn = LUAFN_TargetWeight;
 
 	if (!HasFunction(fn))
@@ -865,6 +888,7 @@ float CLuaUnitScript::TargetWeight(int weaponNum, const CUnit* targetUnit)
 
 void CLuaUnitScript::AnimFinished(AnimType type, int piece, int axis)
 {
+	ZoneScoped;
 	Call((type == AMove)? LUAFN_MoveFinished : LUAFN_TurnFinished, piece + 1, axis + 1);
 }
 
@@ -922,23 +946,23 @@ bool CLuaUnitScript::RawRunCallIn(int functionId, int inArgs, int outArgs)
 }
 
 
-void CLuaUnitScript::Destroy() { Call(LUAFN_Destroy); }
-void CLuaUnitScript::StartMoving(bool reversing) { Call(LUAFN_StartMoving, reversing * 1.0f); }
-void CLuaUnitScript::StopMoving() { Call(LUAFN_StopMoving); }
-void CLuaUnitScript::StartSkidding(const float3& vel) { Call(LUAFN_StartSkidding, vel.x, vel.y, vel.z); }
-void CLuaUnitScript::StopSkidding() { Call(LUAFN_StopSkidding); }
-void CLuaUnitScript::ChangeHeading(short deltaHeading) { Call(LUAFN_ChangeHeading, deltaHeading * 1.0f); }
-void CLuaUnitScript::StartUnload() { Call(LUAFN_StartUnload); }
-void CLuaUnitScript::EndTransport() { Call(LUAFN_EndTransport); }
-void CLuaUnitScript::StartBuilding() { Call(LUAFN_StartBuilding); }
-void CLuaUnitScript::StopBuilding() { Call(LUAFN_StopBuilding); }
-void CLuaUnitScript::Falling() { Call(LUAFN_Falling); }
-void CLuaUnitScript::Landed() { Call(LUAFN_Landed); }
-void CLuaUnitScript::Activate() { Call(LUAFN_Activate); }
-void CLuaUnitScript::Deactivate() { Call(LUAFN_Deactivate); }
-void CLuaUnitScript::MoveRate(int curRate) { Call(LUAFN_MoveRate, curRate); }
-void CLuaUnitScript::FireWeapon(int weaponNum) { Call(LUAFN_FireWeapon, weaponNum + LUA_WEAPON_BASE_INDEX); }
-void CLuaUnitScript::EndBurst(int weaponNum) { Call(LUAFN_EndBurst, weaponNum + LUA_WEAPON_BASE_INDEX); }
+void CLuaUnitScript::Destroy() { ZoneScoped; Call(LUAFN_Destroy); }
+void CLuaUnitScript::StartMoving(bool reversing) { ZoneScoped; Call(LUAFN_StartMoving, reversing * 1.0f); }
+void CLuaUnitScript::StopMoving() { ZoneScoped; Call(LUAFN_StopMoving); }
+void CLuaUnitScript::StartSkidding(const float3& vel) { ZoneScoped; Call(LUAFN_StartSkidding, vel.x, vel.y, vel.z); }
+void CLuaUnitScript::StopSkidding() { ZoneScoped; Call(LUAFN_StopSkidding); }
+void CLuaUnitScript::ChangeHeading(short deltaHeading) { ZoneScoped; Call(LUAFN_ChangeHeading, deltaHeading * 1.0f); }
+void CLuaUnitScript::StartUnload() { ZoneScoped; Call(LUAFN_StartUnload); }
+void CLuaUnitScript::EndTransport() { ZoneScoped; Call(LUAFN_EndTransport); }
+void CLuaUnitScript::StartBuilding() { ZoneScoped; Call(LUAFN_StartBuilding); }
+void CLuaUnitScript::StopBuilding() { ZoneScoped; Call(LUAFN_StopBuilding); }
+void CLuaUnitScript::Falling() { ZoneScoped; Call(LUAFN_Falling); }
+void CLuaUnitScript::Landed() { ZoneScoped; Call(LUAFN_Landed); }
+void CLuaUnitScript::Activate() { ZoneScoped; Call(LUAFN_Activate); }
+void CLuaUnitScript::Deactivate() { ZoneScoped; Call(LUAFN_Deactivate); }
+void CLuaUnitScript::MoveRate(int curRate) { ZoneScoped; Call(LUAFN_MoveRate, curRate); }
+void CLuaUnitScript::FireWeapon(int weaponNum) { ZoneScoped; Call(LUAFN_FireWeapon, weaponNum + LUA_WEAPON_BASE_INDEX); }
+void CLuaUnitScript::EndBurst(int weaponNum) { ZoneScoped; Call(LUAFN_EndBurst, weaponNum + LUA_WEAPON_BASE_INDEX); }
 
 
 /******************************************************************************/

--- a/rts/Sim/Units/Scripts/UnitScript.cpp
+++ b/rts/Sim/Units/Scripts/UnitScript.cpp
@@ -1131,9 +1131,9 @@ int CUnitScript::GetUnitVal(int val, int p1, int p2, int p3, int p4)
 		return weapon->Attack(SWeaponTarget(pos, userTarget)) ? 1 : 0;
 	} break;
 
-	case MIN:
+	case COB_MIN:
 		return std::min(p1, p2);
-	case MAX:
+	case COB_MAX:
 		return std::max(p1, p2);
 	case ABS:
 		return std::abs(p1);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -192,6 +192,7 @@ void CUnit::SanityCheck() const
 
 void CUnit::PreInit(const UnitLoadParams& params)
 {
+	ZoneScoped;
 	// if this is < 0, UnitHandler will give us a random ID
 	id = params.unitID;
 	featureDefID = -1;
@@ -316,6 +317,7 @@ void CUnit::PreInit(const UnitLoadParams& params)
 
 void CUnit::PostInit(const CUnit* builder)
 {
+	ZoneScoped;
 	CWeaponLoader::LoadWeapons(this);
 	CWeaponLoader::InitWeapons(this);
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -69,6 +69,8 @@
 
 #undef near
 
+#include <tracy/Tracy.hpp>
+
 
 // See end of source for member bindings
 //////////////////////////////////////////////////////////////////////
@@ -659,6 +661,7 @@ void CUnit::Update()
 
 void CUnit::UpdateWeapons()
 {
+	ZoneScoped;
 	if (!CanUpdateWeapons())
 		return;
 
@@ -910,6 +913,7 @@ void CUnit::SetStunned(bool stun) {
 
 void CUnit::SlowUpdate()
 {
+	ZoneScoped;
 	UpdatePosErrorParams(false, true);
 
 	DoWaterDamage();
@@ -1044,6 +1048,7 @@ void CUnit::SlowUpdate()
 
 void CUnit::SlowUpdateWeapons()
 {
+	ZoneScoped;
 	if (!CanUpdateWeapons())
 		return;
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -31,6 +31,8 @@
 #include "System/Sound/ISoundChannels.h"
 #include "System/Log/ILog.h"
 
+#include <tracy/Tracy.hpp>
+
 CR_BIND_DERIVED_POOL(CWeapon, CObject, , weaponMemPool.allocMem, weaponMemPool.freeMem)
 CR_REG_METADATA(CWeapon, (
 	CR_MEMBER(owner),
@@ -284,6 +286,7 @@ float CWeapon::GetPredictedImpactTime(float3 p) const
 
 void CWeapon::Update()
 {
+	ZoneScoped;
 	// update conditional cause last SlowUpdate maybe longer away than UNIT_SLOWUPDATE_RATE
 	// i.e. when the unit got stunned (neither is SlowUpdate exactly called at UNIT_SLOWUPDATE_RATE, it's only called `close` to that)
 	float3 newErrorVector = (errorVector + errorVectorAdd);
@@ -323,6 +326,7 @@ void CWeapon::Update()
 
 void CWeapon::UpdateAim()
 {
+	ZoneScoped;
 	if (!HaveTarget())
 		return;
 
@@ -423,6 +427,7 @@ bool CWeapon::CanFire(bool ignoreAngleGood, bool ignoreTargetType, bool ignoreRe
 
 void CWeapon::UpdateFire()
 {
+	ZoneScoped;
 	if (!CanFire(false, false, false))
 		return;
 
@@ -471,6 +476,7 @@ void CWeapon::UpdateFire()
 
 bool CWeapon::UpdateStockpile()
 {
+	ZoneScoped;
 	if (!weaponDef->stockpile)
 		return true;
 
@@ -496,6 +502,7 @@ bool CWeapon::UpdateStockpile()
 
 void CWeapon::UpdateSalvo()
 {
+	ZoneScoped;
 	if (!salvoLeft || nextSalvo > gs->frameNum)
 		return;
 
@@ -529,6 +536,7 @@ void CWeapon::UpdateSalvo()
 
 bool CWeapon::Attack(const SWeaponTarget& newTarget)
 {
+	ZoneScoped;
 	if (newTarget == currentTarget)
 		return true;
 

--- a/rts/System/CMakeLists.txt
+++ b/rts/System/CMakeLists.txt
@@ -102,6 +102,7 @@ make_global_var(sources_engine_System_Log
 		"${CMAKE_CURRENT_SOURCE_DIR}/Log/FramePrefixer.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Log/LogSinkHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Log/LogUtil.c"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Log/TracySink.cpp"
 	)
 make_global_var(sources_engine_System_Log_sinkStream
 		"${CMAKE_CURRENT_SOURCE_DIR}/Log/StreamSink.cpp"

--- a/rts/System/CMakeLists.txt
+++ b/rts/System/CMakeLists.txt
@@ -1,7 +1,12 @@
 
+if (TRACY_PROFILE_MEMORY)
+	set(memoryProfileSource "${CMAKE_CURRENT_SOURCE_DIR}/TraceMemory.cpp")
+endif()
+
 # This list was created using this *nix shell command:
 # > find . -name "*.cpp" -or -name "*.c" | sort
 # Then Sound/ stuff was removed, because it is now a separate static lib.
+
 make_global_var(sources_engine_System_common
 		"${CMAKE_CURRENT_SOURCE_DIR}/AIScriptHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Color.cpp"
@@ -66,6 +71,7 @@ make_global_var(sources_engine_System_common
 		"${CMAKE_CURRENT_SOURCE_DIR}/float4.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/SpringMath.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/SpringMem.cpp"
+		"${memoryProfileSource}"
 	)
 if    (NO_CREG)
 	make_global_var(sources_engine_System_creg )

--- a/rts/System/EventHandler.cpp
+++ b/rts/System/EventHandler.cpp
@@ -9,6 +9,8 @@
 #include "System/Platform/Threading.h"
 #include "System/GlobalConfig.h"
 
+#include <tracy/Tracy.hpp>
+
 CEventHandler eventHandler;
 
 
@@ -242,105 +244,124 @@ template<typename T, typename F, typename... A> bool ControlIterateDefFalse(T& l
 
 bool CEventHandler::CommandFallback(const CUnit* unit, const Command& cmd)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listCommandFallback, &CEventClient::CommandFallback, unit, cmd);
 }
 
 
 bool CEventHandler::AllowCommand(const CUnit* unit, const Command& cmd, int playerNum, bool fromSynced, bool fromLua)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowCommand, &CEventClient::AllowCommand, unit, cmd, playerNum, fromSynced, fromLua);
 }
 
 
 bool CEventHandler::AllowUnitCreation(const UnitDef* unitDef, const CUnit* builder, const BuildInfo* buildInfo)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowUnitCreation, &CEventClient::AllowUnitCreation, unitDef, builder, buildInfo);
 }
 
 bool CEventHandler::AllowUnitTransfer(const CUnit* unit, int newTeam, bool capture)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowUnitTransfer, &CEventClient::AllowUnitTransfer, unit, newTeam, capture);
 }
 
 bool CEventHandler::AllowUnitBuildStep(const CUnit* builder, const CUnit* unit, float part)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowUnitBuildStep, &CEventClient::AllowUnitBuildStep, builder, unit, part);
 }
 
 bool CEventHandler::AllowUnitCaptureStep(const CUnit* builder, const CUnit* unit, float part)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowUnitCaptureStep, &CEventClient::AllowUnitCaptureStep, builder, unit, part);
 }
 
 bool CEventHandler::AllowUnitTransport(const CUnit* transporter, const CUnit* transportee)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowUnitTransport, &CEventClient::AllowUnitTransport, transporter, transportee);
 }
 
 bool CEventHandler::AllowUnitTransportLoad(const CUnit* transporter, const CUnit* transportee, const float3& loadPos, bool allowed)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowUnitTransportLoad, &CEventClient::AllowUnitTransportLoad, transporter, transportee, loadPos, allowed);
 }
 
 bool CEventHandler::AllowUnitTransportUnload(const CUnit* transporter, const CUnit* transportee, const float3& unloadPos, bool allowed)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowUnitTransportUnload, &CEventClient::AllowUnitTransportUnload, transporter, transportee, unloadPos, allowed);
 }
 
 bool CEventHandler::AllowUnitCloak(const CUnit* unit, const CUnit* enemy)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowUnitCloak, &CEventClient::AllowUnitCloak, unit, enemy);
 }
 
 bool CEventHandler::AllowUnitDecloak(const CUnit* unit, const CSolidObject* object, const CWeapon* weapon)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowUnitDecloak, &CEventClient::AllowUnitDecloak, unit, object, weapon);
 }
 
 bool CEventHandler::AllowUnitKamikaze(const CUnit* unit, const CUnit* target, bool allowed)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowUnitKamikaze, &CEventClient::AllowUnitKamikaze, unit, target, allowed);
 }
 
 
 bool CEventHandler::AllowFeatureCreation(const FeatureDef* featureDef, int allyTeamID, const float3& pos)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowFeatureCreation, &CEventClient::AllowFeatureCreation, featureDef, allyTeamID, pos);
 }
 
 
 bool CEventHandler::AllowFeatureBuildStep(const CUnit* builder, const CFeature* feature, float part)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowFeatureBuildStep, &CEventClient::AllowFeatureBuildStep, builder, feature, part);
 }
 
 
 bool CEventHandler::AllowResourceLevel(int teamID, const std::string& type, float level)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowResourceLevel, &CEventClient::AllowResourceLevel, teamID, type, level);
 }
 
 
 bool CEventHandler::AllowResourceTransfer(int oldTeam, int newTeam, const char* type, float amount)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowResourceTransfer, &CEventClient::AllowResourceTransfer, oldTeam, newTeam, type, amount);
 }
 
 
 bool CEventHandler::AllowDirectUnitControl(int playerID, const CUnit* unit)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowDirectUnitControl, &CEventClient::AllowDirectUnitControl, playerID, unit);
 }
 
 
 bool CEventHandler::AllowBuilderHoldFire(const CUnit* unit, int action)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowBuilderHoldFire, &CEventClient::AllowBuilderHoldFire, unit, action);
 }
 
 
 bool CEventHandler::AllowStartPosition(int playerID, int teamID, unsigned char readyState, const float3& clampedPos, const float3& rawPickPos)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowStartPosition, &CEventClient::AllowStartPosition, playerID, teamID, readyState, clampedPos, rawPickPos);
 }
 
@@ -348,18 +369,21 @@ bool CEventHandler::AllowStartPosition(int playerID, int teamID, unsigned char r
 
 bool CEventHandler::TerraformComplete(const CUnit* unit, const CUnit* build)
 {
+	ZoneScoped;
 	return ControlIterateDefFalse(listTerraformComplete, &CEventClient::TerraformComplete, unit, build);
 }
 
 
 bool CEventHandler::MoveCtrlNotify(const CUnit* unit, int data)
 {
+	ZoneScoped;
 	return ControlIterateDefFalse(listMoveCtrlNotify, &CEventClient::MoveCtrlNotify, unit, data);
 }
 
 
 int CEventHandler::AllowWeaponTargetCheck(unsigned int attackerID, unsigned int attackerWeaponNum, unsigned int attackerWeaponDefID)
 {
+	ZoneScoped;
 	int result = -1;
 
 	for (size_t i = 0; i < listAllowWeaponTargetCheck.size(); ) {
@@ -382,11 +406,13 @@ bool CEventHandler::AllowWeaponTarget(
 	unsigned int attackerWeaponDefID,
 	float* targetPriority
 ) {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowWeaponTarget, &CEventClient::AllowWeaponTarget, attackerID, targetID, attackerWeaponNum, attackerWeaponDefID, targetPriority);
 }
 
 bool CEventHandler::AllowWeaponInterceptTarget(const CUnit* interceptorUnit, const CWeapon* interceptorWeapon, const CProjectile* interceptorTarget)
 {
+	ZoneScoped;
 	return ControlIterateDefTrue(listAllowWeaponInterceptTarget, &CEventClient::AllowWeaponInterceptTarget, interceptorUnit, interceptorWeapon, interceptorTarget);
 }
 
@@ -401,6 +427,7 @@ bool CEventHandler::UnitPreDamaged(
 	float* newDamage,
 	float* impulseMult
 ) {
+	ZoneScoped;
 	return ControlIterateDefFalse(listUnitPreDamaged, &CEventClient::UnitPreDamaged, unit, attacker, damage, weaponDefID, projectileID, paralyzer, newDamage, impulseMult);
 }
 
@@ -414,6 +441,7 @@ bool CEventHandler::FeaturePreDamaged(
 	float* newDamage,
 	float* impulseMult
 ) {
+	ZoneScoped;
 	return ControlIterateDefFalse(listFeaturePreDamaged, &CEventClient::FeaturePreDamaged, feature, attacker, damage, weaponDefID, projectileID, newDamage, impulseMult);
 }
 
@@ -428,12 +456,14 @@ bool CEventHandler::ShieldPreDamaged(
 	const float3& startPos,
 	const float3& hitPos
 ) {
+	ZoneScoped;
 	return ControlIterateDefFalse(listShieldPreDamaged, &CEventClient::ShieldPreDamaged, projectile, shieldEmitter, shieldCarrier, bounceProjectile, beamEmitter, beamCarrier, startPos, hitPos);
 }
 
 
 bool CEventHandler::SyncedActionFallback(const std::string& line, int playerID)
 {
+	ZoneScoped;
 	for (size_t i = 0; i < listSyncedActionFallback.size(); ) {
 		CEventClient* ec = listSyncedActionFallback[i];
 
@@ -470,74 +500,88 @@ template<typename T, typename F, typename... A> void IterateEventClientList(T& l
 
 void CEventHandler::Save(zipFile archive)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(Save, archive);
 }
 
 void CEventHandler::Load(IArchive* archive)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(Load, archive);
 }
 
 
 void CEventHandler::GamePreload()
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST_NA(GamePreload);
 }
 
 void CEventHandler::GameStart()
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST_NA(GameStart);
 }
 
 void CEventHandler::GameOver(const std::vector<unsigned char>& winningAllyTeams)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(GameOver, winningAllyTeams);
 }
 
 void CEventHandler::GamePaused(int playerID, bool paused)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(GamePaused, playerID, paused);
 }
 
 void CEventHandler::GameFrame(int gameFrame)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(GameFrame, gameFrame);
 }
 
 void CEventHandler::GameProgress(int gameFrame)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(GameProgress, gameFrame);
 }
 
 void CEventHandler::GameID(const unsigned char* gameID, unsigned int numBytes)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(GameID, gameID, numBytes);
 }
 
 
 void CEventHandler::TeamDied(int teamID)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(TeamDied, teamID);
 }
 
 void CEventHandler::TeamChanged(int teamID)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(TeamChanged, teamID);
 }
 
 
 void CEventHandler::PlayerChanged(int playerID)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(PlayerChanged, playerID);
 }
 
 void CEventHandler::PlayerAdded(int playerID)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(PlayerAdded, playerID);
 }
 
 void CEventHandler::PlayerRemoved(int playerID, int reason)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(PlayerRemoved, playerID, reason);
 }
 
@@ -547,6 +591,7 @@ void CEventHandler::PlayerRemoved(int playerID, int reason)
 
 void CEventHandler::UnitHarvestStorageFull(const CUnit* unit)
 {
+	ZoneScoped;
 	const int unitAllyTeam = unit->allyteam;
 	const int count = listUnitHarvestStorageFull.size();
 	for (int i = 0; i < count; i++) {
@@ -562,6 +607,7 @@ void CEventHandler::UnitHarvestStorageFull(const CUnit* unit)
 
 void CEventHandler::CollectGarbage(bool forced)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(CollectGarbage, forced);
 }
 
@@ -572,12 +618,14 @@ void CEventHandler::DbgTimingInfo(DbgTimingInfoType type, const spring_time star
 
 void CEventHandler::Pong(uint8_t pingTag, const spring_time pktSendTime, const spring_time pktRecvTime)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(Pong, pingTag, pktSendTime, pktRecvTime);
 }
 
 
 void CEventHandler::Update()
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST_NA(Update);
 }
 
@@ -585,11 +633,13 @@ void CEventHandler::Update()
 
 void CEventHandler::SunChanged()
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST_NA(SunChanged);
 }
 
 void CEventHandler::ViewResize()
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST_NA(ViewResize);
 }
 
@@ -597,6 +647,7 @@ void CEventHandler::ViewResize()
 #define DRAW_CALLIN(name)                                                   \
 	void CEventHandler:: Draw ## name ()                                    \
 	{                                                                       \
+		ZoneScoped;                                                         \
 		if (listDraw ## name.empty())                                       \
 			return;                                                         \
                                                                             \
@@ -642,6 +693,7 @@ DRAW_CALLIN(InMiniMapBackground)
 #define DRAW_ENTITY_CALLIN(name, args, args2)                                 \
 	bool CEventHandler:: Draw ## name args                                    \
 	{                                                                         \
+		ZoneScoped;                                                           \
 		bool skipEngineDrawing = false;                                       \
                                                                               \
 		for (size_t i = 0; i < listDraw ## name.size(); ) {                   \
@@ -692,39 +744,46 @@ template<typename T, typename F, typename... A> std::string ControlReverseIterat
 
 bool CEventHandler::CommandNotify(const Command& cmd)
 {
+	ZoneScoped;
 	return ControlReverseIterateDefTrue(listCommandNotify, &CEventClient::CommandNotify, cmd);
 }
 
 
 bool CEventHandler::KeyMapChanged()
 {
+	ZoneScoped;
 	return ControlReverseIterateDefTrue(listKeyMapChanged, &CEventClient::KeyMapChanged);
 }
 
 bool CEventHandler::KeyPress(int keyCode, int scanCode, bool isRepeat)
 {
+	ZoneScoped;
 	return ControlReverseIterateDefTrue(listKeyPress, &CEventClient::KeyPress, keyCode, scanCode, isRepeat);
 }
 
 bool CEventHandler::KeyRelease(int keyCode, int scanCode)
 {
+	ZoneScoped;
 	return ControlReverseIterateDefTrue(listKeyRelease, &CEventClient::KeyRelease, keyCode, scanCode);
 }
 
 
 bool CEventHandler::TextInput(const std::string& utf8)
 {
+	ZoneScoped;
 	return ControlReverseIterateDefTrue(listTextInput, &CEventClient::TextInput, utf8);
 }
 
 bool CEventHandler::TextEditing(const std::string& utf8, unsigned int start, unsigned int length)
 {
+	ZoneScoped;
 	return ControlReverseIterateDefTrue(listTextEditing, &CEventClient::TextEditing, utf8, start, length);
 }
 
 
 bool CEventHandler::MousePress(int x, int y, int button)
 {
+	ZoneScoped;
 	for (size_t i = 0; i < listMousePress.size(); i++) {
 		CEventClient* ec = listMousePress[listMousePress.size() - 1 - i];
 
@@ -741,6 +800,7 @@ bool CEventHandler::MousePress(int x, int y, int button)
 
 void CEventHandler::MouseRelease(int x, int y, int button)
 {
+	ZoneScoped;
 	if (mouseOwner == nullptr)
 		return;
 
@@ -751,6 +811,7 @@ void CEventHandler::MouseRelease(int x, int y, int button)
 
 bool CEventHandler::MouseMove(int x, int y, int dx, int dy, int button)
 {
+	ZoneScoped;
 	if (mouseOwner == nullptr)
 		return false;
 
@@ -759,29 +820,34 @@ bool CEventHandler::MouseMove(int x, int y, int dx, int dy, int button)
 
 bool CEventHandler::MouseWheel(bool up, float value)
 {
+	ZoneScoped;
 	return ControlReverseIterateDefTrue(listMouseWheel, &CEventClient::MouseWheel, up, value);
 }
 
 
 bool CEventHandler::IsAbove(int x, int y)
 {
+	ZoneScoped;
 	return ControlReverseIterateDefTrue(listIsAbove, &CEventClient::IsAbove, x, y);
 }
 
 
 std::string CEventHandler::GetTooltip(int x, int y)
 {
+	ZoneScoped;
 	return ControlReverseIterateDefString(listGetTooltip, &CEventClient::GetTooltip, x, y);
 }
 
 std::string CEventHandler::WorldTooltip(const CUnit* unit, const CFeature* feature, const float3* groundPos)
 {
+	ZoneScoped;
 	return ControlReverseIterateDefString(listWorldTooltip, &CEventClient::WorldTooltip, unit, feature, groundPos);
 }
 
 
 bool CEventHandler::AddConsoleLine(const std::string& msg, const std::string& section, int level)
 {
+	ZoneScoped;
 	if (listAddConsoleLine.empty())
 		return false;
 
@@ -792,12 +858,14 @@ bool CEventHandler::AddConsoleLine(const std::string& msg, const std::string& se
 
 void CEventHandler::LastMessagePosition(const float3& pos)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(LastMessagePosition, pos);
 }
 
 
 bool CEventHandler::GroupChanged(int groupID)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(GroupChanged, groupID);
 	return false;
 }
@@ -809,32 +877,38 @@ bool CEventHandler::GameSetup(
 	bool& ready,
 	const std::vector< std::pair<int, std::string> >& playerStates
 ) {
+	ZoneScoped;
 	return ControlReverseIterateDefTrue(listGameSetup, &CEventClient::GameSetup, state, ready, playerStates);
 }
 
 
 void CEventHandler::DownloadQueued(int ID, const std::string& archiveName, const std::string& archiveType)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(DownloadQueued, ID, archiveName, archiveType);
 }
 
 void CEventHandler::DownloadStarted(int ID)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(DownloadStarted, ID);
 }
 
 void CEventHandler::DownloadFinished(int ID)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(DownloadFinished, ID);
 }
 
 void CEventHandler::DownloadFailed(int ID, int errorID)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(DownloadFailed, ID, errorID);
 }
 
 void CEventHandler::DownloadProgress(int ID, long downloaded, long total)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(DownloadProgress, ID, downloaded, total);
 }
 
@@ -855,36 +929,43 @@ bool CEventHandler::MapDrawCmd(
 
 void CEventHandler::MetalMapChanged(const int x, const int z)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(MetalMapChanged, x, z);
 }
 
 void CEventHandler::DrawOpaqueUnitsLua(bool deferredPass, bool drawReflection, bool drawRefraction)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(DrawOpaqueUnitsLua, deferredPass, drawReflection, drawRefraction);
 }
 
 void CEventHandler::DrawOpaqueFeaturesLua(bool deferredPass, bool drawReflection, bool drawRefraction)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(DrawOpaqueFeaturesLua, deferredPass, drawReflection, drawRefraction);
 }
 
 void CEventHandler::DrawAlphaUnitsLua(bool drawReflection, bool drawRefraction)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(DrawAlphaUnitsLua, drawReflection, drawRefraction);
 }
 
 void CEventHandler::DrawAlphaFeaturesLua(bool drawReflection, bool drawRefraction)
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST(DrawAlphaFeaturesLua, drawReflection, drawRefraction);
 }
 
 void CEventHandler::DrawShadowUnitsLua()
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST_NA(DrawShadowUnitsLua);
 }
 
 void CEventHandler::DrawShadowFeaturesLua()
 {
+	ZoneScoped;
 	ITERATE_EVENTCLIENTLIST_NA(DrawShadowFeaturesLua);
 }
 

--- a/rts/System/FileSystem/ArchiveScanner.cpp
+++ b/rts/System/FileSystem/ArchiveScanner.cpp
@@ -459,7 +459,7 @@ void CArchiveScanner::ScanAllDirs()
 
 	// ArchiveCache has been parsed at this point --> archiveInfos is populated
 #if !defined(DEDICATED) && !defined(UNITSYNC)
-	ScopedOnceTimer foo("CArchiveScanner::ScanAllDirs");
+	SCOPED_ONCE_TIMER("CArchiveScanner::ScanAllDirs");
 #endif
 
 	ScanDirs(scanDirs);

--- a/rts/System/Log/TracySink.cpp
+++ b/rts/System/Log/TracySink.cpp
@@ -1,0 +1,33 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifdef TRACY_ENABLE
+
+#include "Backend.h"
+#include "LogUtil.h"
+#include "lib/fmt/format.h"
+
+#include <algorithm>
+#include <tracy/Tracy.hpp>
+
+static void log_sink_record_tracy(int level, const char* section, const char* record)
+{
+	auto buf = fmt::format("[{}:{}][{}] {}", log_util_levelToString(log_util_getNearestLevel(level)),
+	                       level, section, record);
+	TracyMessageS(buf.c_str(), buf.size(), 30);
+}
+
+namespace {
+
+/// Auto-registers the sink defined in this file before main() is called
+struct TracySinkRegistrator {
+	TracySinkRegistrator() {
+		log_backend_registerSink(&log_sink_record_tracy);
+	}
+	~TracySinkRegistrator() {
+		log_backend_unregisterSink(&log_sink_record_tracy);
+	}
+} tracySinkRegistrator;
+
+}
+
+#endif

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -27,7 +27,7 @@
 	#include "Linux/ThreadSupport.h"
 #endif
 
-
+#include <tracy/Tracy.hpp>
 
 namespace Threading {
 #ifndef _WIN32
@@ -356,6 +356,9 @@ namespace Threading {
 
 	void SetThreadName(const std::string& newname)
 	{
+	#if defined(TRACY_ENABLE)
+		tracy::SetThreadName(newname.c_str());
+	#endif
 	#if defined(__USE_GNU) && !defined(_WIN32)
 		//alternative: pthread_setname_np(pthread_self(), newname.c_str());
 		prctl(PR_SET_NAME, newname.c_str(), 0, 0, 0);

--- a/rts/System/Sound/CMakeLists.txt
+++ b/rts/System/Sound/CMakeLists.txt
@@ -12,7 +12,7 @@ set(noSoundSources
 
 add_library(no-sound STATIC EXCLUDE_FROM_ALL ${noSoundSources})
 set_target_properties(no-sound PROPERTIES COMPILE_FLAGS "-DNO_SOUND")
-
+target_link_libraries(no-sound Tracy::TracyClient)
 
 # Define default sound implementation
 if    (NO_SOUND)
@@ -56,4 +56,5 @@ if    (NOT NO_SOUND)
 	add_library(sound STATIC EXCLUDE_FROM_ALL ${soundSources})
 	target_link_libraries(sound ${VORBISFILE_LIBRARY} ${VORBIS_LIBRARY} ${OGG_LIBRARY})
 	target_link_libraries(sound ${OPENAL_LIBRARY})
+	target_link_libraries(sound Tracy::TracyClient)
 endif (NOT NO_SOUND)

--- a/rts/System/Sound/ISound.cpp
+++ b/rts/System/Sound/ISound.cpp
@@ -63,19 +63,19 @@ void ISound::Initialize(bool reload, bool forceNullSound)
 		Channels::UserInterface = new (audioChannelMem[4]) AudioChannel();
 
 		if (!reload) {
-			ScopedOnceTimer timer("ISound::Init::New");
+			SCOPED_ONCE_TIMER("ISound::Init::New");
 			assert(singleton == nullptr);
 			singleton = new CSound();
 		}
 		{
-			ScopedOnceTimer timer("ISound::Init::Dev");
+			SCOPED_ONCE_TIMER("ISound::Init::Dev");
 
 			// sound device is initialized in a thread, must wait
 			// for it to finish (otherwise LoadSoundDefs can fail)
 			singleton->Init();
 
 			while (!singleton->CanLoadSoundDefs()) {
-				LOG("[ISound::%s] spawning sound-thread (%.1fms)", __func__, (timer.GetDuration()).toMilliSecsf());
+				LOG("[ISound::%s] spawning sound-thread (%.1fms)", __func__, (__timer.GetDuration()).toMilliSecsf());
 
 				if (singleton->SoundThreadQuit()) {
 					// no device or context found, fallback

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -773,7 +773,7 @@ void SpringApp::Reload(const std::string script)
 	// will be reconstructed from given script
 	gameSetup->ResetState();
 
-	profiler.ResetState();
+	CTimeProfiler::GetInstance().ResetState();
 	modInfo.ResetState();
 
 	LOG("[SpringApp::%s][11]", __func__);

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -1014,7 +1014,7 @@ bool SpringApp::MainEventHandler(const SDL_Event& event)
 
 					if (globalRendering->numDisplays > 1 && globalRendering->dualScreenMode) {
 						{
-							ScopedOnceTimer timer("GlobalRendering::UpdateGL");
+							SCOPED_ONCE_TIMER("GlobalRendering::UpdateGL");
 
 							globalRendering->UpdateGLConfigs();
 							globalRendering->UpdateGLGeometry();
@@ -1040,7 +1040,7 @@ bool SpringApp::MainEventHandler(const SDL_Event& event)
 					Watchdog::ClearTimer(WDT_MAIN, true);
 
 					{
-						ScopedOnceTimer timer("GlobalRendering::UpdateGL");
+						SCOPED_ONCE_TIMER("GlobalRendering::UpdateGL");
 
 						SaveWindowPosAndSize();
 						globalRendering->UpdateGLConfigs();
@@ -1049,7 +1049,7 @@ bool SpringApp::MainEventHandler(const SDL_Event& event)
 						UpdateInterfaceGeometry();
 					}
 					{
-						ScopedOnceTimer timer("ActiveController::ResizeEvent");
+						SCOPED_ONCE_TIMER("ActiveController::ResizeEvent");
 
 						activeController->ResizeEvent();
 						mouseInput->InstallWndCallback();
@@ -1067,12 +1067,12 @@ bool SpringApp::MainEventHandler(const SDL_Event& event)
 					globalRendering->active = true;
 
 					if (ISound::IsInitialized()) {
-						ScopedOnceTimer timer("Sound::Iconified");
+						SCOPED_ONCE_TIMER("Sound::Iconified");
 						sound->Iconified(false);
 					}
 
 					if (globalRendering->fullScreen) {
-						ScopedOnceTimer timer("FBO::GLContextReinit");
+						SCOPED_ONCE_TIMER("FBO::GLContextReinit");
 						FBO::GLContextReinit();
 					}
 
@@ -1087,12 +1087,12 @@ bool SpringApp::MainEventHandler(const SDL_Event& event)
 					globalRendering->active = false;
 
 					if (ISound::IsInitialized()) {
-						ScopedOnceTimer timer("Sound::Iconified");
+						SCOPED_ONCE_TIMER("Sound::Iconified");
 						sound->Iconified(true);
 					}
 
 					if (globalRendering->fullScreen) {
-						ScopedOnceTimer timer("FBO::GLContextLost");
+						SCOPED_ONCE_TIMER("FBO::GLContextLost");
 						FBO::GLContextLost();
 					}
 

--- a/rts/System/SpringHashMap.hpp
+++ b/rts/System/SpringHashMap.hpp
@@ -223,8 +223,9 @@ public:
 				_pairs[bucket].~PairT();
 			}
 		}
-		free(_states);
-		free(_pairs);
+
+		::operator delete(_states);
+		::operator delete(_pairs);
 	}
 
 	void swap(HashMap& other)
@@ -482,14 +483,8 @@ public:
 		size_t num_buckets = 4;
 		while (num_buckets < required_buckets) { num_buckets *= 2; }
 
-		auto new_states = (State*)malloc(num_buckets * sizeof(State));
-		auto new_pairs  = (PairT*)malloc(num_buckets * sizeof(PairT));
-
-		if (!new_states || !new_pairs) {
-			free(new_states);
-			free(new_pairs);
-			throw std::bad_alloc();
-		}
+		auto new_states = reinterpret_cast<State*>(::operator new(num_buckets * sizeof(State)));
+		auto new_pairs  = reinterpret_cast<PairT*>(::operator new(num_buckets * sizeof(PairT)));
 
 		//auto old_num_filled  = _num_filled;
 		auto old_num_buckets = _num_buckets;
@@ -523,8 +518,8 @@ public:
 
 		//DCHECK_EQ_F(old_num_filled, _num_filled);
 
-		free(old_states);
-		free(old_pairs);
+		::operator delete(old_states);
+		::operator delete(old_pairs);
 	}
 
 private:

--- a/rts/System/SpringHashSet.hpp
+++ b/rts/System/SpringHashSet.hpp
@@ -220,8 +220,8 @@ public:
 				_keys[bucket].~KeyT();
 			}
 		}
-		free(_states);
-		free(_keys);
+		::operator delete(_states);
+		::operator delete(_keys);
 	}
 
 	void swap(HashSet& other)
@@ -435,14 +435,8 @@ public:
 		size_t num_buckets = 4;
 		while (num_buckets < required_buckets) { num_buckets *= 2; }
 
-		auto new_states = (State*)malloc(num_buckets * sizeof(State));
-		auto new_keys  = (KeyT*)malloc(num_buckets * sizeof(KeyT));
-
-		if (!new_states || !new_keys) {
-			free(new_states);
-			free(new_keys);
-			throw std::bad_alloc();
-		}
+		auto new_states = reinterpret_cast<State*>(::operator new(num_buckets * sizeof(State)));
+		auto new_keys  = reinterpret_cast<KeyT*>(::operator new(num_buckets * sizeof(KeyT)));
 
 		// auto old_num_filled  = _num_filled;
 		auto old_num_buckets = _num_buckets;
@@ -475,9 +469,8 @@ public:
 		}
 
 		// DCHECK_EQ_F(old_num_filled, _num_filled);
-
-		free(old_states);
-		free(old_keys);
+		::operator delete(old_states);
+		::operator delete(old_keys);
 	}
 
 	void rehash(size_t num_elems) {

--- a/rts/System/Threading/ThreadPool.cpp
+++ b/rts/System/Threading/ThreadPool.cpp
@@ -573,7 +573,7 @@ void SetMaximumThreadCount()
 		//   exists before any thread creates a timer that accesses
 		//   it on destruction
 		#ifndef UNIT_TEST
-		profiler.ResetState();
+		CTimeProfiler::GetInstance().ResetState();
 		#endif
 	}
 

--- a/rts/System/TimeProfiler.cpp
+++ b/rts/System/TimeProfiler.cpp
@@ -63,7 +63,7 @@ ScopedTimer::~ScopedTimer()
 	assert(iter->second > 0);
 
 	if (--(iter->second) == 0) {
-		profiler.AddTime(nameHash, startTime, GetDuration(), autoShowGraph, specialTimer, false);
+		CTimeProfiler::GetInstance().AddTime(nameHash, startTime, GetDuration(), autoShowGraph, specialTimer, false);
 	}
 }
 
@@ -107,7 +107,7 @@ ScopedMtTimer::ScopedMtTimer(unsigned _nameHash, bool _autoShowGraph)
 
 ScopedMtTimer::~ScopedMtTimer()
 {
-	profiler.AddTime(nameHash, startTime, GetDuration(), autoShowGraph, false, true);
+	CTimeProfiler::GetInstance().AddTime(nameHash, startTime, GetDuration(), autoShowGraph, false, true);
 }
 
 

--- a/rts/System/TimeProfiler.h
+++ b/rts/System/TimeProfiler.h
@@ -20,14 +20,15 @@
 // disable these for minimal profiling; all special
 // timers contribute even when profiler is disabled
 // NB: names are assumed to be compile-time literals
-#define SCOPED_TIMER(      name)  ZoneScopedN(name); static TimerNameRegistrar __tnr(name); ScopedTimer __scopedTimer(hashString(name));
-#define SCOPED_TIMER_NOREG(name)  ZoneScopedN(name);                                        ScopedTimer __scopedTimer(hashString(name));
+#define SCOPED_TIMER(      name)  ZoneScopedNC(name, tracy::Color::Goldenrod); static TimerNameRegistrar __tnr(name); ScopedTimer __scopedTimer(hashString(name));
+#define SCOPED_TIMER_NOREG(name)  ZoneScopedNC(name, tracy::Color::Goldenrod);                                        ScopedTimer __scopedTimer(hashString(name));
 
 #define SCOPED_SPECIAL_TIMER(      name)  static TimerNameRegistrar __stnr(name); ScopedTimer __scopedTimer(hashString(name), false, true);
 #define SCOPED_SPECIAL_TIMER_NOREG(name)                                          ScopedTimer __scopedTimer(hashString(name), false, true);
 
 #define SCOPED_MT_TIMER(name)  ScopedMtTimer __scopedTimer(hashString(name));
 
+#define SCOPED_ONCE_TIMER(name) ZoneScopedNC(name, tracy::Color::Purple); ScopedOnceTimer __timer(name);
 
 class BasicTimer : public spring::noncopyable
 {

--- a/rts/System/TimeProfiler.h
+++ b/rts/System/TimeProfiler.h
@@ -226,6 +226,4 @@ public:
 	}
 };
 
-#define profiler (CTimeProfiler::GetInstance())
-
 #endif // TIME_PROFILER_H

--- a/rts/System/TimeProfiler.h
+++ b/rts/System/TimeProfiler.h
@@ -15,11 +15,13 @@
 #include "System/StringHash.h"
 #include "System/UnorderedMap.hpp"
 
+#include <tracy/Tracy.hpp>
+
 // disable these for minimal profiling; all special
 // timers contribute even when profiler is disabled
 // NB: names are assumed to be compile-time literals
-#define SCOPED_TIMER(      name)  static TimerNameRegistrar __tnr(name); ScopedTimer __scopedTimer(hashString(name));
-#define SCOPED_TIMER_NOREG(name)                                         ScopedTimer __scopedTimer(hashString(name));
+#define SCOPED_TIMER(      name)  ZoneScopedN(name); static TimerNameRegistrar __tnr(name); ScopedTimer __scopedTimer(hashString(name));
+#define SCOPED_TIMER_NOREG(name)  ZoneScopedN(name);                                        ScopedTimer __scopedTimer(hashString(name));
 
 #define SCOPED_SPECIAL_TIMER(      name)  static TimerNameRegistrar __stnr(name); ScopedTimer __scopedTimer(hashString(name), false, true);
 #define SCOPED_SPECIAL_TIMER_NOREG(name)                                          ScopedTimer __scopedTimer(hashString(name), false, true);

--- a/rts/System/TraceMemory.cpp
+++ b/rts/System/TraceMemory.cpp
@@ -1,0 +1,22 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#if defined(TRACY_ENABLE)
+
+#include <new>
+#include <cstdlib>
+#include <tracy/Tracy.hpp>
+
+void* operator new(std::size_t count)
+{
+	auto ptr = malloc(count);
+	TracyAlloc(ptr, count);
+	return ptr;
+}
+
+void operator delete (void* ptr) noexcept
+{
+	TracyFree(ptr);
+	free(ptr);
+}
+
+#endif

--- a/rts/builds/dedicated/CMakeLists.txt
+++ b/rts/builds/dedicated/CMakeLists.txt
@@ -22,7 +22,7 @@ set(ENGINE_SRC_ROOT_DIR "${CMAKE_SOURCE_DIR}/rts")
 ### Assemble libraries
 list(APPEND engineDedicatedLibraries cpuid)
 list(APPEND engineDedicatedLibraries ${Boost_REGEX_LIBRARY})
-list(APPEND engineDedicatedLibraries lua archives 7zip prd::jsoncpp ${SPRING_MINIZIP_LIBRARY} ${ZLIB_LIBRARY} gflags)
+list(APPEND engineDedicatedLibraries lua archives 7zip prd::jsoncpp ${SPRING_MINIZIP_LIBRARY} ${ZLIB_LIBRARY} gflags Tracy::TracyClient)
 list(APPEND engineDedicatedLibraries headlessStubs engineSystemNet)
 list(APPEND engineDedicatedLibraries ${LIBUNWIND_LIBRARIES})
 list(APPEND engineDedicatedLibraries ${LZMA_LIBRARY})

--- a/rts/builds/dedicated/CMakeLists.txt
+++ b/rts/builds/dedicated/CMakeLists.txt
@@ -97,6 +97,7 @@ set(system_files
 	${ENGINE_SRC_ROOT_DIR}/System/Log/LogSinkHandler.cpp
 	${ENGINE_SRC_ROOT_DIR}/System/Log/LogUtil.c
 	${ENGINE_SRC_ROOT_DIR}/System/Log/ConsoleSink.cpp
+	${ENGINE_SRC_ROOT_DIR}/System/Log/TracySink.cpp
 	${ENGINE_SRC_ROOT_DIR}/System/Misc/SpringTime.cpp
 	${ENGINE_SRC_ROOT_DIR}/System/Platform/errorhandler.cpp
 	${ENGINE_SRC_ROOT_DIR}/System/Platform/CpuID.cpp

--- a/rts/lib/CMakeLists.txt
+++ b/rts/lib/CMakeLists.txt
@@ -71,3 +71,6 @@ if    (NOT HEADLESS_SYSTEM)
 		ADD_SUBDIRECTORY(squish)
 	endif (USE_LIBSQUISH)
 endif (NOT HEADLESS_SYSTEM)
+
+option(TRACY_ENABLE "Enable tracy profiling" OFF)
+add_subdirectory(tracy)

--- a/rts/lib/CMakeLists.txt
+++ b/rts/lib/CMakeLists.txt
@@ -73,4 +73,14 @@ if    (NOT HEADLESS_SYSTEM)
 endif (NOT HEADLESS_SYSTEM)
 
 option(TRACY_ENABLE "Enable tracy profiling" OFF)
+
+# On demand profiling is *slightly* more expensive, but it allows to run the
+# build with tracing like regular build and attach late in game, where regular
+# trace would just run out of memory because of size.
+option(TRACY_ON_DEMAND "Enable tracy profiling" ON)
+
+# Off by default because it's pretty expensive and because some places use
+# raw malloc have to be used with care.
+option(TRACY_PROFILE_MEMORY "Profile memory allocations" OFF)
+
 add_subdirectory(tracy)

--- a/tools/unitsync/CMakeLists.txt
+++ b/tools/unitsync/CMakeLists.txt
@@ -48,6 +48,8 @@ include_directories(${ENGINE_SRC_ROOT}/lib/7zip)
 include_directories(${ENGINE_SRC_ROOT})
 include_directories(${CMAKE_BINARY_DIR}/src-generated/engine)
 
+# Just add include directories, but ENABLE_TRACY won't be defined so no linking issues
+include_directories(${ENGINE_SRC_ROOT}/lib/tracy/public)
 
 set(main_files
 	"${ENGINE_SRC_ROOT}/ExternalAI/LuaAIImplHandler.cpp"


### PR DESCRIPTION
Basic integration of https://github.com/wolfpld/tracy into engine. Pinned to version 0.9 using git submodule.

Tested on Linux GCC and Windows MSVC. It might be working on MINGW but per tracy documentation: "You may also try your luck with Mingw, but don’t get your hopes too high. This platform was usable some time ago, but nobody is actively working on resolving any issues you might encounter with it."

To enable tracy, you have to switch CMake option. There are a bunch of other tunables for profiling that increase/decrease cost and features.

Current features:
- Covered all existing scoped timer zones from existing build-in profiling.
- Added a bunch more zone definition in codebase to see execution in more details.
- Ploting of number of COB threads, game speed and wanted game speed
- Optional memory allocation profiler (Might not cover all allocations atm, depends on standard library using standard new operator)
- Integrated tracy Lua bindings so it's possible to add zones inside of the Game lua code.
- All logs are also send to profiler and are visible on timeline.

More options should be added as development and optimization happens, it takes time to add the most useful generic zones and plots: tracy documentation is quite excellent in describing features and useful integration modes.