### PR TITLE
Remove `Game.allowTeamColors`

### DIFF
--- a/AI/Interfaces/Java/bin/native_createCallbackFunctionImpls.awk
+++ b/AI/Interfaces/Java/bin/native_createCallbackFunctionImpls.awk
@@ -7,7 +7,7 @@
 #
 # Accepts input like this:
 # [code]
-# 	bool allowTeamColors;
+# 	bool requireSonarUnderWater;
 # 
 # 	// construction related fields
 # 	/// Should constructions without builders decay?

--- a/rts/Lua/LuaConstGame.cpp
+++ b/rts/Lua/LuaConstGame.cpp
@@ -60,7 +60,6 @@
  * @string gameVersion
  * @string gameMutator
  * @string gameDesc
- * @bool allowTeamColors
  * @bool requireSonarUnderWater
  * @number transportAir
  * @number transportShip
@@ -212,11 +211,6 @@ bool LuaConstGame::PushEntries(lua_State* L)
 
 		LuaPushNamedString(L, "mapChecksum", mapHexDigest.data());
 		LuaPushNamedString(L, "modChecksum", modHexDigest.data());
-	}
-
-	{
-		// deprecated nonsense
-		LuaPushNamedBool(L, "allowTeamColors", true);
 	}
 
 	{


### PR DESCRIPTION
Obsolete and long deprecated.
As far as I can tell, not used by any game.
No need to pollute code and, more importantly, docs.