### PR TITLE
Remove singletons from audio stream

### DIFF
--- a/rts/System/FileSystem/FileHandler.h
+++ b/rts/System/FileSystem/FileHandler.h
@@ -22,6 +22,7 @@
 class CFileHandler
 {
 public:
+	CFileHandler() { Close(); }
 	CFileHandler(const char* fileName, const char* modes = SPRING_VFS_RAW_FIRST);
 	CFileHandler(const std::string& fileName, const std::string& modes = SPRING_VFS_RAW_FIRST);
 	virtual ~CFileHandler() { Close(); }
@@ -63,7 +64,6 @@ public:
 
 
 protected:
-	CFileHandler() { Close(); } // for CGZFileHandler
 
 	virtual bool TryReadFromPWD(const std::string& fileName);
 	virtual bool TryReadFromRawFS(const std::string& fileName);

--- a/rts/System/Sound/OpenAL/MusicStream.cpp
+++ b/rts/System/Sound/OpenAL/MusicStream.cpp
@@ -1,36 +1,19 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 #include "MusicStream.h"
 
-#include "System/FileSystem/FileHandler.h"
 #include "System/Sound/SoundLog.h"
 #include "System/SafeUtil.h"
 #include "ALShared.h"
 #include "VorbisShared.h"
-#include "System/Sound/OpenAL/OggDecoder.h"
-#include "System/Sound/OpenAL/Mp3Decoder.h"
 
-#include <cstring> //memset
 #include <filesystem>
 #include <string_view>
 #include <variant>
 
-// NOTE:
-//   this buffer gets recycled by each new stream, across *all* audio-channels
-//   as a result streams are limited to only ever being played within a single
-//   channel (currently BGMusic), but cause far less memory fragmentation
-// TODO:
-//   can easily be fixed if necessary by giving each channel its own index and
-//   passing that along to the callbacks via COggStream{::Play}
-// CFileHandler fileBuffers[NUM_AUDIO_CHANNELS];
-static CFileHandler fileBuffer("", "");
 
-// FIXME these parts of MusicStream are outside the class because every instance
-// of CSoundSource has a copy of MusicStream class but only one is ever active
-static std::variant<OggDecoder, Mp3Decoder> decoder;
-
-
-MusicStream::MusicStream(ALuint _source)
-	: source(_source)
+MusicStream::MusicStream()
+	: buffers{}
+	, source(0)
 	, format(AL_FORMAT_MONO16)
 	, stopped(true)
 	, paused(false)
@@ -38,7 +21,6 @@ MusicStream::MusicStream(ALuint _source)
 	, lastTick(spring_nulltime)
 	, totalTime(0.0f)
 {
-	std::fill(buffers.begin(), buffers.end(), 0);
 }
 
 MusicStream::~MusicStream()
@@ -46,32 +28,8 @@ MusicStream::~MusicStream()
 	Stop();
 }
 
-
-MusicStream& MusicStream::operator=(MusicStream&& rhs) noexcept
-{
-	if (this != &rhs) {
-		std::swap(pcmDecodeBuffer, rhs.pcmDecodeBuffer);
-
-		for (auto i = 0; i < buffers.size(); ++i) {
-			std::swap(buffers[i], rhs.buffers[i]);
-		}
-
-		std::swap(source, rhs.source);
-		std::swap(format, rhs.format);
-
-		std::swap(stopped, rhs.stopped);
-		std::swap(paused, rhs.paused);
-
-		std::swap(msecsPlayed, rhs.msecsPlayed);
-		std::swap(lastTick, rhs.lastTick);
-		std::swap(totalTime, rhs.totalTime);
-	}
-
-	return *this;
-}
-
 // open a music stream from a given file and start playing it
-void MusicStream::Play(const std::string& path, float volume)
+void MusicStream::Play(const std::string& path, float volume, ALuint src)
 {
 	// we're already playing another stream
 	if (!stopped)
@@ -85,6 +43,8 @@ void MusicStream::Play(const std::string& path, float volume)
 		return;
 	}
 
+	source = src;
+
 	if (fileBuffer.GetFileExt() == std::string_view{"mp3"}) {
 		decoder = Mp3Decoder();
 	} else {
@@ -93,7 +53,6 @@ void MusicStream::Play(const std::string& path, float volume)
 	}
 
 	if (!fileBuffer.IsBuffered()) {
-		// TODO move buffer to class scope
 		auto& buf = fileBuffer.GetBuffer();
 		buf.resize(fileBuffer.FileSize());
 		fileBuffer.Read(buf.data(), fileBuffer.FileSize());
@@ -138,11 +97,12 @@ void MusicStream::Stop()
 	ReleaseBuffers();
 
 	msecsPlayed = spring_nulltime;
+	totalTime = 0.0f;
 	lastTick = spring_gettime();
 
-	source = 0;
 	format = 0;
-	totalTime = 0.0f;
+	stopped = true;
+	paused = false;
 
 	assert(!Valid());
 }
@@ -150,8 +110,8 @@ void MusicStream::Stop()
 // clean up the OpenAL resources
 void MusicStream::ReleaseBuffers()
 {
-	stopped = true;
-	paused = false;
+	if (!source)
+		return;
 
 #if 0
 	EmptyBuffers();
@@ -167,6 +127,10 @@ void MusicStream::ReleaseBuffers()
 	alDeleteBuffers(2, buffers.data());
 	CheckError("[MusicStream::ReleaseBuffers][2]");
 	std::fill(buffers.begin(), buffers.end(), 0);
+
+	source = 0;
+	assert(!Valid());
+	assert(IsFinished());
 }
 
 
@@ -248,7 +212,8 @@ void MusicStream::Update()
 		// releasing buffers is only allowed once the source has actually
 		// stopped playing, since it might still be reading from the last
 		// decoded chunk
-		if (UpdateBuffers(), !IsPlaying())
+		UpdateBuffers();
+		if (!IsPlaying())
 			ReleaseBuffers();
 
 		msecsPlayed += (tick - lastTick);

--- a/rts/System/Sound/OpenAL/MusicStream.h
+++ b/rts/System/Sound/OpenAL/MusicStream.h
@@ -4,6 +4,9 @@
 #define MUSIC_STREAM_H
 
 #include "System/Misc/SpringTime.h"
+#include "System/Sound/OpenAL/OggDecoder.h"
+#include "System/Sound/OpenAL/Mp3Decoder.h"
+#include "System/FileSystem/FileHandler.h"
 
 #include <al.h>
 #include <ogg/ogg.h>
@@ -11,21 +14,22 @@
 
 #include <array>
 #include <string>
+#include <variant>
 
 
 class MusicStream
 {
 public:
-	MusicStream(ALuint _source = 0);
+	MusicStream();
 	~MusicStream();
 
 	MusicStream(const MusicStream& rhs) = delete;
 	MusicStream& operator=(const MusicStream& rhs) = delete;
 
-	MusicStream(MusicStream&& rhs) noexcept { *this = std::move(rhs); }
-	MusicStream& operator=(MusicStream&& rhs) noexcept;
+	MusicStream(MusicStream&& rhs) = delete;
+	MusicStream& operator=(MusicStream&& rhs) = delete;
 
-	void Play(const std::string& path, float volume);
+	void Play(const std::string& path, float volume, ALuint src);
 	void Stop();
 	void Update();
 
@@ -65,6 +69,9 @@ private:
 	spring_time msecsPlayed;
 	spring_time lastTick;
 	float totalTime;
+
+	std::variant <OggDecoder, Mp3Decoder> decoder;
+	CFileHandler fileBuffer;
 };
 
 #endif // MUSIC_STREAM_H


### PR DESCRIPTION
This change allows for creating more sound streams. We currently have only one dedicated to BG music. https://github.com/beyond-all-reason/spring/blob/414df1e8bb81535792fe9e77a6dcc0ae8c44e414/rts/System/Sound/ISoundChannels.h#L11
 
TODO rewrite SoundSource and AudioChannel and split samples from streams?