### PR TITLE
Allow `Spring.SetActiveCommand(nil)` to cancel

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -10,6 +10,8 @@ Spring changelog
 
 Lua:
  - removed `Game.allowTeamColors` (was deprecated and always `true`)
+ - `Spring.SetActiveCommand()` or passing explicit `nil` now cancels the command.
+   The previous method to pass `-1` still works.
  - allow shallow recursion in `Spring.TransferUnit`
  
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2459,8 +2459,10 @@ int LuaUnsyncedCtrl::SetActiveCommand(lua_State* L)
 	if (guihandler == nullptr)
 		return 0;
 
-	if (lua_gettop(L) < 1)
-		luaL_error(L, "[%s] one argument required", __func__);
+	if (lua_isnoneornil(L, 1)) {
+		lua_pushboolean(L, guihandler->SetActiveCommand(-1, false));
+		return 1;
+	}
 
 	if (lua_isnumber(L, 1))
 		return SetActiveCommandByIndex(L);


### PR DESCRIPTION
Previously required passing an explicit `-1`