### PR TITLE
Accurate lead target

### DIFF
--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -53,6 +53,10 @@ UnitDefWeapon::UnitDefWeapon(const WeaponDef* weaponDef, const LuaTable& weaponT
 
 	// allow weapon to select a new target immediately after the current target is destroyed, without waiting for slow update.
 	fastAutoRetargeting = weaponTable.GetBool("fastAutoRetargeting", fastAutoRetargeting);
+
+	// allow weapon to perform additional iterations when calculating target leading on a moving target, for better accuracy
+	// stops undershooting when firing at approaching enemies, and stops overshooting when firing at retreating enemies
+	accurateLeading = weaponTable.GetBool("accurateLeading", accurateLeading);
 }
 
 

--- a/rts/Sim/Units/UnitDef.h
+++ b/rts/Sim/Units/UnitDef.h
@@ -44,6 +44,7 @@ struct UnitDefWeapon {
 	float3 mainDir = FwdVector;
 
 	bool fastAutoRetargeting = false;	///< pick new targets as soon as possible, don't wait for slow update
+	bool accurateLeading = false;	///< Perform extra iterations when leading a moving target, for better accuracy 
 	float weaponAimAdjustPriority = 1.f;		///< relative importance of picking enemy targets that are in front
 };
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -1268,43 +1268,53 @@ float3 CWeapon::GetUnitLeadTargetPos(const CUnit* unit) const
 	return aimPos;
 }
 
+#include "Map/MapInfo.h"
+#include<iostream>
+#include<string>
 
 float3 CWeapon::GetLeadVec(const CUnit* unit) const
 {
 	float predictTime = GetPredictedImpactTime(unit->pos);
 	const float predictMult = mix(predictSpeedMod, 1.0f, weaponDef->predictBoost);
 
-	if (weaponDef->myGravity > 0) {
-		// precise target leading
-		// newton iterations are too unstable, due to impossible to intercept targets
-		// use fixed point iterations
-		float3 dist = unit->pos - weaponMuzzlePos;
-		//const float aa = dist.dot(dist);
-		//const float bb = 2 * dist.dot(unit->speed);
-		//const float cc = -(weaponDef->projectilespeed) * (weaponDef->projectilespeed)
-		//	+ (weaponDef->projectilespeed) * (weaponDef->myGravity)
-		//	+ (unit->speed).dot(unit->speed);
-		//const float dd = (unit->speed).y * (weaponDef->myGravity);
-		//const float ee = 0.25f * (weaponDef->myGravity) * (weaponDef->myGravity);
+	std::cout << "weapon type = " << weaponDef->projectileType << " " << WEAPON_EXPLOSIVE_PROJECTILE << std::endl;
+	if (weaponDef->projectileType == WEAPON_EXPLOSIVE_PROJECTILE) {
+		const float gravity = mix(mapInfo->map.gravity, -weaponDef->myGravity, weaponDef->myGravity != 0.0f);
+		std::cout << "weapon gravity = " << gravity << std::endl;
 
-		const float ee = 0.25f * (weaponDef->myGravity) * (weaponDef->myGravity);
+		if (gravity < 0) {
+			// precise target leading
+			// newton iterations are too unstable, due to impossible to intercept targets
+			// use fixed point iterations
+			float3 dist = unit->pos - weaponMuzzlePos;
+			//const float aa = dist.dot(dist);
+			//const float bb = 2 * dist.dot(unit->speed);
+			//const float cc = -(weaponDef->projectilespeed) * (weaponDef->projectilespeed)
+			//	+ (weaponDef->projectilespeed) * (weaponDef->myGravity)
+			//	+ (unit->speed).dot(unit->speed);
+			//const float dd = (unit->speed).y * (weaponDef->myGravity);
+			//const float ee = 0.25f * (weaponDef->myGravity) * (weaponDef->myGravity);
 
-		//float t0 = 0.0f;
-		float t1 = 1.0f;
-		for (int ii = 0; ii < 32; ii++) {
-			float cc = -(weaponDef->projectilespeed) * (weaponDef->projectilespeed) - dist.y * (weaponDef->myGravity);
-			if ((4 * dist.dot(dist) * ee) >= (cc * cc)) {
-				break;
-			}
-			t1 = math::sqrt((-cc - math::sqrt((cc * cc) - (4 * dist.dot(dist) * ee))) / (2 * ee));
-			if (std::abs(t1 - predictTime) < 1) {
+			const float ee = 0.25f * (gravity) * (gravity);
+
+			//float t0 = 0.0f;
+			float t1 = 1.0f;
+			for (int ii = 0; ii < 32; ii++) {
+				std::cout << "Precision calcs = " << ii << std::endl;
+				float cc = -(weaponDef->projectilespeed) * (weaponDef->projectilespeed) - dist.y * (gravity);
+				if ((4 * dist.dot(dist) * ee) >= (cc * cc)) {
+					break;
+				}
+				t1 = math::sqrt((-cc - math::sqrt((cc * cc) - (4 * dist.dot(dist) * ee))) / (2 * ee));
+				if (std::abs(t1 - predictTime) < 1) {
+					predictTime = t1;
+					break;
+				}
 				predictTime = t1;
-				break;
+				dist = unit->pos + unit->speed * predictTime - weaponMuzzlePos;
 			}
-			predictTime = t1;
-			dist = unit->pos + unit->speed * predictTime - weaponMuzzlePos;
-
 		}
+
 	}
 
 	float3 lead = unit->speed * predictTime * predictMult;

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -201,6 +201,7 @@ public:
 
 	float weaponAimAdjustPriority;
 	bool fastAutoRetargeting;
+	bool accurateLeading;
 
 protected:
 	SWeaponTarget currentTarget;

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -180,5 +180,6 @@ void CWeaponLoader::InitWeapon(CUnit* owner, CWeapon* weapon, const UnitDefWeapo
 
 	weapon->weaponAimAdjustPriority = defWeapon->weaponAimAdjustPriority;
 	weapon->fastAutoRetargeting = defWeapon->fastAutoRetargeting;
+	weapon->accurateLeading = defWeapon->accurateLeading;
 }
 


### PR DESCRIPTION
PR to address this issue:
https://github.com/beyond-all-reason/spring/issues/746

Seeking advice on how this change should be structured.
Currently, this PR just applies to gravity affected `WEAPON_EXPLOSIVE_PROJECTILE`, but issues 746 applies to all weapons with a non-zero travel time. And only addresses low trajectory units. 

This PR adds a new weapondef boolean `accurateLeading`, to use fixed point iterations to calculate accurate intercept positions.  
The current method is inaccurate for targets moving towards or away from the unit, because the current method does not take into account changes in projectile travel time as the target moves closer or further away. 
The gameplay implication is units with slow projectiles, such as the BAR fatboy, leads approaching fast units too much, frequently firing too far ahead and friendly firing. 

Fundamentally, this target leading problem for gravity-affected projectiles involves solving for the smallest positive zero of a quartic polynomial, and I found fixed point iterations to be the most stable way of finding this value, or exiting if no positive real solution exists. 