### PR TITLE
fix overview camera not being centered in 2nd and subsequent games

### DIFF
--- a/rts/Game/Camera/OverviewController.cpp
+++ b/rts/Game/Camera/OverviewController.cpp
@@ -8,13 +8,13 @@
 #include "Game/UI/MouseHandler.h"
 #include "System/Log/ILog.h"
 
-static float fit_cam_height_to_map(float map_x, float map_y, float fov) {
-    const auto extra_margin = 1.037;
-    const auto fov_coefficient = 1.0/math::tan(fov * math::DEG_TO_RAD) * extra_margin;
-    const auto max_height = 25000.0;
-    return std::min(CGround::GetHeightAboveWater(map_x, map_y, false) +
-                    (fov_coefficient * std::max(map_x / globalRendering->aspectRatio, map_y)),
-                    max_height);
+static float getCamHeightToFitMapInView(float mapx, float mapy, float fov) {
+    static constexpr float marginForUI = 1.037f; // leave some space for UI outside of map edges
+    static constexpr float maxHeight = 25000.0f;
+    const float fovCoefficient = 1.0f/math::tan(fov * math::DEG_TO_RAD) * marginForUI;
+    return std::min(CGround::GetHeightAboveWater(mapx, mapy, false) +
+                    (fovCoefficient * std::max(mapx / globalRendering->aspectRatio, mapy)),
+                    maxHeight);
 }
 
 COverviewController::COverviewController()
@@ -22,7 +22,7 @@ COverviewController::COverviewController()
 	enabled = false;
 	minimizeMinimap = false;
 
-	pos.y = fit_cam_height_to_map(pos.x, pos.z, fov/2.0);
+	pos.y = getCamHeightToFitMapInView(pos.x, pos.z, fov/2.0);
 	dir = float3(0.0f, -1.0f, -0.001f).ANormalize();
 }
 
@@ -59,6 +59,6 @@ bool COverviewController::SetState(const StateMap& sm)
 	// CCameraController::SetState(sm);
 	// always centered, allow only for FOV change
 	SetStateFloat(sm, "fov", fov);
-	pos.y = fit_cam_height_to_map(pos.x, pos.z, fov/2.0);
+	pos.y = getCamHeightToFitMapInView(pos.x, pos.z, fov/2.0);
 	return true;
 }

--- a/rts/Game/Camera/OverviewController.cpp
+++ b/rts/Game/Camera/OverviewController.cpp
@@ -8,7 +8,7 @@
 #include "Game/UI/MouseHandler.h"
 #include "System/Log/ILog.h"
 
-static float getCamHeightToFitMapInView(float mapx, float mapy, float fov) {
+static float GetCamHeightToFitMapInView(float mapx, float mapy, float fov) {
     static constexpr float marginForUI = 1.037f; // leave some space for UI outside of map edges
     static constexpr float maxHeight = 25000.0f;
     const float fovCoefficient = 1.0f/math::tan(fov * math::DEG_TO_RAD) * marginForUI;
@@ -22,7 +22,7 @@ COverviewController::COverviewController()
 	enabled = false;
 	minimizeMinimap = false;
 
-	pos.y = getCamHeightToFitMapInView(pos.x, pos.z, fov/2.0);
+	pos.y = GetCamHeightToFitMapInView(pos.x, pos.z, fov/2.0);
 	dir = float3(0.0f, -1.0f, -0.001f).ANormalize();
 }
 
@@ -59,6 +59,6 @@ bool COverviewController::SetState(const StateMap& sm)
 	// CCameraController::SetState(sm);
 	// always centered, allow only for FOV change
 	SetStateFloat(sm, "fov", fov);
-	pos.y = getCamHeightToFitMapInView(pos.x, pos.z, fov/2.0);
+	pos.y = GetCamHeightToFitMapInView(pos.x, pos.z, fov/2.0);
 	return true;
 }

--- a/rts/Game/Camera/OverviewController.cpp
+++ b/rts/Game/Camera/OverviewController.cpp
@@ -49,6 +49,8 @@ void COverviewController::GetState(StateMap& sm) const
 
 bool COverviewController::SetState(const StateMap& sm)
 {
-	CCameraController::SetState(sm);
+	// this camera is unique per map so we don't want to restore its settings
+	// from previous one
+	// CCameraController::SetState(sm);
 	return true;
 }


### PR DESCRIPTION
overview camera settings should not be loaded from previous maps as it depends on the current map dimensions only.

steps to reproduce: 
1. start a game on flats and forests v2.1
2. go back to menu and start a game on eight horses map.
3. press tab to go to overview camera and see that the view is not centered

in this screenshot the camera cuts a bit from the top and leaves too much space below the map
![Screenshot from 2023-02-25 22-34-44](https://user-images.githubusercontent.com/13596691/221380758-b1398d99-553d-4656-a7f7-1cb938a64db7.png)
