### PR TITLE
simplify container util func VectorInsertUniqueSorted

### DIFF
--- a/rts/Sim/Misc/GroundBlockingObjectMap.cpp
+++ b/rts/Sim/Misc/GroundBlockingObjectMap.cpp
@@ -239,7 +239,7 @@ bool CGroundBlockingObjectMap::CellInsertUnique(unsigned int sqr, CSolidObject* 
 		if (vecIndcs.empty()) {
 			assert(vecCells.size() > 0);
 			ac.SetVecIndx(vecCells.size());
-			vc = &spring::VectorEmplaceBack(vecCells);
+			vc = &vecCells.emplace_back();
 		} else {
 			ac.SetVecIndx(spring::VectorBackPop(vecIndcs));
 			vc = &vecCells[ac.GetVecIndx()];

--- a/rts/System/ContainerUtil.h
+++ b/rts/System/ContainerUtil.h
@@ -207,10 +207,6 @@ namespace spring {
 		return true;
 	}
 
-	// emulate C++17's emplace_back
-	template<typename T, typename... A>
-	static T& VectorEmplaceBack(std::vector<T>& v, A&&... a) { v.emplace_back(std::forward<A>(a)...); return (v.back()); }
-
 	template<typename T>
 	static T VectorBackPop(std::vector<T>& v) { T e = v.back(); v.pop_back(); return e; }
 };

--- a/rts/System/ContainerUtil.h
+++ b/rts/System/ContainerUtil.h
@@ -203,15 +203,7 @@ namespace spring {
 		if ((iter != v.end()) && (*iter == e))
 			return false;
 
-		v.push_back(e);
-
-		for (size_t n = v.size() - 1; n > 0; n--) {
-			if (pred(v[n - 1], v[n]))
-				break;
-
-			std::swap(v[n - 1], v[n]);
-		}
-
+		v.insert(iter, e);
 		return true;
 	}
 

--- a/rts/System/ContainerUtil.h
+++ b/rts/System/ContainerUtil.h
@@ -208,7 +208,7 @@ namespace spring {
 	}
 
 	template<typename T>
-	static T VectorBackPop(std::vector<T>& v) { T e = v.back(); v.pop_back(); return e; }
+	static T VectorBackPop(std::vector<T>& v) { T e = std::move(v.back()); v.pop_back(); return e; }
 };
 
 #endif

--- a/rts/System/ContainerUtil.h
+++ b/rts/System/ContainerUtil.h
@@ -212,7 +212,7 @@ namespace spring {
 	static T& VectorEmplaceBack(std::vector<T>& v, A&&... a) { v.emplace_back(std::forward<A>(a)...); return (v.back()); }
 
 	template<typename T>
-	static const T& VectorBackPop(std::vector<T>& v) { const T& e = v.back(); v.pop_back(); return e; }
+	static T VectorBackPop(std::vector<T>& v) { T e = v.back(); v.pop_back(); return e; }
 };
 
 #endif


### PR DESCRIPTION
VectorInsertUniqueSorted does not need to swap elements. lower_bound iterator already points to the right place and the rest of the vector is already sorted.
 improvement over previous implementation from 83 to 60 assembly lines for trivial types.