### PR TITLE
Add `Script.DelayByFrames`

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -40,6 +40,9 @@ Lua:
  - add `Spring.GetUnitIsBeingBuilt(unitID) -> bool beingBuilt, number buildProgress`. Note that this
    doesn't bring new capability because `buildProgress` was already available from `GetUnitHealth`,
    and `beingBuilt` from `GetUnitIsStunned`, but as you can see it wasn't terribly convenient/intuitive.
+ - add `Script.DelayByFrames(frameDelay, function, args...)`. Runs `function(args...)` after a delay
+   of the specified number of frames (at least 1). Multiple functions can be queued onto the same frame
+   and run in the order they were added, just before that frame's GameFrame call-in.
  
 
 Misc:

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -10,7 +10,9 @@
 #include "LuaHashString.h"
 #include "lib/lua/include/LuaInclude.h" //FIXME needed for GetLuaContextData
 
+#include <map>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #define LUA_HANDLE_ORDER_RULES            100
@@ -326,6 +328,9 @@ class CLuaHandle : public CEventClient
 
 		std::string killMsg;
 
+		std::map <int, std::vector <std::pair <int, std::vector <int>>>> delayedCallsByFrame;
+		void RunDelayedFunctions(int frameNum);
+
 		std::vector<bool> watchUnitDefs;        // callin masks for Unit*Collision, UnitMoveFailed
 		std::vector<bool> watchFeatureDefs;     // callin masks for UnitFeatureCollision
 		std::vector<bool> watchProjectileDefs;  // callin masks for Projectile*
@@ -347,6 +352,7 @@ class CLuaHandle : public CEventClient
 		static int CallOutGetCallInList(lua_State* L);
 		static int CallOutUpdateCallIn(lua_State* L);
 		static int CallOutIsEngineMinVersion(lua_State* L);
+		static int CallOutDelayByFrames(lua_State* L);
 
 	public: // static
 #if (!defined(UNITSYNC) && !defined(DEDICATED))


### PR DESCRIPTION
User story: many games want to run something after X frames, this is a very common case.

Some games poll the frame in the GameFrame event manually, in each individual wupget that needs it:
https://github.com/ZeroK-RTS/Zero-K/blob/master/LuaRules/Gadgets/unit_puppy_handler.lua#L231
https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/luarules/gadgets/chicken_spawner_defense.lua#L1465

Some more advanced games have an internal API for this:
https://github.com/spring1944/spring1944/blob/master/LuaRules/Gadgets/api_delay.lua
https://github.com/FluidPlay/TAPrime/blob/master/luarules/gadgets/api_delay.lua
https://github.com/Spring-SpringBoard/SpringBoard-Core/blob/master/LuaRules/Gadgets/api_delay.lua

Such commonly desired game-agnostic building block would be an excellent addition to the engine.