### PR TITLE
Modrules: `allowGroundUnitGravity` defaults to false

### DIFF
--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -32,7 +32,7 @@ void CModInfo::ResetState()
 		allowUnitCollisionDamage   = false;
 		allowUnitCollisionOverlap  = true;
 		allowSepAxisCollisionTest  = false;
-		allowGroundUnitGravity     = true;
+		allowGroundUnitGravity     = false;
 		allowHoverUnitStrafing     = true;
 
 		maxCollisionPushMultiplier = std::numeric_limits<float>::infinity();


### PR DESCRIPTION
The default makes for bad gameplay in the cases where it makes a difference. Units randomly fall off cliffs, or get stuck on cliffs when they are already at the bottom. I can't tell whether falling off cliffs is the main feature, it brings C&C Generals GLA Bike to mind, which was very cool when it worked, but it seems fairly hard to actually do it on purpose in our implementation, plus there is no pathfinder support to use it automatically where appropriate. Here's an example of the difference (the bottom-right corner shows `false`, the top-left shows units that have the same stats but the modrule is set to `true`): https://www.youtube.com/watch?v=4e3qHOrALZU

Most known games use `false` already:
https://github.com/ZeroK-RTS/Zero-K/blob/master/gamedata/modrules.lua#L26
https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/gamedata/modrules.lua#L74
https://github.com/SplinterFaction/SplinterFaction/blob/master/Gamedata/modrules.lua#L26
https://github.com/FluidPlay/TAP/blob/main/gamedata/modrules.lua#L7
https://github.com/techannihilation/TA/blob/master/gamedata/modrules.lua#L32
https://github.com/PicassoCT/MOSAIC/blob/master/gamedata/modrules.lua#L15
https://github.com/Balanced-Annihilation/Balanced-Annihilation/blob/master/gamedata/modrules.lua#L26
https://github.com/SpringMCLegacy/SpringMCLegacy/blob/master/Gamedata/modrules.lua#L15

No known games use an explicit `true` (though that doesn't necessarily mean it's unwanted, because that's the default). These games rely on the defaults, I made sure they won't have a regression:
https://github.com/springraaar/metal_factions/pull/7
https://github.com/spring1944/spring1944/pull/478
https://github.com/azaremoth/cursed/pull/9
