### PR TITLE
Allow shallow recursion in `Spring.TransferUnit`

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -10,6 +10,7 @@ Spring changelog
 
 Lua:
  - removed `Game.allowTeamColors` (was deprecated and always `true`)
+ - allow shallow recursion in `Spring.TransferUnit`
  
 
 Misc:

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -120,7 +120,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 		inCreateFeature = 0;
 		inDestroyFeature = 0;
 		inGiveOrder = 0;
-		inTransferUnit = false;
+		inTransferUnit = 0;
 		inHeightMap = false;
 		inSmoothMesh = false;
 
@@ -1704,16 +1704,16 @@ int LuaSyncedCtrl::TransferUnit(lua_State* L)
 	if (FullCtrl(L) && lua_isboolean(L, 3))
 		given = lua_toboolean(L, 3);
 
-	if (inTransferUnit)
-		luaL_error(L, "TransferUnit() recursion is not permitted");
+	if (inTransferUnit >= MAX_CMD_RECURSION_DEPTH)
+		luaL_error(L, "TransferUnit() recursion is not permitted, max depth: %d", MAX_CMD_RECURSION_DEPTH);
 
-	inTransferUnit = true;
+	++ inTransferUnit;
 	ASSERT_SYNCED(unit->id);
 	ASSERT_SYNCED((int)newTeam);
 	ASSERT_SYNCED(given);
 	unit->ChangeTeam(newTeam, given ? CUnit::ChangeGiven
 	                                : CUnit::ChangeCaptured);
-	inTransferUnit = false;
+	-- inTransferUnit;
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -26,8 +26,8 @@ class LuaSyncedCtrl
 		inline static int inCreateFeature = 0;
 		inline static int inDestroyFeature = 0;
 		inline static int inGiveOrder = 0;
+		inline static int inTransferUnit = 0;
 
-		inline static bool inTransferUnit = false;
 		inline static bool inHeightMap = false;
 		inline static bool inOriginalHeightMap = false;
 		inline static bool inSmoothMesh = false;


### PR DESCRIPTION
Same max depth as other callouts