### PR TITLE
Spring controller add smooth mesh and static camera height tracking

### DIFF
--- a/rts/Game/Camera/SpringController.cpp
+++ b/rts/Game/Camera/SpringController.cpp
@@ -14,6 +14,7 @@
 #include "System/SpringMath.h"
 #include "System/Input/KeyInput.h"
 #include "Sim/Misc/SmoothHeightMesh.h"
+#include "Sim/Misc/ModInfo.h"
 
 namespace {
     enum HeightTracking : int {
@@ -73,6 +74,11 @@ void CSpringController::ConfigUpdate()
 	doRotate = configHandler->GetBool("CamSpringEdgeRotate");
 	lockCardinalDirections = configHandler->GetBool("CamSpringLockCardinalDirections");
 	trackMapHeight = configHandler->GetInt("CamSpringTrackMapHeightMode");
+
+	if (trackMapHeight == HeightTracking::Smooth && !modInfo.enableSmoothMesh) {
+		LOG_L(L_ERROR, "Smooth mesh disabled");
+		trackMapHeight = HeightTracking::Terrain;
+	}
 }
 
 void CSpringController::ConfigNotify(const std::string & key, const std::string & value)

--- a/rts/Game/Camera/SpringController.cpp
+++ b/rts/Game/Camera/SpringController.cpp
@@ -52,7 +52,7 @@ CSpringController::CSpringController()
 	, zoomBack(false)
 {
 	enabled = configHandler->GetBool("CamSpringEnabled");
-    configHandler->NotifyOnChange(this, {"CamSpringScrollSpeed", "CamSpringFOV", "CamSpringZoomInToMousePos", "CamSpringZoomOutFromMousePos", "CamSpringFastScaleMousewheelMove", "CamSpringFastScaleMouseMove", "CamSpringEdgeRotate", "CamSpringLockCardinalDirections", "CamSpringTrackMapHeightMode"});
+	configHandler->NotifyOnChange(this, {"CamSpringScrollSpeed", "CamSpringFOV", "CamSpringZoomInToMousePos", "CamSpringZoomOutFromMousePos", "CamSpringFastScaleMousewheelMove", "CamSpringFastScaleMouseMove", "CamSpringEdgeRotate", "CamSpringLockCardinalDirections", "CamSpringTrackMapHeightMode"});
 	ConfigUpdate();
 }
 
@@ -293,7 +293,6 @@ void CSpringController::Update()
 	pos.ClampInMap();
 
 	pos.y = CGround::GetHeightReal(pos.x, pos.z, false); // always focus on the ground
-
 	rot.x = Clamp(rot.x, math::PI * 0.51f, math::PI * 0.99f);
 
 	// camera->SetRot(float3(rot.x, GetAzimuth(), rot.z));

--- a/rts/Game/Camera/SpringController.h
+++ b/rts/Game/Camera/SpringController.h
@@ -56,6 +56,7 @@ private:
 	bool cursorZoomOut;
 	bool doRotate;
 	bool lockCardinalDirections;
+	bool trackMapHeight;
 };
 
 #endif // _SPRING_CONTROLLER_H

--- a/rts/Game/Camera/SpringController.h
+++ b/rts/Game/Camera/SpringController.h
@@ -42,6 +42,8 @@ private:
 	inline float ZoomIn(const float3& curCamPos, const float3& dir, const float& scaledMode);
 	inline float ZoomOut(const float3& curCamPos, const float3& dir, const float& curDistPre, const float& scaledMode);
 
+	void SmoothCamHeight(float3 prevPos);
+
 private:
 	float3 rot;
 
@@ -56,7 +58,7 @@ private:
 	bool cursorZoomOut;
 	bool doRotate;
 	bool lockCardinalDirections;
-	bool trackMapHeight;
+	int trackMapHeight;
 };
 
 #endif // _SPRING_CONTROLLER_H

--- a/rts/Game/Camera/SpringController.h
+++ b/rts/Game/Camera/SpringController.h
@@ -42,7 +42,7 @@ private:
 	inline float ZoomIn(const float3& curCamPos, const float3& dir, const float& scaledMode);
 	inline float ZoomOut(const float3& curCamPos, const float3& dir, const float& curDistPre, const float& scaledMode);
 
-	void SmoothCamHeight(float3 prevPos);
+	void SmoothCamHeight(const float3& prevPos);
 
 private:
 	float3 rot;


### PR DESCRIPTION
Fixes #708

SpringController - track airmesh height instead of ground  for smooth horizontal camera movements
* add bool option CamSpringTrackMapHeight (default=1) to disable tracking the ground height entirely. with this option disabled camera can move up if it's below the ground of the hill but will never go back down by itself