### PR TITLE
Unit Tracking - do not disable when rotating camera with middle mouse…

### DIFF
--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -277,7 +277,9 @@ void CMouseHandler::MouseMove(int x, int y, int dx, int dy)
 
 	if (buttons[SDL_BUTTON_MIDDLE].pressed && (activeReceiver == nullptr)) {
 		camHandler->GetCurrentController().MouseMove(float3(dx, dy, invertMouse ? -1.0f : 1.0f));
-		unitTracker.Disable();
+		if (!camHandler->GetActiveCamera()->GetMovState()[CCamera::MOVE_STATE_RTT]) {
+			unitTracker.Disable();
+		}
 		return;
 	}
 }


### PR DESCRIPTION
… button
not a beautiful fix but it works. 
Fixes #626 
@6AKU66 are there any other actions you can think of that should be patched for camera tracking?