### PR TITLE
feat(UCtrl): Allow erase when local and spectator

### DIFF
--- a/rts/Game/InMapDrawModel.h
+++ b/rts/Game/InMapDrawModel.h
@@ -33,7 +33,7 @@ public:
 
 	bool AddPoint(const float3& pos, const std::string& label, int playerID);
 	bool AddLine(const float3& pos1, const float3& pos2, int playerID);
-	void EraseNear(const float3& pos, int playerID);
+	void EraseNear(const float3& pos, int playerID, const bool alwaysErase = false);
 	void EraseAll();
 
 	size_t GetNumPoints() const { return numPoints; }

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -3461,12 +3461,16 @@ int LuaUnsyncedCtrl::MarkerAddLine(lua_State* L)
 
 
 /*** @function Spring.MarkerErasePosition
+ *
+ * Issue an erase command for markers on the map.
+ *
  * @number x
  * @number y
  * @number z
  * @param noop
- * @bool[opt=false] localOnly
- * @number[opt] playerId
+ * @bool[opt=false] localOnly do not issue a network message, erase only for the current player
+ * @number[opt] playerId when not specified it uses the issuer playerId
+ * @bool[opt=false] alwaysErase erase any marker when `localOnly` and current player is spectating. Allows spectators to erase players markers locally
  * @treturn nil
  */
 int LuaUnsyncedCtrl::MarkerErasePosition(lua_State* L)
@@ -3483,7 +3487,9 @@ int LuaUnsyncedCtrl::MarkerErasePosition(lua_State* L)
 
 	const bool onlyLocal = luaL_optboolean(L, 5, false);
 	if (onlyLocal) {
-		inMapDrawerModel->EraseNear(pos, luaL_optnumber(L, 6, gu->myPlayerNum));
+		// always erase if onlyLocal and current player is spectator
+		const bool alwaysErase = luaL_optboolean(L, 7, false) && gu->spectating;
+		inMapDrawerModel->EraseNear(pos, luaL_optnumber(L, 6, gu->myPlayerNum), alwaysErase);
 	} else {
 		inMapDrawer->SendErase(pos);
 	}


### PR DESCRIPTION
Add 7th parameter `alwaysErase` to allow spectators to erase players markers when `onlyLocal`

Keep in mind it's already possible to erase all marks on map regardless if player generated or not, as a spectator, via clearmapmarks. We only allow targeted erasure for games that wish that to be possible.

Fixes #639 

cc @Ruwetuin