### PR TITLE
Add a way to disable `/info`

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -29,6 +29,9 @@ Lua:
 
 Misc:
  - Add `/debugvisibility` command for debugging the visible quadfield quads
+ - add `system.allowEnginePlayerlist` modrule, defaults to true. If false,
+   the built-in `/info` playerlist won't display. Use for anonymous modes
+   in conjunction with `Spring.GetPlayerInfo` poisoning.
  
 
 Sim:

--- a/rts/Game/UI/PlayerRosterDrawer.cpp
+++ b/rts/Game/UI/PlayerRosterDrawer.cpp
@@ -12,6 +12,7 @@
 #include "Rendering/GlobalRendering.h"
 #include "Sim/Misc/GlobalConstants.h"
 #include "Sim/Misc/GlobalSynced.h"
+#include "Sim/Misc/ModInfo.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "System/GlobalConfig.h"
 #include "System/Misc/SpringTime.h"
@@ -23,6 +24,9 @@
 void CPlayerRosterDrawer::Draw()
 {
 	if (playerRoster.GetSortType() == PlayerRoster::Disabled)
+		return;
+
+	if (!modInfo.allowEnginePlayerlist)
 		return;
 
 	const unsigned currentTime = spring_now().toSecsi();

--- a/rts/Lua/LuaConstGame.cpp
+++ b/rts/Lua/LuaConstGame.cpp
@@ -207,6 +207,8 @@ bool LuaConstGame::PushEntries(lua_State* L)
 
 		LuaPushNamedBool  (L, "paralyzeOnMaxHealth", modInfo.paralyzeOnMaxHealth);
 		LuaPushNamedNumber(L, "paralyzeDeclineRate", modInfo.paralyzeDeclineRate);
+
+		LuaPushNamedBool  (L, "allowEnginePlayerlist", modInfo.allowEnginePlayerlist);
 	}
 
 	if (archiveScanner != nullptr && mapInfo != nullptr) {

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -119,6 +119,8 @@ void CModInfo::ResetState()
 		SLuaAllocLimit::MAX_ALLOC_BYTES = SLuaAllocLimit::MAX_ALLOC_BYTES_DEFAULT;
 
 		allowTake = true;
+
+		allowEnginePlayerlist = true;
 	}
 }
 
@@ -168,6 +170,7 @@ void CModInfo::Init(const std::string& modFileName)
 		SLuaAllocLimit::MAX_ALLOC_BYTES = static_cast<decltype(SLuaAllocLimit::MAX_ALLOC_BYTES)>(system.GetInt("LuaAllocLimit", SLuaAllocLimit::MAX_ALLOC_BYTES >> 20u)) << 20u;
 
 		allowTake = system.GetBool("allowTake", allowTake);
+		allowEnginePlayerlist = system.GetBool("allowEnginePlayerlist", allowEnginePlayerlist);
 	}
 
 	{

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -200,6 +200,7 @@ public:
 	int quadFieldQuadSizeInElmos;
 
 	bool allowTake;
+	bool allowEnginePlayerlist;
 };
 
 extern CModInfo modInfo;


### PR DESCRIPTION
New version of #175 with a simpler approach.