### PR TITLE
Spring cam zoom out when cursor points out of map bounds

### DIFF
--- a/rts/Game/Camera/SpringController.cpp
+++ b/rts/Game/Camera/SpringController.cpp
@@ -279,10 +279,21 @@ float CSpringController::ZoomOut(const float3& curCamPos, const float3& newDir, 
 		return 0.25f;
 
 	// same logic as ZoomIn, but in opposite direction
-	const float3 zoomedCamPos =    curCamPos + newDir * zoomInDist;
-	const float3 wantedCamPos = zoomedCamPos - newDir * zoomInDist * scaledMode;
+	const float3 cursorVec = newDir * zoomInDist;
 
-	const float newDist = CGround::LineGroundCol(wantedCamPos, wantedCamPos + dir * 150000.0f, false);
+	auto extrapolate_position = [&] (float scale) {
+		const float3 wantedCamPos = curCamPos + cursorVec * (1.0f - scaledMode) * scale;
+		const float newDist = DistanceToGround(wantedCamPos, dir, pos.y);
+		return std::pair{wantedCamPos, newDist};
+	};
+
+	auto [wantedCamPos, newDist] = extrapolate_position(1.0);
+	// don't move above the limit as camera height will be trimmed and the 
+	// transition will not appear smooth
+	if (newDist > maxDist) {
+		// try to get as close as possible to the height limit
+		std::tie(wantedCamPos, newDist) = extrapolate_position(0.5);
+	}
 
 	if (newDist > maxDist) {
 		curDist = curDistPre;

--- a/rts/Game/Camera/SpringController.cpp
+++ b/rts/Game/Camera/SpringController.cpp
@@ -273,7 +273,7 @@ float CSpringController::ZoomOut(const float3& curCamPos, const float3& newDir, 
 	if (!cursorZoomOut)
 		return 0.25f;
 
-	const float zoomInDist = CGround::LineGroundCol(curCamPos, curCamPos + newDir * 150000.0f, false);
+	const float zoomInDist = DistanceToGround(curCamPos, newDir, pos.y);
 
 	if (zoomInDist <= 0.0f)
 		return 0.25f;
@@ -284,8 +284,6 @@ float CSpringController::ZoomOut(const float3& curCamPos, const float3& newDir, 
 
 	const float newDist = CGround::LineGroundCol(wantedCamPos, wantedCamPos + dir * 150000.0f, false);
 
-	// don't move above the limit as translation loses precision
-	// and zooming-in to the same point is not possible
 	if (newDist > maxDist) {
 		curDist = curDistPre;
 		return 0.25f;


### PR DESCRIPTION
CamSpringZoomOutFromMousePos is an option that changes zoom-out behavior to zoom from the cursor instead current camera focus.
Before the fix the camera wouldn't zoom out from the cursor if the cursor was pointed outside the map bounds.
Another improvement is to make the camera zoom closer to maximum limit if current translation vector is too big and new camera position would be past it (zooming out with shift modifier uses bigger vector than zooming just using the scroll).