### PR TITLE
Noop refactor to make MSVC compiler not crash with internal error

### DIFF
--- a/rts/Game/SelectedUnitsAI.cpp
+++ b/rts/Game/SelectedUnitsAI.cpp
@@ -18,6 +18,8 @@
 #include "Sim/Units/UnitDef.h"
 #include "Net/Protocol/NetProtocol.h"
 
+#include <algorithm>
+
 static constexpr int CMDPARAM_MOVE_X = 0;
 static constexpr int CMDPARAM_MOVE_Y = 1;
 static constexpr int CMDPARAM_MOVE_Z = 2;
@@ -536,12 +538,11 @@ bool CSelectedUnitsHandlerAI::SelectAttackNet(const Command& cmd, int playerNum)
 	const std::vector<int>& netSelectedUnitIDs = selectedUnitsHandler.netSelected[playerNum];
 
 	const unsigned int targetsCount = targetUnitIDs.size();
-	const unsigned int selectedCount = netSelectedUnitIDs.size();
-	      unsigned int realCount = 0;
-
-	if (selectedCount == 0)
+	const unsigned int realCount = std::count_if(netSelectedUnitIDs.begin(), netSelectedUnitIDs.end(), [](int id) {
+		return unitHandler.GetUnit(id) != nullptr;
+	});
+	if (realCount == 0)
 		return ret;
-
 
 	Command attackCmd(CMD_ATTACK, cmd.GetOpts(), 0.0f);
 
@@ -583,12 +584,7 @@ bool CSelectedUnitsHandlerAI::SelectAttackNet(const Command& cmd, int playerNum)
 			continue;
 
 		midPos += (queueingCmd? LastQueuePosition(unit): float3(unit->midPos));
-
-		realCount++;
 	}
-
-	if (realCount == 0)
-		return ret;
 
 	midPos /= realCount;
 


### PR DESCRIPTION
MSVC 17.4.5 crashes with internal compilation error when trying to build RelWithDebInfo:

```
25>C:\Users\Marek\Workspace\spring\rts\Game\SelectedUnitsAI.cpp(590): fatal error C1001: Internal compiler error.
25>(compiler file 'D:\a\_work\1\s\src\vctools\Compiler\Utc\src\p2\main.c', line 224)
25> To work around this problem, try simplifying or changing the program near the locations listed above.
25>If possible please provide a repro here: https://developercommunity.visualstudio.com
25>Please choose the Technical Support command on the Visual C++
25> Help menu, or open the Technical Support help file for more information
25>  link!RaiseException()+0x6c
25>  link!RaiseException()+0x6c
25>  link!InvokeCompilerPassW()+0x87d1b
25>  link!InvokeCompilerPassW()+0xf86f1
25>
25>C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(1096,5): error MSB6006: "link.exe" exited with code -529706956.
25>Done building project "engine-legacy.vcxproj" -- FAILED.
```

so I've rewritten the code as little as possible to get rid of this issue...