### PR TITLE
Fix creation of integer textures by CreateTexture and other formats

### DIFF
--- a/rts/Lua/LuaConstGL.cpp
+++ b/rts/Lua/LuaConstGL.cpp
@@ -602,6 +602,8 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	PUSH_GL(RG8_SNORM);
 	PUSH_GL(R16_SNORM);
 	PUSH_GL(R8_SNORM);
+	PUSH_GL(DEPTH_COMPONENT16);
+	PUSH_GL(DEPTH_COMPONENT32F);
 
 	//access specifiers
 	PUSH_GL(READ_ONLY);
@@ -702,8 +704,6 @@ bool LuaConstGL::PushEntries(lua_State* L)
 /// @field GL_RGBA32F_ARB 0x8814
 
 /// @field GL_DEPTH_COMPONENT 0x1902
-
-/// @field GL_DEPTH_COMPONENT16 0x81A5
 
 /// @field GL_DEPTH_COMPONENT24 0x81A6
 

--- a/rts/Lua/LuaConstGL.cpp
+++ b/rts/Lua/LuaConstGL.cpp
@@ -603,6 +603,8 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	PUSH_GL(R16_SNORM);
 	PUSH_GL(R8_SNORM);
 	PUSH_GL(DEPTH_COMPONENT16);
+	PUSH_GL(DEPTH_COMPONENT24);
+	PUSH_GL(DEPTH_COMPONENT32);
 	PUSH_GL(DEPTH_COMPONENT32F);
 
 	//access specifiers
@@ -704,10 +706,6 @@ bool LuaConstGL::PushEntries(lua_State* L)
 /// @field GL_RGBA32F_ARB 0x8814
 
 /// @field GL_DEPTH_COMPONENT 0x1902
-
-/// @field GL_DEPTH_COMPONENT24 0x81A6
-
-/// @field GL_DEPTH_COMPONENT32 0x81A7
 
 /******************************************************************************
  * Not included, but useful RBO Formats

--- a/rts/Lua/LuaTextures.cpp
+++ b/rts/Lua/LuaTextures.cpp
@@ -29,6 +29,111 @@ const spring::unordered_map<GLenum, GLenum> LuaTextures::Format2Query =
 /******************************************************************************/
 /******************************************************************************/
 
+namespace Impl {
+	static GLenum GetInternalFormatDataFormat(GLenum internalFormat) {
+		GLenum dataFormat;
+		switch (internalFormat) {
+			case GL_R8UI:
+			case GL_R16UI:
+			case GL_R32UI: {
+				dataFormat = GL_RED_INTEGER;
+			} break;
+			case GL_RG8UI:
+			case GL_RG16UI:
+			case GL_RG32UI: {
+				dataFormat = GL_RG_INTEGER;
+			} break;
+			case GL_RGB10_A2UI: {
+				dataFormat = GL_RGB_INTEGER;
+			} break;
+			case GL_RGBA8UI:
+			case GL_RGBA16UI:
+			case GL_RGBA32UI: {
+				dataFormat = GL_RGBA_INTEGER;
+			} break;
+			case GL_R8:
+			case GL_R16:
+			case GL_R16F:
+			case GL_R32F: {
+				dataFormat = GL_RED;
+			} break;
+			case GL_DEPTH_COMPONENT:
+			case GL_DEPTH_COMPONENT16:
+			case GL_DEPTH_COMPONENT24:
+			case GL_DEPTH_COMPONENT32:
+			case GL_DEPTH_COMPONENT32F: {
+				dataFormat = GL_DEPTH_COMPONENT;
+			} break;
+			case GL_RG8:
+			case GL_RG16:
+			case GL_RG16F:
+			case GL_RG32F: {
+				dataFormat = GL_RG;
+			} break;
+			case GL_RGB10_A2:
+			case GL_R11F_G11F_B10F: {
+				dataFormat = GL_RGB;
+			} break;
+			case GL_RGBA8:
+			case GL_RGBA16:
+			case GL_RGBA16F:
+			case GL_RGBA32F:
+			default: {
+				dataFormat = GL_RGBA;
+			} break;
+		}
+		return dataFormat;
+	}
+	static GLenum GetInternalFormatDataType(GLenum internalFormat) {
+		GLenum dataType;
+		switch (internalFormat) {
+			case GL_RGBA16F:
+			case GL_R11F_G11F_B10F:
+			case GL_RG16F:
+			case GL_R16F: {
+				dataType = GL_HALF_FLOAT;
+			} break;
+			case GL_RGBA32F:
+			case GL_RG32F:
+			case GL_R32F:
+			case GL_DEPTH_COMPONENT32F: {
+				dataType = GL_FLOAT;
+			} break;
+			case GL_RGBA32UI:
+			case GL_RG32UI:
+			case GL_R32UI:
+			case GL_DEPTH_COMPONENT24:
+			case GL_DEPTH_COMPONENT32: {
+				dataType = GL_UNSIGNED_INT;
+			} break;
+			case GL_RGBA16:
+			case GL_RGBA16UI:
+			case GL_RG16:
+			case GL_RG16UI:
+			case GL_R16:
+			case GL_R16UI:
+			case GL_DEPTH_COMPONENT16: {
+				dataType = GL_UNSIGNED_SHORT;
+			} break;
+			case GL_RGB10_A2:
+			case GL_RGB10_A2UI: {
+				dataType = GL_UNSIGNED_INT_2_10_10_10_REV;
+			} break;
+			case GL_RGBA8:
+			case GL_RGBA8UI:
+			case GL_RG8:
+			case GL_RG8UI:
+			case GL_R8:
+			case GL_R8UI:
+			case GL_DEPTH_COMPONENT:
+			default: {
+				dataType = GL_UNSIGNED_BYTE;
+			} break;
+		}
+		return dataType;
+	}
+}
+
 std::string LuaTextures::Create(const Texture& tex)
 {
 	GLint currentBinding = 0;
@@ -46,21 +151,8 @@ std::string LuaTextures::Create(const Texture& tex)
 
 	glClearErrors("LuaTex", __func__, globalRendering->glDebugErrors);
 
-	GLenum dataFormat = GL_RGBA;
-	GLenum dataType   = GL_UNSIGNED_BYTE;
-
-	switch (tex.format) {
-		case GL_DEPTH_COMPONENT:
-		case GL_DEPTH_COMPONENT16:
-		case GL_DEPTH_COMPONENT24:
-		case GL_DEPTH_COMPONENT32:
-		case GL_DEPTH_COMPONENT32F: {
-			dataFormat = GL_DEPTH_COMPONENT;
-			dataType = GL_FLOAT;
-		} break;
-		default: {
-		} break;
-	}
+	GLenum dataFormat = Impl::GetInternalFormatDataFormat(tex.format);
+	GLenum dataType   = Impl::GetInternalFormatDataType(tex.format);
 
 	switch (tex.target) {
 		case GL_TEXTURE_1D: {

--- a/rts/Lua/LuaTextures.cpp
+++ b/rts/Lua/LuaTextures.cpp
@@ -96,14 +96,16 @@ namespace Impl {
 			case GL_RGBA32F:
 			case GL_RG32F:
 			case GL_R32F:
+			case GL_DEPTH_COMPONENT32:
+				// internally, GL_DEPTH_COMPONENT32 is the same value as GL_DEPTH_COMPONENT32F
+				// as the correspondence must be one-to-one, GL_FLOAT representation is preferred
 			case GL_DEPTH_COMPONENT32F: {
 				dataType = GL_FLOAT;
 			} break;
 			case GL_RGBA32UI:
 			case GL_RG32UI:
 			case GL_R32UI:
-			case GL_DEPTH_COMPONENT24:
-			case GL_DEPTH_COMPONENT32: {
+			case GL_DEPTH_COMPONENT24: {
 				dataType = GL_UNSIGNED_INT;
 			} break;
 			case GL_RGBA16:

--- a/rts/Lua/LuaTextures.cpp
+++ b/rts/Lua/LuaTextures.cpp
@@ -1,6 +1,7 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "LuaTextures.h"
+#include "Rendering/Textures/TextureFormat.h"
 #include "Rendering/GlobalRendering.h"
 #include "Rendering/GL/FBO.h"
 #include "System/SpringMath.h"
@@ -29,113 +30,6 @@ const spring::unordered_map<GLenum, GLenum> LuaTextures::Format2Query =
 /******************************************************************************/
 /******************************************************************************/
 
-namespace Impl {
-	static GLenum GetInternalFormatDataFormat(GLenum internalFormat) {
-		GLenum dataFormat;
-		switch (internalFormat) {
-			case GL_R8UI:
-			case GL_R16UI:
-			case GL_R32UI: {
-				dataFormat = GL_RED_INTEGER;
-			} break;
-			case GL_RG8UI:
-			case GL_RG16UI:
-			case GL_RG32UI: {
-				dataFormat = GL_RG_INTEGER;
-			} break;
-			case GL_RGB10_A2UI: {
-				dataFormat = GL_RGB_INTEGER;
-			} break;
-			case GL_RGBA8UI:
-			case GL_RGBA16UI:
-			case GL_RGBA32UI: {
-				dataFormat = GL_RGBA_INTEGER;
-			} break;
-			case GL_R8:
-			case GL_R16:
-			case GL_R16F:
-			case GL_R32F: {
-				dataFormat = GL_RED;
-			} break;
-			case GL_DEPTH_COMPONENT:
-			case GL_DEPTH_COMPONENT16:
-			case GL_DEPTH_COMPONENT24:
-			case GL_DEPTH_COMPONENT32:
-			case GL_DEPTH_COMPONENT32F: {
-				dataFormat = GL_DEPTH_COMPONENT;
-			} break;
-			case GL_RG8:
-			case GL_RG16:
-			case GL_RG16F:
-			case GL_RG32F: {
-				dataFormat = GL_RG;
-			} break;
-			case GL_RGB10_A2:
-			case GL_R11F_G11F_B10F: {
-				dataFormat = GL_RGB;
-			} break;
-			case GL_RGBA8:
-			case GL_RGBA16:
-			case GL_RGBA16F:
-			case GL_RGBA32F:
-			default: {
-				dataFormat = GL_RGBA;
-			} break;
-		}
-		return dataFormat;
-	}
-	static GLenum GetInternalFormatDataType(GLenum internalFormat) {
-		GLenum dataType;
-		switch (internalFormat) {
-			case GL_RGBA16F:
-			case GL_R11F_G11F_B10F:
-			case GL_RG16F:
-			case GL_R16F: {
-				dataType = GL_HALF_FLOAT;
-			} break;
-			case GL_RGBA32F:
-			case GL_RG32F:
-			case GL_R32F:
-			case GL_DEPTH_COMPONENT32:
-				// internally, GL_DEPTH_COMPONENT32 is the same value as GL_DEPTH_COMPONENT32F
-				// as the correspondence must be one-to-one, GL_FLOAT representation is preferred
-			case GL_DEPTH_COMPONENT32F: {
-				dataType = GL_FLOAT;
-			} break;
-			case GL_RGBA32UI:
-			case GL_RG32UI:
-			case GL_R32UI:
-			case GL_DEPTH_COMPONENT24: {
-				dataType = GL_UNSIGNED_INT;
-			} break;
-			case GL_RGBA16:
-			case GL_RGBA16UI:
-			case GL_RG16:
-			case GL_RG16UI:
-			case GL_R16:
-			case GL_R16UI:
-			case GL_DEPTH_COMPONENT16: {
-				dataType = GL_UNSIGNED_SHORT;
-			} break;
-			case GL_RGB10_A2:
-			case GL_RGB10_A2UI: {
-				dataType = GL_UNSIGNED_INT_2_10_10_10_REV;
-			} break;
-			case GL_RGBA8:
-			case GL_RGBA8UI:
-			case GL_RG8:
-			case GL_RG8UI:
-			case GL_R8:
-			case GL_R8UI:
-			case GL_DEPTH_COMPONENT:
-			default: {
-				dataType = GL_UNSIGNED_BYTE;
-			} break;
-		}
-		return dataType;
-	}
-}
-
 std::string LuaTextures::Create(const Texture& tex)
 {
 	GLint currentBinding = 0;
@@ -153,8 +47,8 @@ std::string LuaTextures::Create(const Texture& tex)
 
 	glClearErrors("LuaTex", __func__, globalRendering->glDebugErrors);
 
-	GLenum dataFormat = Impl::GetInternalFormatDataFormat(tex.format);
-	GLenum dataType   = Impl::GetInternalFormatDataType(tex.format);
+	GLenum dataFormat = Texture::GetInternalFormatDataFormat(tex.format);
+	GLenum dataType   = Texture::GetInternalFormatDataType(tex.format);
 
 	switch (tex.target) {
 		case GL_TEXTURE_1D: {

--- a/rts/Lua/LuaTextures.cpp
+++ b/rts/Lua/LuaTextures.cpp
@@ -47,8 +47,8 @@ std::string LuaTextures::Create(const Texture& tex)
 
 	glClearErrors("LuaTex", __func__, globalRendering->glDebugErrors);
 
-	GLenum dataFormat = Texture::GetInternalFormatDataFormat(tex.format);
-	GLenum dataType   = Texture::GetInternalFormatDataType(tex.format);
+	GLenum dataFormat = ::Texture::GetInternalFormatDataFormat(tex.format);
+	GLenum dataType   = ::Texture::GetInternalFormatDataType(tex.format);
 
 	switch (tex.target) {
 		case GL_TEXTURE_1D: {

--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -820,7 +820,7 @@ size_t LuaVBOImpl::ModelsVBOImpl()
 	};
 
 	const auto engineIndxAttribDefFunc = [this]() {
-		// float3 pos
+		// uint index
 		this->bufferAttribDefs[0] = {
 			GL_UNSIGNED_INT, //type
 			1, //size

--- a/rts/Rendering/Textures/TextureFormat.h
+++ b/rts/Rendering/Textures/TextureFormat.h
@@ -1,0 +1,117 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef TEXTURE_FORMAT_H
+#define TEXTURE_FORMAT_H
+
+namespace Texture
+{
+	GLenum GetInternalFormatDataFormat(GLenum internalFormat) {
+		GLenum dataFormat;
+		switch (internalFormat) {
+			case GL_R8UI:
+			case GL_R16UI:
+			case GL_R32UI: {
+				dataFormat = GL_RED_INTEGER;
+			} break;
+			case GL_RG8UI:
+			case GL_RG16UI:
+			case GL_RG32UI: {
+				dataFormat = GL_RG_INTEGER;
+			} break;
+			case GL_RGB10_A2UI: {
+				dataFormat = GL_RGB_INTEGER;
+			} break;
+			case GL_RGBA8UI:
+			case GL_RGBA16UI:
+			case GL_RGBA32UI: {
+				dataFormat = GL_RGBA_INTEGER;
+			} break;
+			case GL_R8:
+			case GL_R16:
+			case GL_R16F:
+			case GL_R32F: {
+				dataFormat = GL_RED;
+			} break;
+			case GL_DEPTH_COMPONENT:
+			case GL_DEPTH_COMPONENT16:
+			case GL_DEPTH_COMPONENT24:
+			case GL_DEPTH_COMPONENT32:
+			case GL_DEPTH_COMPONENT32F: {
+				dataFormat = GL_DEPTH_COMPONENT;
+			} break;
+			case GL_RG8:
+			case GL_RG16:
+			case GL_RG16F:
+			case GL_RG32F: {
+				dataFormat = GL_RG;
+			} break;
+			case GL_RGB10_A2:
+			case GL_R11F_G11F_B10F: {
+				dataFormat = GL_RGB;
+			} break;
+			case GL_RGBA8:
+			case GL_RGBA16:
+			case GL_RGBA16F:
+			case GL_RGBA32F:
+			default: {
+				dataFormat = GL_RGBA;
+			} break;
+		}
+		return dataFormat;
+	}
+
+	GLenum GetInternalFormatDataType(GLenum internalFormat) {
+		GLenum dataType;
+		switch (internalFormat) {
+			case GL_RGBA16F:
+			case GL_RG16F:
+			case GL_R16F: {
+				dataType = GL_HALF_FLOAT;
+			} break;
+			case GL_RGBA32F:
+			case GL_RG32F:
+			case GL_R32F:
+			case GL_DEPTH_COMPONENT32F: {
+				dataType = GL_FLOAT;
+			} break;
+			case GL_RGBA32UI:
+			case GL_RG32UI:
+			case GL_R32UI:
+			case GL_DEPTH_COMPONENT32: {
+				dataType = GL_UNSIGNED_INT;
+			} break;
+			case GL_DEPTH_COMPONENT24: {
+				dataType = GL_UNSIGNED_INT_24_8;
+			} break;
+			case GL_RGBA16:
+			case GL_RGBA16UI:
+			case GL_RG16:
+			case GL_RG16UI:
+			case GL_R16:
+			case GL_R16UI:
+			case GL_DEPTH_COMPONENT16: {
+				dataType = GL_UNSIGNED_SHORT;
+			} break;
+			case GL_R11F_G11F_B10F: {
+				dataType = GL_UNSIGNED_INT_10F_11F_11F_REV;
+			} break;
+			case GL_RGB10_A2:
+			case GL_RGB10_A2UI: {
+				dataType = GL_UNSIGNED_INT_2_10_10_10_REV;
+			} break;
+			case GL_RGBA8:
+			case GL_RGBA8UI:
+			case GL_RG8:
+			case GL_RG8UI:
+			case GL_R8:
+			case GL_R8UI:
+			case GL_DEPTH_COMPONENT:
+			default: {
+				dataType = GL_UNSIGNED_BYTE;
+			} break;
+		}
+		return dataType;
+	}
+}
+
+#endif // TEXTURE_FORMAT_H


### PR DESCRIPTION
You could not create integer textures before, as well as some other formats because previous code did not produce valid data formats and types for internal formats.

GL specs reference:
https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml