### PR TITLE
Cleanup Cob threads killed by signal early.

### DIFF
--- a/rts/Sim/Units/Scripts/CobEngine.cpp
+++ b/rts/Sim/Units/Scripts/CobEngine.cpp
@@ -62,8 +62,16 @@ bool CCobEngine::RemoveThread(int threadID) {
 	return false;
 }
 
-void CCobEngine::AddQueuedThreads() {
+void CCobEngine::ProcessQueuedThreads() {
 	ZoneScoped;
+
+	// Remove threads killed during Tick by other thread (SIGNAL), we do it
+	// here as nothing is actively referencing any thread's memory here.
+	for (int threadID: tickRemovedThreads) {
+		RemoveThread(threadID);
+	}
+	tickRemovedThreads.clear();
+
 	// move new threads spawned by START into threadInstances;
 	// their ID's will already have been scheduled into either
 	// waitingThreadIDs or sleepingThreadIDs
@@ -177,10 +185,10 @@ void CCobEngine::Tick(int deltaTime)
 	currentTime += deltaTime;
 
 	TickRunningThreads();
-	AddQueuedThreads();
+	ProcessQueuedThreads();
 
 	WakeSleepingThreads();
-	AddQueuedThreads();
+	ProcessQueuedThreads();
 }
 
 

--- a/rts/Sim/Units/Scripts/CobEngine.h
+++ b/rts/Sim/Units/Scripts/CobEngine.h
@@ -84,7 +84,8 @@ public:
 	int GetCurrentTime() const { return currentTime; }
 
 	void QueueAddThread(CCobThread&& thread) { tickAddedThreads.emplace_back(std::move(thread)); }
-	void AddQueuedThreads();
+	void QueueRemoveThread(int threadID) { tickRemovedThreads.emplace_back(threadID); }
+	void ProcessQueuedThreads();
 
 	void ScheduleThread(const CCobThread* thread);
 	void SanityCheckThreads(const CCobInstance* owner);
@@ -100,6 +101,8 @@ private:
 	spring::unordered_map<int, CCobThread> threadInstances;
 	// threads that are spawned during Tick
 	std::vector<CCobThread> tickAddedThreads;
+	// threads that are killed during Tick
+	std::vector<int> tickRemovedThreads;
 
 	std::vector<int> runningThreadIDs;
 	std::vector<int> waitingThreadIDs;

--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -590,7 +590,7 @@ int CCobInstance::RealCall(int functionId, std::array<int, 1 + MAX_COB_ARGS>& ar
 	}
 
 	// handle any spawned threads
-	cobEngine->AddQueuedThreads();
+	cobEngine->ProcessQueuedThreads();
 	return ret;
 }
 
@@ -708,6 +708,7 @@ void CCobInstance::Signal(int signal)
 			continue;
 
 		t->SetState(CCobThread::Dead);
+		cobEngine->QueueRemoveThread(t->GetID());
 	}
 }
 


### PR DESCRIPTION
Cleanup Cob threads killed by signal early.

Addressing https://github.com/beyond-all-reason/spring/issues/573

In the current implementation, when sleeping thread was killed by signal, it was destructed and removed from the CobInstance thread list only after it's sleep time was reached in CobEngine::WakeSleepingThreads which caused the list of threads for cob instance to quickly grow in size when sleep time was long. This was slowing down every operation that had to iterate over the list of active threads in the CobInstance and also used a lot of memory in the CobEngine.

This change initiates destruction of the thread killed by signal to an earlier point of time, on the next engine tick. All other operations that could reference that thread by id: like list of sleeping thread, are already ignoring threads not present in global thread map.

This reduced the number of active threads for 500 firing armjanus 100x, from hundreds, only to ~3-4 threads active threads per unit.