### PR TITLE
Remove snext, spairs, and sipairs

### DIFF
--- a/cont/base/springcontent/LuaGadgets/system.lua
+++ b/cont/base/springcontent/LuaGadgets/system.lua
@@ -53,9 +53,6 @@ if (System == nil) then
     --  Unsynced Utilities
     --
     SYNCED  = SYNCED,
-    snext   = snext,
-    spairs  = spairs,
-    sipairs = sipairs,
 
     --
     --  Standard libraries

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -39,6 +39,8 @@ Lua:
    partially for technical reasons and can be changed if need be. Synced and specs see everything.
  - `Spring.MapArchive` and `Spring.UnmapArchive` have been temporarily removed due to sync safety.
    They will come back at some point, but there is no timeline yet. Use `Spring.UseArchive` meanwhile.
+ - removed `snext`, `spairs` and `sipairs`. These functions can be replaced by the regular `next`,
+   `pairs`, and `ipairs` respectively with no change in behaviour.
  - add `Spring.GetUnitIsBeingBuilt(unitID) -> bool beingBuilt, number buildProgress`. Note that this
    doesn't bring new capability because `buildProgress` was already available from `GetUnitHealth`,
    and `beingBuilt` from `GetUnitIsStunned`, but as you can see it wasn't terribly convenient/intuitive.

--- a/doc/site/migrating-from-spring.markdown
+++ b/doc/site/migrating-from-spring.markdown
@@ -170,6 +170,17 @@ end
 In the meantime, use `Spring.UseArchive`. These functions are going to come back at some point,
 but there is no concrete timeline for that yet.
 
+## Iterating synced proxy tables
+
+Functions for iterating synced proxy tables: `snext`, `spairs` and `sipairs` have been removed.
+These have been able to be replaced by the regular `next`, `pairs` and `ipairs` for some time
+already (so the change can be done before migrating):
+```diff
+ local syncedProxyTable = SYNCED.foo
+-for key, value in spairs(syncedProxyTable) do
++for key, value in  pairs(syncedProxyTable) do
+```
+
 ## General
 
 - Paletted image files are no longer accepted. Convert your images not to be paletted.

--- a/rts/Lua/LuaREADME.txt
+++ b/rts/Lua/LuaREADME.txt
@@ -19,8 +19,9 @@ The LuaHandleSynced derivatives all use the same mechanism for sync protection.
 2. The synced code can not read from the unsynced code, but may send
    messages to it.
 3. The unsynced code can read from the synced code using the SYNCED proxy table.
-   That table does not allow access to functions. There snext(), spairs(),
-   and sipairs() functions can be used on the SYNCED tables and its sub-tables.
+   That table makes *a copy* of the object on the other side, and only copies
+   numbers, strings, bools and tables (recursively but with the type restriction),
+   in particular this does not allow access to functions.
 
 
 Access Modes

--- a/rts/Lua/LuaSyncedTable.cpp
+++ b/rts/Lua/LuaSyncedTable.cpp
@@ -13,29 +13,6 @@ static int SyncTableIndex(lua_State* L);
 static int SyncTableNewIndex(lua_State* L);
 static int SyncTableMetatable(lua_State* L);
 
-
-/******************************************************************************/
-/******************************************************************************/
-
-static bool PushSyncedTable(lua_State* L)
-{
-	HSTR_PUSH(L, "SYNCED");
-	lua_newtable(L); { // the proxy table
-
-		lua_newtable(L); { // the metatable
-			LuaPushNamedCFunc(L, "__index",     SyncTableIndex);
-			LuaPushNamedCFunc(L, "__newindex",  SyncTableNewIndex);
-			LuaPushNamedCFunc(L, "__metatable", SyncTableMetatable);
-		}
-
-		lua_setmetatable(L, -2);
-	}
-	lua_rawset(L, -3);
-
-	return true;
-}
-
-
 /******************************************************************************/
 
 static int SyncTableIndex(lua_State* dstL)
@@ -95,18 +72,18 @@ static int SyncTableMetatable(lua_State* L)
 
 bool LuaSyncedTable::PushEntries(lua_State* L)
 {
-	PushSyncedTable(L);
+	HSTR_PUSH(L, "SYNCED");
+	lua_newtable(L); { // the proxy table
 
-	// backward compability
-	lua_pushliteral(L, "snext");
-		lua_getglobal(L, "next");
-		lua_rawset(L, -3);
-	lua_pushliteral(L, "spairs");
-		lua_getglobal(L, "pairs");
-		lua_rawset(L, -3);
-	lua_pushliteral(L, "sipairs");
-		lua_getglobal(L, "ipairs");
-		lua_rawset(L, -3);
+		lua_newtable(L); { // the metatable
+			LuaPushNamedCFunc(L, "__index",     SyncTableIndex);
+			LuaPushNamedCFunc(L, "__newindex",  SyncTableNewIndex);
+			LuaPushNamedCFunc(L, "__metatable", SyncTableMetatable);
+		}
+
+		lua_setmetatable(L, -2);
+	}
+	lua_rawset(L, -3);
 
 	return true;
 }

--- a/rts/Lua/LuaSyncedTable.h
+++ b/rts/Lua/LuaSyncedTable.h
@@ -3,7 +3,7 @@
 #ifndef LUA_SYNCED_TABLE_H
 #define LUA_SYNCED_TABLE_H
 
-// Adds UNSYNCED table, snext(), spairs(), and sipairs()
+// Adds the `SYNCED` proxy table
 
 struct lua_State;
 


### PR DESCRIPTION
Obsolete for almost 10 years now (can use the regular `next`, `pairs` and `ipairs`).

This is backwards-incompatible, but as a measure of goodwill all known games have received PRs or commits such that it won't be a problem:
https://github.com/ZeroK-RTS/Zero-K/commit/363f9de61968158e44aa982668db56131a55710d
https://github.com/beyond-all-reason/Beyond-All-Reason/commit/b12b6965883e062f166a9044196872cd3401fad6
https://github.com/SplinterFaction/SplinterFaction/pull/3
https://github.com/springraaar/metal_factions/pull/6
https://github.com/FluidPlay/TAP/pull/7
https://github.com/techannihilation/TA/pull/1659
https://github.com/spring1944/spring1944/pull/477
https://github.com/Balanced-Annihilation/Balanced-Annihilation/pull/188
https://github.com/PicassoCT/MOSAIC/pull/33
https://github.com/azaremoth/cursed/pull/10