### PR TITLE
glTextureInfo fix & GL_CLAMP_TO_EDGE

### DIFF
--- a/rts/Lua/LuaOpenGLUtils.cpp
+++ b/rts/Lua/LuaOpenGLUtils.cpp
@@ -850,7 +850,7 @@ std::tuple<int, int, int> LuaMatTexture::GetSize() const
 			const LuaTextures& luaTextures = CLuaHandle::GetActiveTextures(reinterpret_cast<lua_State*>(state));
 			const LuaTextures::Texture* luaTexture = luaTextures.GetInfo(*reinterpret_cast<const size_t*>(&data));
 
-			return ReturnHelper(luaTexture->xsize, luaTexture->ysize);
+			return ReturnHelper(luaTexture->xsize, luaTexture->ysize, luaTexture->zsize);
 		} break;
 
 		case LUATEX_LUATEXTUREATLAS: {

--- a/rts/Rendering/Textures/NamedTextures.cpp
+++ b/rts/Rendering/Textures/NamedTextures.cpp
@@ -238,8 +238,8 @@ namespace CNamedTextures {
 			glBindTexture(GL_TEXTURE_2D, texID);
 
 			if (clamped) {
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 			}
 
 			if (nearest || linear) {


### PR DESCRIPTION
Fix glTextureInfo returning zero z-size for 3D textures.

GL_CLAMP is outdated and deprecated, use GL_CLAMP_TO_EDGE instead