### PR TITLE
Improve release creation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,11 @@
-name: Release Engine
+name: Draft Engine Release
 on:
   workflow_dispatch:
     inputs:
       wf-run-id:
         description: Workflow Run Id to Upload
         required: true
-        default: ""
-      bin-type:
-        description: Upload Spring as (prerelease|release)
-        required: true
-        default: "prerelease"
+        default: "latest"
       release-tag:
         description: Release Name/Tag
         required: false
@@ -31,12 +27,24 @@ jobs:
       - name: Download Artifacts
         id: dl-artifacts
         run: |
-          get_code=$(curl -X GET -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/beyond-all-reason/spring/actions/runs/${{ github.event.inputs.wf-run-id }}")
+          if [ "${{ github.event.inputs.wf-run-id }}" == "latest" ]; then
+            run_id=$(curl -X GET -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" -s 'https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-docker.yml/runs?status=success&per_page=1' | jq '.workflow_runs[0].id')
+            if [ "$run_id" == "null" ]; then
+              echo "Failed to fetch latest runs"
+              exit 1
+            fi
+          else
+            run_id="${{ github.event.inputs.wf-run-id }}"
+          fi
+
+          get_code=$(curl -X GET -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/${{ github.repository }}/actions/runs/${run_id}")
           if [ $get_code != 200 ]; then
+            echo "Failed to fetch run $run_id"
             exit 1
           fi
 
-          artifact_dl_urls=$(curl -X GET -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" -s "https://api.github.com/repos/beyond-all-reason/spring/actions/runs/${{ github.event.inputs.wf-run-id }}/artifacts" | jq ".artifacts[].archive_download_url" |  tr -d "\"")
+          echo "Creating release from run $run_id"
+          artifact_dl_urls=$(curl -X GET -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" -s "https://api.github.com/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts" | jq ".artifacts[].archive_download_url" |  tr -d "\"")
 
           for adl in $artifact_dl_urls; do
             curl -X GET -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" -L -s -o tmp.zip $adl
@@ -54,13 +62,9 @@ jobs:
         shell: bash
 
       - name: Upload Artifacts As Release
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./*
-          file_glob: true
-          overwrite: true
-          prerelease: ${{ github.event.inputs.bin-type == 'prerelease' }}
-          asset_name: ${{ steps.dl-artifacts.outputs.release_tag }}
-          tag: ${{ steps.dl-artifacts.outputs.release_tag }}
+          files: ./*
+          tag_name: ${{ steps.dl-artifacts.outputs.release_tag }}
           body: "Github Action Upload"
+          draft: true


### PR DESCRIPTION
- Don't create new release marked as pre-release, create a draft release instead that can be made a release that is neither latest nor-prelease, or just one of them. Had to switch to other github action to be able to do it.
- Rename workflow accordingly.
- Add logic to pick the latest engine build action run as default to reduce unnecesary copy pasting of the run id.
- Fix workflow on the forked repositories.