### PR TITLE
remove obsolete Intel C Compiler support

### DIFF
--- a/AI/Interfaces/C/src/Interface.cpp
+++ b/AI/Interfaces/C/src/Interface.cpp
@@ -116,7 +116,7 @@ sharedLib_t CInterface::LoadSkirmishAILib(
 	std::string funcName = "getLevelOfSupportFor";
 	void* funcAddr = sharedLib_findAddress(sharedLib, funcName.c_str());
 
-	skirmishAILibrary->getLevelOfSupportFor = (LevelOfSupport (CALLING_CONV_FUNC_POINTER *)(
+	skirmishAILibrary->getLevelOfSupportFor = (LevelOfSupport (CALLING_CONV *)(
 		const char* aiShortName,
 		const char* aiVersion,
 		const char* engineVersionString,
@@ -134,7 +134,7 @@ sharedLib_t CInterface::LoadSkirmishAILib(
 	funcName = "init";
 	funcAddr = sharedLib_findAddress(sharedLib, funcName.c_str());
 
-	skirmishAILibrary->init = (int (CALLING_CONV_FUNC_POINTER *)(
+	skirmishAILibrary->init = (int (CALLING_CONV *)(
 		int skirmishAIId,
 		const SSkirmishAICallback*
 	)) funcAddr;
@@ -149,7 +149,7 @@ sharedLib_t CInterface::LoadSkirmishAILib(
 	funcName = "release";
 	funcAddr = sharedLib_findAddress(sharedLib, funcName.c_str());
 
-	skirmishAILibrary->release = (int (CALLING_CONV_FUNC_POINTER *)(
+	skirmishAILibrary->release = (int (CALLING_CONV *)(
 		int skirmishAIId
 	)) funcAddr;
 
@@ -163,7 +163,7 @@ sharedLib_t CInterface::LoadSkirmishAILib(
 	funcName = "handleEvent";
 	funcAddr = sharedLib_findAddress(sharedLib, funcName.c_str());
 
-	skirmishAILibrary->handleEvent = (int (CALLING_CONV_FUNC_POINTER *)(
+	skirmishAILibrary->handleEvent = (int (CALLING_CONV *)(
 		int skirmishAIId,
 		int topicId,
 		const void* data

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,12 +423,7 @@ add_definitions(-DASIO_STANDALONE)
 
 ### compiler specific flags
 set(CXX_FLAGS_DEBUG_ADDITIONAL "")
-if    ($ENV{CXX} MATCHES "icpc")
-	# intel C/C++ compiler fix; it does not support these flags:
-	# "-march -mfpmath -msse -ggdb"
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -axK") # SSE1
-	set(CXX_FLAGS_DEBUG_ADDITIONAL "-g -debug full")
-elseif (CMAKE_COMPILER_IS_GNUCXX)
+if (CMAKE_COMPILER_IS_GNUCXX)
 	if    (UNIX)
 		check_and_add_flags(CMAKE_CXX_FLAGS "-fdiagnostics-color=auto")
 	endif (UNIX)
@@ -472,7 +467,7 @@ elseif (MSVC)
 	add_definitions(-D_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS)
 else   (MSVC)
 	message(WARNING "unknown compiler")
-endif ($ENV{CXX} MATCHES "icpc")
+endif ($CMAKE_COMPILER_IS_GNUCXX)
 
 set(CXX_DEBUG_DEFINES          "-DDEBUG -D_DEBUG -DNO_CATCH_EXCEPTIONS")
 set(CXX_RELWITHDEBINFO_DEFINES "-DNDEBUG")

--- a/rts/ExternalAI/AIInterfaceLibrary.cpp
+++ b/rts/ExternalAI/AIInterfaceLibrary.cpp
@@ -261,7 +261,7 @@ int CAIInterfaceLibrary::InitializeFromLib(const std::string& libFilePath) {
 	const char* funcName = "initStatic";
 	const void* funcAddr = sharedLib->FindAddress(funcName);
 
-	sAIInterfaceLibrary.initStatic = (int (CALLING_CONV_FUNC_POINTER *)(
+	sAIInterfaceLibrary.initStatic = (int (CALLING_CONV *)(
 		int interfaceId,
 		const SAIInterfaceCallback* callback
 	)) funcAddr;
@@ -276,7 +276,7 @@ int CAIInterfaceLibrary::InitializeFromLib(const std::string& libFilePath) {
 	funcName = "releaseStatic";
 	funcAddr = sharedLib->FindAddress(funcName);
 
-	sAIInterfaceLibrary.releaseStatic = (int (CALLING_CONV_FUNC_POINTER *)(
+	sAIInterfaceLibrary.releaseStatic = (int (CALLING_CONV *)(
 	)) funcAddr;
 
 	if (sAIInterfaceLibrary.releaseStatic == nullptr) {
@@ -290,7 +290,7 @@ int CAIInterfaceLibrary::InitializeFromLib(const std::string& libFilePath) {
 	funcName = "getLevelOfSupportFor";
 	funcAddr = sharedLib->FindAddress(funcName);
 
-	sAIInterfaceLibrary.getLevelOfSupportFor = (LevelOfSupport (CALLING_CONV_FUNC_POINTER *)(
+	sAIInterfaceLibrary.getLevelOfSupportFor = (LevelOfSupport (CALLING_CONV *)(
 		const char*,
 		int
 	)) funcAddr;
@@ -306,7 +306,7 @@ int CAIInterfaceLibrary::InitializeFromLib(const std::string& libFilePath) {
 	funcName = "loadSkirmishAILibrary";
 	funcAddr = sharedLib->FindAddress(funcName);
 
-	sAIInterfaceLibrary.loadSkirmishAILibrary = (const SSkirmishAILibrary* (CALLING_CONV_FUNC_POINTER *)(
+	sAIInterfaceLibrary.loadSkirmishAILibrary = (const SSkirmishAILibrary* (CALLING_CONV *)(
 		const char* const shortName,
 		const char* const version
 	)) funcAddr;
@@ -320,7 +320,7 @@ int CAIInterfaceLibrary::InitializeFromLib(const std::string& libFilePath) {
 	funcName = "unloadSkirmishAILibrary";
 	funcAddr = sharedLib->FindAddress(funcName);
 
-	sAIInterfaceLibrary.unloadSkirmishAILibrary = (int (CALLING_CONV_FUNC_POINTER *)(
+	sAIInterfaceLibrary.unloadSkirmishAILibrary = (int (CALLING_CONV *)(
 		const char* const shortName,
 		const char* const version
 	)) funcAddr;
@@ -334,7 +334,7 @@ int CAIInterfaceLibrary::InitializeFromLib(const std::string& libFilePath) {
 	funcName = "unloadAllSkirmishAILibraries";
 	funcAddr = sharedLib->FindAddress(funcName);
 
-	sAIInterfaceLibrary.unloadAllSkirmishAILibraries = (int (CALLING_CONV_FUNC_POINTER *)(
+	sAIInterfaceLibrary.unloadAllSkirmishAILibraries = (int (CALLING_CONV *)(
 	)) funcAddr;
 
 	if (sAIInterfaceLibrary.unloadAllSkirmishAILibraries == nullptr) {
@@ -344,32 +344,32 @@ int CAIInterfaceLibrary::InitializeFromLib(const std::string& libFilePath) {
 
 
 	funcAddr = nullptr;
-	sAIInterfaceLibrary.listSkirmishAILibraries = (int (CALLING_CONV_FUNC_POINTER *)(
+	sAIInterfaceLibrary.listSkirmishAILibraries = (int (CALLING_CONV *)(
 		int interfaceId
 	)) funcAddr;
 
 	funcAddr = nullptr;
-	sAIInterfaceLibrary.listSkirmishAILibraryInfos = (int (CALLING_CONV_FUNC_POINTER *)(
+	sAIInterfaceLibrary.listSkirmishAILibraryInfos = (int (CALLING_CONV *)(
 		int interfaceId,
 		int aiIndex
 	)) funcAddr;
 
 	funcAddr = nullptr;
-	sAIInterfaceLibrary.listSkirmishAILibraryInfoKey = (const char* (CALLING_CONV_FUNC_POINTER *)(
+	sAIInterfaceLibrary.listSkirmishAILibraryInfoKey = (const char* (CALLING_CONV *)(
 		int interfaceId,
 		int aiIndex,
 		int infoIndex
 	)) funcAddr;
 
 	funcAddr = nullptr;
-	sAIInterfaceLibrary.listSkirmishAILibraryInfoValue = (const char* (CALLING_CONV_FUNC_POINTER *)(
+	sAIInterfaceLibrary.listSkirmishAILibraryInfoValue = (const char* (CALLING_CONV *)(
 		int interfaceId,
 		int aiIndex,
 		int infoIndex
 	)) funcAddr;
 
 	funcAddr = nullptr;
-	sAIInterfaceLibrary.listSkirmishAILibraryOptions = (const char* (CALLING_CONV_FUNC_POINTER *)(
+	sAIInterfaceLibrary.listSkirmishAILibraryOptions = (const char* (CALLING_CONV *)(
 		int interfaceId,
 		int aiIndex
 	)) funcAddr;

--- a/rts/System/ConcurrentQueue.h
+++ b/rts/System/ConcurrentQueue.h
@@ -134,7 +134,7 @@ namespace moodycamel { namespace details {
 // Use a nice trick from this answer: http://stackoverflow.com/a/8438730/21475
 // In order to get a numeric thread ID in a platform-independent way, we use a thread-local
 // static variable's address as a thread identifier :-)
-#if defined(__GNUC__) || defined(__INTEL_COMPILER)
+#if defined(__GNUC__)
 #define MOODYCAMEL_THREADLOCAL __thread
 #elif defined(_MSC_VER)
 #define MOODYCAMEL_THREADLOCAL __declspec(thread)

--- a/rts/System/ExportDefines.h
+++ b/rts/System/ExportDefines.h
@@ -73,11 +73,6 @@
 	#endif // defined _WIN64 ...
 #endif // CALLING_CONV
 
-// Is used when assigning function pointers, for example in:
-// ExternalAI/AIInterfaceLibrary.cpp
-// Originally implemented as a fix for Intel compiler
-#define CALLING_CONV_FUNC_POINTER CALLING_CONV
-
 #define EXPORT(type) SHARED_EXPORT type CALLING_CONV
 
 

--- a/rts/System/ExportDefines.h
+++ b/rts/System/ExportDefines.h
@@ -68,23 +68,15 @@
 		#define CALLING_CONV SPRING_CALLING_CONVENTION_2
 	#elif __GNUC__
 		#define CALLING_CONV __attribute__ ((SPRING_CALLING_CONVENTION))
-	#elif __INTEL_COMPILER
-		#define CALLING_CONV __attribute__ ((SPRING_CALLING_CONVENTION))
 	#else // defined _WIN64 ...
 		#define CALLING_CONV SPRING_CALLING_CONVENTION_2
 	#endif // defined _WIN64 ...
 #endif // CALLING_CONV
 
-// Intel Compiler compatibility fix for non-Windows
 // Is used when assigning function pointers, for example in:
 // ExternalAI/AIInterfaceLibrary.cpp
-#ifndef CALLING_CONV_FUNC_POINTER
-	#if !defined(_WIN32) && defined(__INTEL_COMPILER)
-		#define CALLING_CONV_FUNC_POINTER
-	#else
-		#define CALLING_CONV_FUNC_POINTER CALLING_CONV
-	#endif
-#endif // CALLING_CONV_FUNC_POINTER
+// Originally implemented as a fix for Intel compiler
+#define CALLING_CONV_FUNC_POINTER CALLING_CONV
 
 #define EXPORT(type) SHARED_EXPORT type CALLING_CONV
 


### PR DESCRIPTION
this removes checks and code related to support for the Intel C Compiler Classic. this compiler is officially deprecated by Intel, and is almost certainly not actually supported for building this engine. the last commits related to this compiler seem to be about 15 years old.

this (somewhat ironically) comes as part of my effort to improve platform support for the engine - cleaning out cruft makes it easier to rewrite what is left into a better state.