### PR TITLE
disable debug library postfix

### DIFF
--- a/rts/lib/assimp/CMakeLists.txt
+++ b/rts/lib/assimp/CMakeLists.txt
@@ -263,12 +263,6 @@ SET( ASSIMP_INCLUDE_INSTALL_DIR "include" CACHE STRING
 SET( ASSIMP_BIN_INSTALL_DIR "bin" CACHE STRING
   "Path the tool executables are installed to." )
 
-#IF (CMAKE_BUILD_TYPE STREQUAL "Debug")
-#  SET(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Debug Postfix for lib, samples and tools")
-#ELSE()
-#  SET(CMAKE_DEBUG_POSTFIX "" CACHE STRING "Debug Postfix for lib, samples and tools")
-#ENDIF()
-
 # Only generate this target if no higher-level project already has
 # IF (NOT TARGET uninstall)
   # # add make uninstall capability

--- a/rts/lib/assimp/CMakeLists.txt
+++ b/rts/lib/assimp/CMakeLists.txt
@@ -263,11 +263,11 @@ SET( ASSIMP_INCLUDE_INSTALL_DIR "include" CACHE STRING
 SET( ASSIMP_BIN_INSTALL_DIR "bin" CACHE STRING
   "Path the tool executables are installed to." )
 
-IF (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  SET(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Debug Postfix for lib, samples and tools")
-ELSE()
-  SET(CMAKE_DEBUG_POSTFIX "" CACHE STRING "Debug Postfix for lib, samples and tools")
-ENDIF()
+#IF (CMAKE_BUILD_TYPE STREQUAL "Debug")
+#  SET(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Debug Postfix for lib, samples and tools")
+#ELSE()
+#  SET(CMAKE_DEBUG_POSTFIX "" CACHE STRING "Debug Postfix for lib, samples and tools")
+#ENDIF()
 
 # Only generate this target if no higher-level project already has
 # IF (NOT TARGET uninstall)


### PR DESCRIPTION
DataDirLocater depeneds on specific library names and with custom postfix it failed to find libsync.so (renamed to libsyncd.so) in current directory. bug prevents spring to start/recognize correct datadir. affects Debug builds only.
 
https://github.com/beyond-all-reason/spring/blob/cbeb010dca48d56f9ce6d474e309992d671db7bb/rts/System/FileSystem/DataDirLocater.cpp#L61

commented out entire section as assimp shouldn't change our global project settings.