### PR TITLE
feat(OverviewCam): Add OverviewRotation option

### DIFF
--- a/rts/Game/Camera/OverviewController.h
+++ b/rts/Game/Camera/OverviewController.h
@@ -9,8 +9,17 @@ class COverviewController : public CCameraController
 {
 public:
 	COverviewController();
+	~COverviewController();
+
+	constexpr static float3 DIR_UP = float3(0.0f, -0.999999500000375f, -0.000999999500000375f); // -90 deg
+	constexpr static float3 DIR_LEFT = float3(0.000999999500000375f, -0.999999500000375f, 0.0f); // -90 deg
+	constexpr static float3 DIR_BOTTOM = float3(0.0f, -0.999999500000375f, 0.000999999500000375f); // 90 deg
+	constexpr static float3 DIR_RIGHT = float3(-0.000999999500000375f, -0.999999500000375f, 0.0f); // -90 deg
 
 	const std::string GetName() const { return "ov"; }
+
+	void ConfigNotify(const std::string& key, const std::string& value);
+	void ConfigUpdate();
 
 	void KeyMove(float3 move) override {}
 	void MouseMove(float3 move) override {}
@@ -29,6 +38,7 @@ public:
 
 private:
 	bool minimizeMinimap;
+	bool followRotation;
 };
 
 #endif // _OV_CONTROLLER_H

--- a/rts/Game/CameraHandler.cpp
+++ b/rts/Game/CameraHandler.cpp
@@ -428,6 +428,34 @@ void CCameraHandler::ToggleOverviewCamera()
 
 	if (controllerStack.empty()) {
 		PushMode();
+
+		// Set overview camera direction according to rotation of current camera
+		// controller. This way we avoid jarring transitions.
+		if (configHandler->GetBool("OverviewRotation")) {
+			const float rotY = fmod(abs(camHandler->GetCurrentController().GetRot().y), math::TWOPI);
+			float3 dir = COverviewController::DIR_UP;
+
+			static constexpr float three_quarters_pi = math::HALFPI + math::QUARTERPI;
+			static constexpr float five_quarters_pi = math::PI + math::QUARTERPI;
+			static constexpr float seven_quarters_pi = five_quarters_pi + math::HALFPI;
+
+			if (rotY < math::QUARTERPI) {
+			} else if (rotY < three_quarters_pi) {
+				dir = COverviewController::DIR_LEFT;
+			} else if (rotY < five_quarters_pi) {
+				dir = COverviewController::DIR_BOTTOM;
+			} else if (rotY < seven_quarters_pi) {
+				dir = COverviewController::DIR_RIGHT;
+			}
+
+			CCameraController::StateMap sm;
+			camControllers[CAMERA_MODE_OVERVIEW]->GetState(sm);
+			sm["dx"] = dir.x;
+			sm["dy"] = dir.y;
+			sm["dz"] = dir.z;
+			camControllers[CAMERA_MODE_OVERVIEW]->SetState(sm);
+		}
+
 		SetCameraMode(CAMERA_MODE_OVERVIEW);
 	} else {
 		PopMode();


### PR DESCRIPTION
Add "OverviewRotation" option, default false, so Overview camera controller is oriented in the closest direction to last camera controller rotation.

This avoids jarring transitions, especially useful for flipped overhead camera.