### PR TITLE
feat: add fixedSeed param to GameSetup and use it to initialize RNG

### DIFF
--- a/doc/StartScriptFormat.txt
+++ b/doc/StartScriptFormat.txt
@@ -50,7 +50,8 @@
 	NumTeams=y;         // same here, set this to check if the script is right
 	NumAllyTeams=z;     // see above
 
-	FixedSeed = 1; //Initialize the synced RNG with a specific seed for reproducible benchmarking runs only
+	FixedSeed = 1; // Initialize the synced RNG with a specific seed for reproducible runs, eg. for benchmarking or cutscenes.
+                       // Default value 0 will generate a random seed.
 
 	// A player (controlls a team, player 0 is the host only if IsHost is not set)
 	[PLAYER0]

--- a/doc/StartScriptFormat.txt
+++ b/doc/StartScriptFormat.txt
@@ -50,6 +50,8 @@
 	NumTeams=y;         // same here, set this to check if the script is right
 	NumAllyTeams=z;     // see above
 
+	FixedSeed = 1; //Initialize the synced RNG with a specific seed for reproducible benchmarking runs only
+
 	// A player (controlls a team, player 0 is the host only if IsHost is not set)
 	[PLAYER0]
 	{

--- a/doc/StartScriptFormat.txt
+++ b/doc/StartScriptFormat.txt
@@ -50,8 +50,8 @@
 	NumTeams=y;         // same here, set this to check if the script is right
 	NumAllyTeams=z;     // see above
 
-	FixedSeed = 1; // Initialize the synced RNG with a specific seed for reproducible runs, eg. for benchmarking or cutscenes.
-                       // Default value 0 will generate a random seed.
+	FixedRNGSeed = 1; // Initialize the synced RNG with a specific seed for reproducible runs, eg. for benchmarking or cutscenes.
+                          // Default value 0 will generate a random seed.
 
 	// A player (controlls a team, player 0 is the host only if IsHost is not set)
 	[PLAYER0]

--- a/rts/Game/GameSetup.cpp
+++ b/rts/Game/GameSetup.cpp
@@ -37,7 +37,7 @@ CR_REG_METADATA(CGameSetup, (
 	CR_IGNORED(dsMapHash),
 	CR_IGNORED(dsModHash),
 	CR_IGNORED(mapSeed),
-	CR_IGNORED(fixedSeed),
+	CR_IGNORED(fixedRNGSeed),
 
 	CR_IGNORED(gameStartDelay),
 
@@ -181,7 +181,7 @@ void CGameSetup::ResetState()
 	std::memset(dsMapHash, 0, sizeof(dsMapHash));
 	std::memset(dsModHash, 0, sizeof(dsModHash));
 	mapSeed = 0;
-	fixedSeed = 0;
+	fixedRNGSeed = 0;
 
 	gameStartDelay = 0;
 	numDemoPlayers = 0;
@@ -584,7 +584,7 @@ bool CGameSetup::Init(const std::string& buf)
 
 	file.GetTDef(mapSeed, unsigned(0), "GAME\\MapSeed");
 
-	file.GetTDef(fixedSeed, unsigned(0), "GAME\\FixedSeed"); // 0 means use random seed
+	file.GetTDef(fixedRNGSeed, unsigned(0), "GAME\\FixedRNGSeed"); // 0 means use random seed
 	gameID      = file.SGetValueDef("",  "GAME\\GameID");
 	modName     = file.SGetValueDef("",  "GAME\\Gametype");
 	mapName     = file.SGetValueDef("",  "GAME\\MapName");

--- a/rts/Game/GameSetup.cpp
+++ b/rts/Game/GameSetup.cpp
@@ -37,6 +37,7 @@ CR_REG_METADATA(CGameSetup, (
 	CR_IGNORED(dsMapHash),
 	CR_IGNORED(dsModHash),
 	CR_IGNORED(mapSeed),
+	CR_IGNORED(fixedSeed),
 
 	CR_IGNORED(gameStartDelay),
 
@@ -180,6 +181,7 @@ void CGameSetup::ResetState()
 	std::memset(dsMapHash, 0, sizeof(dsMapHash));
 	std::memset(dsModHash, 0, sizeof(dsModHash));
 	mapSeed = 0;
+	fixedSeed = 0;
 
 	gameStartDelay = 0;
 	numDemoPlayers = 0;
@@ -582,6 +584,7 @@ bool CGameSetup::Init(const std::string& buf)
 
 	file.GetTDef(mapSeed, unsigned(0), "GAME\\MapSeed");
 
+	file.GetTDef(fixedSeed, unsigned(0), "GAME\\FixedSeed"); // 0 means use random seed
 	gameID      = file.SGetValueDef("",  "GAME\\GameID");
 	modName     = file.SGetValueDef("",  "GAME\\Gametype");
 	mapName     = file.SGetValueDef("",  "GAME\\MapName");

--- a/rts/Game/GameSetup.h
+++ b/rts/Game/GameSetup.h
@@ -44,7 +44,7 @@ public:
 		std::copy(gs.dsMapHash, gs.dsMapHash + sizeof(dsMapHash), dsMapHash);
 		std::copy(gs.dsModHash, gs.dsModHash + sizeof(dsModHash), dsModHash);
 		mapSeed = gs.mapSeed;
-		fixedSeed = gs.fixedSeed;
+		fixedRNGSeed = gs.fixedRNGSeed;
 
 		gameStartDelay = gs.gameStartDelay;
 
@@ -175,7 +175,7 @@ public:
 		StartPos_Last             = 3  // last entry in enum (for user input check)
 	};
 
-	uint32_t fixedSeed;
+	uint32_t fixedRNGSeed;
 
 	bool fixedAllies;
 	bool useLuaGaia;

--- a/rts/Game/GameSetup.h
+++ b/rts/Game/GameSetup.h
@@ -44,6 +44,7 @@ public:
 		std::copy(gs.dsMapHash, gs.dsMapHash + sizeof(dsMapHash), dsMapHash);
 		std::copy(gs.dsModHash, gs.dsModHash + sizeof(dsModHash), dsModHash);
 		mapSeed = gs.mapSeed;
+		fixedSeed = gs.fixedSeed;
 
 		gameStartDelay = gs.gameStartDelay;
 
@@ -174,6 +175,7 @@ public:
 		StartPos_Last             = 3  // last entry in enum (for user input check)
 	};
 
+	uint32_t fixedSeed;
 
 	bool fixedAllies;
 	bool useLuaGaia;

--- a/rts/Game/PreGame.cpp
+++ b/rts/Game/PreGame.cpp
@@ -242,10 +242,10 @@ void CPreGame::StartServer(const std::string& setupscript)
 	std::shared_ptr<CGameSetup> startGameSetup(new CGameSetup());
 
 	startGameSetup->Init(setupscript);
-	if (startGameSetup->fixedSeed == 0) {
+	if (startGameSetup->fixedRNGSeed == 0) {
 		startGameData->SetRandomSeed(static_cast<unsigned>(guRNG.NextInt()));
 	} else {
-		startGameData->SetRandomSeed(startGameSetup->fixedSeed);
+		startGameData->SetRandomSeed(startGameSetup->fixedRNGSeed);
 	}
 
 	if (startGameSetup->mapName.empty())

--- a/rts/Game/PreGame.cpp
+++ b/rts/Game/PreGame.cpp
@@ -242,7 +242,11 @@ void CPreGame::StartServer(const std::string& setupscript)
 	std::shared_ptr<CGameSetup> startGameSetup(new CGameSetup());
 
 	startGameSetup->Init(setupscript);
-	startGameData->SetRandomSeed(static_cast<unsigned>(guRNG.NextInt()));
+	if (startGameSetup->fixedSeed == 0) {
+		startGameData->SetRandomSeed(static_cast<unsigned>(guRNG.NextInt()));
+	} else {
+		startGameData->SetRandomSeed(startGameSetup->fixedSeed);
+	}
 
 	if (startGameSetup->mapName.empty())
 		throw content_error("No map selected in startscript");

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -269,11 +269,11 @@ void CGameServer::Initialize()
 
 	if (!demoReader) {
 		GenerateAndSendGameID();
-		if (myGameSetup->fixedSeed == 0) {
+		if (myGameSetup->fixedRNGSeed == 0) {
 			rng.Seed(gameID.intArray[0] ^ gameID.intArray[1] ^ gameID.intArray[2] ^ gameID.intArray[3]);
 			Broadcast(CBaseNetProtocol::Get().SendRandSeed(rng()));
 		} else {
-			Broadcast(CBaseNetProtocol::Get().SendRandSeed(myGameSetup->fixedSeed));
+			Broadcast(CBaseNetProtocol::Get().SendRandSeed(myGameSetup->fixedRNGSeed));
 		}
 	}
 }

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -268,9 +268,13 @@ void CGameServer::Initialize()
 	streflop::streflop_init<streflop::Simple>();
 
 	if (!demoReader) {
-		GenerateAndSendGameID();
-		rng.Seed(gameID.intArray[0] ^ gameID.intArray[1] ^ gameID.intArray[2] ^ gameID.intArray[3]);
-		Broadcast(CBaseNetProtocol::Get().SendRandSeed(rng()));
+		if (myGameSetup->fixedSeed == 0) {
+			GenerateAndSendGameID();
+			rng.Seed(gameID.intArray[0] ^ gameID.intArray[1] ^ gameID.intArray[2] ^ gameID.intArray[3]);
+			Broadcast(CBaseNetProtocol::Get().SendRandSeed(rng()));
+		} else {
+			Broadcast(CBaseNetProtocol::Get().SendRandSeed(myGameSetup->fixedSeed));
+		}
 	}
 }
 

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -268,8 +268,8 @@ void CGameServer::Initialize()
 	streflop::streflop_init<streflop::Simple>();
 
 	if (!demoReader) {
+		GenerateAndSendGameID();
 		if (myGameSetup->fixedSeed == 0) {
-			GenerateAndSendGameID();
 			rng.Seed(gameID.intArray[0] ^ gameID.intArray[1] ^ gameID.intArray[2] ^ gameID.intArray[3]);
 			Broadcast(CBaseNetProtocol::Get().SendRandSeed(rng()));
 		} else {

--- a/rts/builds/dedicated/main.cpp
+++ b/rts/builds/dedicated/main.cpp
@@ -163,7 +163,11 @@ int main(int argc, char* argv[])
 		const uint32_t randSeed = time(nullptr) % ((spring_gettime().toNanoSecsi() + 1) * 9007);
 
 		rng.Seed(randSeed);
-		dsGameData->SetRandomSeed(rng.NextInt());
+		if (dsGameData->fixedSeed == 0) {
+			dsGameData->SetRandomSeed(rng.NextInt());
+		} else {
+			dsGameData->SetRandomSeed(dsGameData->fixedSeed);
+		}
 
 		{
 			sha512::raw_digest dsMapChecksum;

--- a/rts/builds/dedicated/main.cpp
+++ b/rts/builds/dedicated/main.cpp
@@ -163,10 +163,10 @@ int main(int argc, char* argv[])
 		const uint32_t randSeed = time(nullptr) % ((spring_gettime().toNanoSecsi() + 1) * 9007);
 
 		rng.Seed(randSeed);
-		if (dsGameSetup->fixedSeed == 0) {
+		if (dsGameSetup->fixedRNGSeed == 0) {
 			dsGameData->SetRandomSeed(rng.NextInt());
 		} else {
-			dsGameData->SetRandomSeed(dsGameSetup->fixedSeed);
+			dsGameData->SetRandomSeed(dsGameSetup->fixedRNGSeed);
 		}
 
 		{

--- a/rts/builds/dedicated/main.cpp
+++ b/rts/builds/dedicated/main.cpp
@@ -163,10 +163,10 @@ int main(int argc, char* argv[])
 		const uint32_t randSeed = time(nullptr) % ((spring_gettime().toNanoSecsi() + 1) * 9007);
 
 		rng.Seed(randSeed);
-		if (dsGameData->fixedSeed == 0) {
+		if (dsGameSetup->fixedSeed == 0) {
 			dsGameData->SetRandomSeed(rng.NextInt());
 		} else {
-			dsGameData->SetRandomSeed(dsGameData->fixedSeed);
+			dsGameData->SetRandomSeed(dsGameSetup->fixedSeed);
 		}
 
 		{


### PR DESCRIPTION
By specifying a fixed seed, this fixes variance between benchmark runs of, say, fightertest. See thread in: https://discord.com/channels/549281623154229250/1122484736913318021

Credit to @Beherith for figuring out this was a seeding issue

Feel free to nitpick, so I can get a better idea of what's important to y'all.