### PR TITLE
fix: cpu affinity on linux now correctly prints success messages for thread affinity

### DIFF
--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -92,7 +92,7 @@ namespace Threading {
 		return coreMask;
 	}
 
-	static void SetWantedCoreAffinityMask(const cpu_set_t* cpuSrcSet, cpu_set_t* cpuDstSet, std::uint32_t coreMask) {
+	static void SetWantedCoreAffinityMask(cpu_set_t* cpuDstSet, std::uint32_t coreMask) {
 		CPU_ZERO(cpuDstSet);
 
 		const int numCPUs = std::min(CPU_COUNT(&cpusSystem), 32);
@@ -102,7 +102,7 @@ namespace Threading {
 				CPU_SET(n, cpuDstSet);
 		}
 
-		CPU_AND(cpuDstSet, cpuDstSet, cpuSrcSet);
+		CPU_AND(cpuDstSet, cpuDstSet, &cpusSystem);
 	}
 	#endif
 
@@ -158,7 +158,7 @@ namespace Threading {
 		cpu_set_t cpusWanted;
 
 		// create wanted mask
-		SetWantedCoreAffinityMask(&cpusSystem, &cpusWanted, coreMask);
+		SetWantedCoreAffinityMask(&cpusWanted, coreMask);
 
 		// set the affinity; return final mask (can differ from wanted)
 		if (sched_setaffinity(0, sizeof(cpu_set_t), &cpusWanted) == 0)

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -82,7 +82,7 @@ namespace Threading {
 		std::uint32_t coreMask = 0;
 
 		// without the min(..., 32), `(1 << n)` could overflow
-		const int numCPUs = std::min(CPU_COUNT(cpuSet), 32);
+		const int numCPUs = std::min(CPU_COUNT(&cpusSystem), 32);
 
 		for (int n = numCPUs - 1; n >= 0; --n) {
 			if (CPU_ISSET(n, cpuSet))
@@ -95,7 +95,7 @@ namespace Threading {
 	static void SetWantedCoreAffinityMask(const cpu_set_t* cpuSrcSet, cpu_set_t* cpuDstSet, std::uint32_t coreMask) {
 		CPU_ZERO(cpuDstSet);
 
-		const int numCPUs = std::min(CPU_COUNT(cpuSrcSet), 32);
+		const int numCPUs = std::min(CPU_COUNT(&cpusSystem), 32);
 
 		for (int n = numCPUs - 1; n >= 0; --n) {
 			if ((coreMask & (1 << n)) != 0)


### PR DESCRIPTION
NOTE: affinity IS actually working on linux, but we're returning errors after a successful set for a worker thread.

This bug goes back ~9 years, from [this commit](https://github.com/beyond-all-reason/spring/commit/ef467bae5ed408fb2f142e6af4c9f9cf804c6e47#diff-492361d44f4a51548f868672b639fe964da1c7b21b59df2490fd1af23c6efedbL112) and [this refactor](https://github.com/beyond-all-reason/spring/commit/e342a2dde71daf9c475a140ed6c897b0b2d9dfb7#diff-492361d44f4a51548f868672b639fe964da1c7b21b59df2490fd1af23c6efedbR90-R118).
original commit's ticket: https://springrts.com/mantis/view.php?id=4544

Basically, the logic of this is wrong:
```
const int numCPUs = std::min(CPU_COUNT(inputCpuSetMask), 32);
for (int n = numCPUs - 1; n >= 0; --n) {
    ...
}
```

The code assumes CPU_COUNT(inputCpuSetMask) will give the total # of cpus on the system, and therefore acts as a limit on the mask in the for loop.
BUT `CPU_COUNT` actually just `Returns the number of CPUs in input set.` [0]

So, for our worker threads affinity code, the `inputCpuSetMask` only contains 1 cpu so the for loop just runs once, instead of once per possible cpu.



[0] https://man7.org/linux/man-pages/man3/CPU_COUNT.3.html#:~:text=.%0A%0A%20%20%20%20%20%20%20CPU_COUNT()-,Return%20the%20number%20of%20CPUs%20in%20set.,-Where%20a%20cpu