### PR TITLE
Optimize CProjectileDrawer::Draw

### DIFF
--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -947,7 +947,7 @@ size_t LuaVBOImpl::MatrixDataFromProjectileIDsImpl(const Iterable& ids, int attr
 		const CWeaponProjectile* wp = p->weapon ? static_cast<const CWeaponProjectile*>(p) : nullptr;
 		const bool doOffset = wp && wp->GetProjectileType() == WEAPON_MISSILE_PROJECTILE;
 
-		const CMatrix44f trMat = projectileDrawer->CanDrawProjectile(p, /*p->owner()*/ nullptr) ?
+		const CMatrix44f trMat = projectileDrawer->CanDrawProjectile(p, -1) ?
 			p->GetTransformMatrix(doOffset) :
 			CMatrix44f::Zero();
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -594,18 +594,18 @@ void CProjectileDrawer::DrawProjectilesSet(const std::vector<CProjectile*>& proj
 	}
 }
 
-bool CProjectileDrawer::CanDrawProjectile(const CProjectile* pro, const CSolidObject* owner)
+bool CProjectileDrawer::CanDrawProjectile(const CProjectile* pro, int allyTeam)
 {
 	auto& th = teamHandler;
 	auto& lh = losHandler;
-	return (gu->spectatingFullView || (owner != nullptr && th.Ally(owner->allyteam, gu->myAllyTeam)) || lh->InLos(pro, gu->myAllyTeam));
+	return (gu->spectatingFullView || (th.IsValidAllyTeam(allyTeam) && th.Ally(allyTeam, gu->myAllyTeam)) || lh->InLos(pro, gu->myAllyTeam));
 }
 
 void CProjectileDrawer::DrawProjectileNow(CProjectile* pro, bool drawReflection, bool drawRefraction)
 {
 	pro->drawPos = pro->GetDrawPos(globalRendering->timeOffset);
 
-	if (!CanDrawProjectile(pro, pro->owner()))
+	if (!CanDrawProjectile(pro, pro->GetAllyteamID()))
 		return;
 
 
@@ -655,7 +655,7 @@ void CProjectileDrawer::DrawProjectilesSetShadow(const std::vector<CProjectile*>
 
 void CProjectileDrawer::DrawProjectileShadow(CProjectile* p)
 {
-	if (CanDrawProjectile(p, p->owner())) {
+	if (CanDrawProjectile(p, p->GetAllyteamID())) {
 		const CCamera* cam = CCameraHandler::GetActiveCamera();
 		if (!cam->InView(p->drawPos, p->GetDrawRadius()))
 			return;
@@ -685,7 +685,7 @@ void CProjectileDrawer::DrawProjectilesMiniMap()
 			const auto& projectileBin = mdlRenderer.GetObjectBin(i);
 
 			for (CProjectile* p: projectileBin) {
-				if (!CanDrawProjectile(p, p->owner()))
+				if (!CanDrawProjectile(p, p->GetAllyteamID()))
 					continue;
 
 				p->DrawOnMinimap();
@@ -695,7 +695,7 @@ void CProjectileDrawer::DrawProjectilesMiniMap()
 
 	if (!modellessProjectiles.empty()) {
 		for (CProjectile* p: modellessProjectiles) {
-			if (!CanDrawProjectile(p, p->owner()))
+			if (!CanDrawProjectile(p, p->GetAllyteamID()))
 				continue;
 
 			p->DrawOnMinimap();

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -8,7 +8,6 @@
 #include "Game/GlobalUnsynced.h"
 #include "Game/LoadScreen.h"
 #include "Lua/LuaParser.h"
-#include "Map/MapInfo.h"
 #include "Rendering/GroundFlash.h"
 #include "Rendering/GlobalRendering.h"
 #include "Rendering/ShadowHandler.h"
@@ -17,9 +16,7 @@
 #include "Rendering/GL/FBO.h"
 #include "Rendering/GL/RenderBuffers.h"
 #include "Rendering/Shaders/Shader.h"
-#include "Rendering/Textures/Bitmap.h"
 #include "Rendering/Textures/ColorMap.h"
-#include "Rendering/Textures/S3OTextureHandler.h"
 #include "Rendering/Textures/TextureAtlas.h"
 #include "Rendering/Common/ModelDrawerHelpers.h"
 #include "Sim/Misc/GlobalSynced.h"
@@ -33,15 +30,25 @@
 #include "Sim/Weapons/WeaponDefHandler.h"
 #include "Sim/Weapons/WeaponDef.h"
 #include "System/Config/ConfigHandler.h"
-#include "System/Platform/Misc.h"
 #include "System/EventHandler.h"
 #include "System/Exceptions.h"
 #include "System/Log/ILog.h"
 #include "System/SafeUtil.h"
 #include "System/StringUtil.h"
 #include "System/ScopedResource.h"
+#include <tuple>
 
 CONFIG(int, SoftParticles).defaultValue(1).safemodeValue(0).description("Soften up CEG particles on clipping edges");
+
+
+static bool CProjectileDrawOrderSortingPredicate(const CProjectile* p1, const CProjectile* p2) noexcept {
+	return std::tie(p2->drawOrder, p1->GetSortDist(), p1) > std::tie(p1->drawOrder, p2->GetSortDist(), p2);
+}
+
+static bool CProjectileSortingPredicate(const CProjectile* p1, const CProjectile* p2) noexcept {
+	return std::tie(p1->GetSortDist(), p1) > std::tie(p2->GetSortDist(), p2);
+};
+
 
 CProjectileDrawer* projectileDrawer = nullptr;
 
@@ -327,8 +334,8 @@ void CProjectileDrawer::Kill() {
 	smokeTextures.clear();
 
 	modellessProjectiles.clear();
-	sortedProjectiles[0].clear();
-	sortedProjectiles[1].clear();
+	sortedProjectiles.clear();
+	unsortedProjectiles.clear();
 
 	perlinFB.Kill();
 
@@ -617,17 +624,12 @@ void CProjectileDrawer::DrawProjectileNow(CProjectile* pro, bool drawReflection,
 
 	pro->SetSortDist(cam->ProjectedDistance(pro->pos));
 
+	if (drawSorted && pro->drawSorted) {
+		sortedProjectiles.emplace_back(pro);
+	} else {
+		unsortedProjectiles.emplace_back(pro);
+	}
 
-	using PushProjectileFunctorsT = void (*)(CProjectileDrawer*, CProjectile*);
-	static PushProjectileFunctorsT PushProjectileFunctors[] = {
-		[](CProjectileDrawer* pd, CProjectile* pro) -> void {
-			pd->sortedProjectiles[0].emplace_back(pro);
-		},
-		[](CProjectileDrawer* pd, CProjectile* pro) -> void {
-			spring::VectorInsertSorted(pd->sortedProjectiles[1], pro, pd->GetSortingPredicate());
-		}
-	};
-	PushProjectileFunctors[drawSorted && pro->drawSorted](this, pro);
 }
 
 
@@ -756,8 +758,9 @@ void CProjectileDrawer::Draw(bool drawReflection, bool drawRefraction) {
 
 	ISky::GetSky()->SetupFog();
 
-	sortedProjectiles[0].clear();
-	sortedProjectiles[1].clear();
+
+	sortedProjectiles.clear();
+	unsortedProjectiles.clear();
 
 	{
 		{
@@ -777,11 +780,16 @@ void CProjectileDrawer::Draw(bool drawReflection, bool drawRefraction) {
 		// only z-sorted (if the projectiles indicate they want to be)
 		DrawProjectilesSet(modellessProjectiles, drawReflection, drawRefraction);
 
-		for (auto p : sortedProjectiles[1]) {
+		if (wantDrawOrder)
+			std::sort(sortedProjectiles.begin(), sortedProjectiles.end(), CProjectileDrawOrderSortingPredicate);
+		else
+			std::sort(sortedProjectiles.begin(), sortedProjectiles.end(), CProjectileSortingPredicate);
+
+		for (auto p : sortedProjectiles) {
 			p->Draw();
 		}
 
-		for (auto p : sortedProjectiles[0]) {
+		for (auto p : unsortedProjectiles) {
 			p->Draw();
 		}
 	}

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -42,11 +42,11 @@ CONFIG(int, SoftParticles).defaultValue(1).safemodeValue(0).description("Soften 
 
 
 static bool CProjectileDrawOrderSortingPredicate(const CProjectile* p1, const CProjectile* p2) noexcept {
-	return std::tie(p2->drawOrder, p1->GetSortDist(), p1) > std::tie(p1->drawOrder, p2->GetSortDist(), p2);
+	return std::make_tuple(p2->drawOrder, p1->GetSortDist(), p1) > std::make_tuple(p1->drawOrder, p2->GetSortDist(), p2);
 }
 
 static bool CProjectileSortingPredicate(const CProjectile* p1, const CProjectile* p2) noexcept {
-	return std::tie(p1->GetSortDist(), p1) > std::tie(p2->GetSortDist(), p2);
+	return std::make_tuple(p1->GetSortDist(), p1) > std::make_tuple(p2->GetSortDist(), p2);
 };
 
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -124,7 +124,7 @@ public:
 
 	AtlasedTexture* seismictex = nullptr;
 public:
-	static bool CanDrawProjectile(const CProjectile* pro, const CSolidObject* owner);
+	static bool CanDrawProjectile(const CProjectile* pro, int allyTeam);
 private:
 	static void ParseAtlasTextures(const bool, const LuaTable&, spring::unordered_set<std::string>&, CTextureAtlas*);
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -167,23 +167,9 @@ private:
 	/// projectiles with a model
 	std::array<ModelRenderContainer<CProjectile>, MODELTYPE_CNT> modelRenderers;
 
-	/// {[0] := unsorted, [1] := distance-sorted} projectiles;
 	/// used to render particle effects in back-to-front order
-	std::vector<CProjectile*> sortedProjectiles[2];
-
-	auto GetSortingPredicate() const {
-		auto sp = [this](const CProjectile* p1, const CProjectile* p2)
-		{
-			if (wantDrawOrder && p1->drawOrder != p2->drawOrder)
-				return (p1->drawOrder < p2->drawOrder);
-
-			if (p1->GetSortDist() != p2->GetSortDist()) // strict ordering required
-				return (p1->GetSortDist() > p2->GetSortDist());
-
-			return (p1 > p2);
-		};
-		return sp;
-	}
+	std::vector<CProjectile*> sortedProjectiles;
+	std::vector<CProjectile*> unsortedProjectiles;
 
 	bool drawSorted = true;
 

--- a/rts/Sim/Projectiles/Projectile.h
+++ b/rts/Sim/Projectiles/Projectile.h
@@ -92,7 +92,7 @@ public:
 	// UNSYNCED ONLY
 	CMatrix44f GetTransformMatrix(bool offsetPos) const;
 
-	float GetSortDist() const { return sortDist; }
+	const float& GetSortDist() const { return sortDist; }
 	void SetSortDist(float d) { sortDist = d + sortDistOffset; }
 public:
 	bool synced = false;           // is this projectile part of the simulation?

--- a/rts/Sim/Projectiles/Projectile.h
+++ b/rts/Sim/Projectiles/Projectile.h
@@ -92,7 +92,7 @@ public:
 	// UNSYNCED ONLY
 	CMatrix44f GetTransformMatrix(bool offsetPos) const;
 
-	const float& GetSortDist() const { return sortDist; }
+	float GetSortDist() const { return sortDist; }
 	void SetSortDist(float d) { sortDist = d + sortDistOffset; }
 public:
 	bool synced = false;           // is this projectile part of the simulation?


### PR DESCRIPTION
Instead of inserting inside the vector we append to it and sort after all elements are ready. This minor optimization reduces cpu cycles by 2% in 1 min demo play of `/fightertest armbull armbull 400` on spring-headless. No intended functional changes.

Measurements taken with command `sudo perf record -g -p $(pgrep spring) -F 999 -a`.
Overall cpu usage by projectile drawer is still very high but it's possible to move some heuristics to `RenderProjectileCreated()` instead (e.g. check if projectile is within camera range - in GTA style with dynamic world loading) can significantly reduce further cpu usage. Or somehow avoid copying CProjectile pointers to new vector altogether.
Before:
![Screenshot from 2023-05-04 00-49-13](https://user-images.githubusercontent.com/13596691/236073947-5e97277b-2092-4ca4-80b0-ad76205b2527.png)
After:
![Screenshot from 2023-05-04 00-49-23](https://user-images.githubusercontent.com/13596691/236073964-7542d39c-bc21-4705-b810-9408a8cd46d3.png)
