### PR TITLE
Fix COB SetMaxReloadTime parameter

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -164,6 +164,7 @@ Fixes:
  - Fix issues where the ground and other visibility features would not render or return expected
    features when looking at certain oblique angles
  - Fix using Set<Any>RulesParam with an incorrect type leaving that param set with a value of 0.
+ - Fix COB SetMaxReloadTime receiving a value 10% smaller than it should
 
 
 

--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -190,18 +190,15 @@ bool CCobInstance::HasTargetWeight(int weaponNum) const
 void CCobInstance::Create()
 {
 	ZoneScoped;
-	// calculate maximum reload-time of the available weapons
-	int maxReloadTime = 0;
 
-	for (const CWeapon* w: unit->weapons) {
-		maxReloadTime = std::max(maxReloadTime, w->reloadTime);
-	}
+	int maxReloadFrames = 0;
+	for (const auto* w: unit->weapons)
+		maxReloadFrames = std::max(maxReloadFrames, w->reloadTime);
 
-	// convert ticks to milliseconds
-	maxReloadTime *= GAME_SPEED;
+	const int maxReloadMs = 1000 * maxReloadFrames / GAME_SPEED;
 
 	Call(COBFN_Create);
-	Call(COBFN_SetMaxReloadTime, maxReloadTime);
+	Call(COBFN_SetMaxReloadTime, maxReloadMs);
 }
 
 


### PR DESCRIPTION
Was supposed to multiply by 1000/30 but instead multiplied by 30. Happens to be close enough to the proper value, and the parameter is unimportant enough, that apparently nobody noticed.