### PR TITLE
fix: Inverted orientation on frustumlines basis

### DIFF
--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -621,7 +621,7 @@ void CCamera::CalcFrustumLine(
 
 	// compose an orthonormal axis-system around the frustum plane normal
 	// top plane normal can point straight up if camera is angled downward
-	const float3 aux = (std::fabs(normal.dot(UpVector)) > 0.995f)? -forward: UpVector;
+	const float3 aux = (std::fabs(normal.dot(UpVector)) > 0.995f) ? forward : UpVector;
 
 	float3 xdir = (normal.cross( aux)).UnsafeANormalize();
 	float3 ydir = (normal.cross(xdir)).UnsafeANormalize();


### PR DESCRIPTION
What can only be assumed as a typo or an untested case dating back to 2025be7e2b843d5ecc43fb0bfd168b86276e4759