### PR TITLE
gcc13 compatibility

### DIFF
--- a/rts/System/CRC.h
+++ b/rts/System/CRC.h
@@ -3,6 +3,7 @@
 #ifndef CRC_H
 #define CRC_H
 
+#include <cstdint>
 #include <string>
 
 /** @brief An updateable CRC-32 checksum. */

--- a/rts/System/Platform/Misc.h
+++ b/rts/System/Platform/Misc.h
@@ -3,6 +3,7 @@
 #ifndef PLATFORM_MISC_H
 #define PLATFORM_MISC_H
 
+#include <cstdint>
 #include <string>
 #include <array>
 

--- a/rts/System/Sound/ISound.h
+++ b/rts/System/Sound/ISound.h
@@ -3,6 +3,7 @@
 #ifndef _I_SOUND_H_
 #define _I_SOUND_H_
 
+#include <cstdint>
 #include <string>
 
 class float3;

--- a/rts/System/SpringHash.h
+++ b/rts/System/SpringHash.h
@@ -4,6 +4,7 @@
 #define _SPRING_HASH_H_
 
 #include "lib/xxhash/xxh3.h"
+#include <cstdint>
 #include <string>
 #include <type_traits>
 #include <memory>

--- a/rts/System/SpringHashMap.hpp
+++ b/rts/System/SpringHashMap.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstdlib>
 #include <iterator>
 #include <utility>

--- a/rts/System/SpringHashSet.hpp
+++ b/rts/System/SpringHashSet.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstdlib> // malloc
 #include <iterator>
 #include <utility>

--- a/rts/System/StringHash.h
+++ b/rts/System/StringHash.h
@@ -3,6 +3,8 @@
 #ifndef STRING_HASH_H
 #define STRING_HASH_H
 
+#include <cstdint>
+
 [[nodiscard]] uint32_t HashString(const char* s, size_t n);
 [[nodiscard]] static inline uint32_t HashString(const std::string& s) { return (HashString(s.c_str(), s.size())); }
 

--- a/rts/System/StringUtil.h
+++ b/rts/System/StringUtil.h
@@ -3,6 +3,7 @@
 #ifndef STRING_UTIL_H
 #define STRING_UTIL_H
 
+#include <cstdint>
 #include <algorithm>
 #include <cstring>
 #include <string>

--- a/rts/lib/luasocket/src/restrictions.cpp
+++ b/rts/lib/luasocket/src/restrictions.cpp
@@ -2,6 +2,7 @@
 
 #include "restrictions.h"
 
+#include <cstdint>
 #include <string>
 
 #include "System/SafeUtil.h"


### PR DESCRIPTION
Not sure how viable it's till we consider gcc13, maybe gcc14+ will do it other way.

gcc13 throws compilation error:
```
rts/lib/luasocket/src/restrictions.cpp:32:8: error: ‘uint8_t’ does not name a type
   32 | static uint8_t luaSocketRestrictionsMem[sizeof(CLuaSocketRestrictions)];
      |        ^~~~~~~
rts/lib/luasocket/src/restrictions.cpp:11:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   10 | #include "System/Config/ConfigHandler.h"
  +++ |+#include <cstdint>
   11 | 
```

Also next submodules require `#include <cstdint>`
```
tools/pr-downloader/src/FileSystem/FileSystem.h
AI/Skirmish/CircuitAI/src/circuit/util/MaskHandler.h
AI/Skirmish/BARb/src/circuit/util/MaskHandler.h
```