### PR TITLE
SpringController - zoom out fix

### DIFF
--- a/rts/Game/Camera/SpringController.cpp
+++ b/rts/Game/Camera/SpringController.cpp
@@ -225,6 +225,13 @@ float CSpringController::ZoomOut(const float3& curCamPos, const float3& newDir, 
 
 	const float newDist = CGround::LineGroundCol(wantedCamPos, wantedCamPos + dir * 150000.0f, false);
 
+	// don't move above the limit as translation loses precision
+	// and zooming-in to the same point is not possible
+	if (newDist > maxDist) {
+		curDist = curDistPre;
+		return 0.25f;
+	}
+
 	if (newDist > 0.0f)
 		pos = wantedCamPos + dir * (curDist = newDist);
 

--- a/rts/Game/Camera/SpringController.h
+++ b/rts/Game/Camera/SpringController.h
@@ -46,7 +46,7 @@ private:
 	float3 rot;
 
 	float curDist; // current zoom-out distance
-	float maxDist; // maximum zoom-out distance
+	const float maxDist; // maximum zoom-out distance
 	float oldDist;
 	float fastScaleMove;
 	float fastScaleMousewheel;


### PR DESCRIPTION
Fix zooming out when option CamSpringZoomOutFromMousePos is enabled. When camera is zoomed out maximally it will no longer move to the sides when mouse scrolled out.
Problem shown here https://streamable.com/5d0f4f . Sorry cursor is not visible but the lateral movement (when camera is already on the zoom limit) is undesired and uncontrollable.
After the fix the cursor always remains in the same place on the ground so it's possible to: 
1. scroll max out 
2. scroll back in to exactly the same point (if mouse wasn't moved)