### PR TITLE
VBO Clear and code cosmetic

### DIFF
--- a/rts/Lua/LuaVBO.cpp
+++ b/rts/Lua/LuaVBO.cpp
@@ -35,6 +35,7 @@ bool LuaVBOs::PushEntries(lua_State* L)
 		"Define", &LuaVBOImpl::Define,
 		"Upload", &LuaVBOImpl::Upload,
 		"Download", &LuaVBOImpl::Download,
+		"Clear", &LuaVBOImpl::Clear,
 
 		"ModelsVBO", &LuaVBOImpl::ModelsVBO,
 

--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -753,13 +753,9 @@ void LuaVBOImpl::Clear()
 	VBOExistenceCheck(vbo, __func__);
 
 	GLubyte val = 0;
-	if (GLEW_ARB_direct_state_access) {
-		glClearNamedBufferData(GetId(), GL_R8UI, GL_RED_INTEGER, GL_UNSIGNED_BYTE, &val);
-	} else {
-		vbo->Bind();
-		glClearBufferData(defTarget, GL_R8UI, GL_RED_INTEGER, GL_UNSIGNED_BYTE, &val);
-		vbo->Unbind();
-	}
+	vbo->Bind();
+	glClearBufferData(defTarget, GL_R8UI, GL_RED_INTEGER, GL_UNSIGNED_BYTE, &val);
+	vbo->Unbind();
 }
 
 void LuaVBOImpl::UpdateModelsVBOElementCount()

--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -66,6 +66,20 @@ LuaVBOImpl::~LuaVBOImpl()
 }
 
 
+/***********************/
+//
+//  Validity Checks
+//
+
+namespace {
+	inline void VBOExistenceCheck(const VBO* vbo, const char* func)
+	{
+		if (!vbo) {
+			LuaUtils::SolLuaError("[LuaVBOImpl::%s] Buffer definition is invalid. Did you succesfully call :Define()?", func);
+		}
+	}
+}
+
 /***
  *
  * @function VBO:Delete
@@ -557,9 +571,7 @@ std::tuple<uint32_t, uint32_t, uint32_t> LuaVBOImpl::GetBufferSize()
  */
 size_t LuaVBOImpl::Upload(const sol::stack_table& luaTblData, sol::optional<int> attribIdxOpt, sol::optional<int> elemOffsetOpt, sol::optional<int> luaStartIndexOpt, sol::optional<int> luaFinishIndexOpt)
 {
-	if (!vbo) {
-		LuaUtils::SolLuaError("[LuaVBOImpl::%s] Invalid VBO. Did you call :Define() or :ShapeFromUnitDefID/ShapeFromFeatureDefID()?", __func__);
-	}
+	VBOExistenceCheck(vbo, __func__);
 
 	const uint32_t elemOffset = static_cast<uint32_t>(std::max(elemOffsetOpt.value_or(0), 0));
 	if (elemOffset >= elementsCount) {
@@ -615,9 +627,7 @@ sol::as_table_t<std::vector<lua_Number>> LuaVBOImpl::Download(sol::optional<int>
 {
 	std::vector<lua_Number> dataVec;
 
-	if (!vbo) {
-		LuaUtils::SolLuaError("[LuaVBOImpl::%s] Invalid VBO. Did you call :Define()?", __func__);
-	}
+	VBOExistenceCheck(vbo, __func__);
 
 	const uint32_t elemOffset = static_cast<uint32_t>(std::max(elemOffsetOpt.value_or(0), 0));
 	const uint32_t elemCount = static_cast<uint32_t>(std::clamp(elemCountOpt.value_or(elementsCount), 1, static_cast<int>(elementsCount)));
@@ -710,6 +720,14 @@ sol::as_table_t<std::vector<lua_Number>> LuaVBOImpl::Download(sol::optional<int>
 		vbo->Unbind();
 	}
 	return sol::as_table(dataVec);
+}
+
+void LuaVBOImpl::Clear()
+{
+	VBOExistenceCheck(vbo, __func__);
+
+	GLubyte val = 0;
+	glClearNamedBufferData(GetId(), GL_R8UI, GL_RED_INTEGER, GL_UNSIGNED_BYTE, &val);
 }
 
 void LuaVBOImpl::UpdateModelsVBOElementCount()
@@ -874,9 +892,7 @@ void LuaVBOImpl::InstanceBufferCheckAndFormatCheck(int attrID, const char* func)
 
 void LuaVBOImpl::InstanceBufferCheck(int attrID, const char* func)
 {
-	if (!vbo) {
-		LuaUtils::SolLuaError("[LuaVBOImpl::%s] Invalid instance VBO. Did you call :Define() succesfully?", func);
-	}
+	VBOExistenceCheck(vbo, func);
 	/*
 	if (defTarget != GL_ARRAY_BUFFER) {
 		LuaUtils::SolLuaError("[LuaVBOImpl::%s] Invalid instance VBO. Target type (%u) is not GL_ARRAY_BUFFER(%u)", func, defTarget, GL_ARRAY_BUFFER);
@@ -1321,9 +1337,7 @@ size_t LuaVBOImpl::MatrixDataFromProjectileIDs(const sol::stack_table& ids, int 
 
 int LuaVBOImpl::BindBufferRangeImpl(GLuint bindingIndex,  const sol::optional<int> elemOffsetOpt, const sol::optional<int> elemCountOpt, const sol::optional<GLenum> targetOpt, bool bind)
 {
-	if (!vbo) {
-		LuaUtils::SolLuaError("[LuaVBOImpl::%s] Buffer definition is invalid. Did you succesfully call :Define()?", __func__);
-	}
+	VBOExistenceCheck(vbo, __func__);
 
 	const uint32_t elemOffset = static_cast<uint32_t>(std::max(elemOffsetOpt.value_or(0), 0));
 	const uint32_t elemCount = static_cast<uint32_t>(std::clamp(elemCountOpt.value_or(elementsCount), 1, static_cast<int>(elementsCount)));
@@ -1414,9 +1428,7 @@ int LuaVBOImpl::UnbindBufferRange(const GLuint index, const sol::optional<int> e
  */
 void LuaVBOImpl::DumpDefinition()
 {
-	if (!vbo) {
-		LuaUtils::SolLuaError("[LuaVBOImpl::%s] Buffer definition is invalid. Did you succesfully call :Define()?", __func__);
-	}
+	VBOExistenceCheck(vbo, __func__);
 
 	std::ostringstream ss;
 	ss << fmt::format("Definition information on LuaVBOs. OpenGL Buffer ID={}:\n", vbo->GetId());

--- a/rts/Lua/LuaVBOImpl.h
+++ b/rts/Lua/LuaVBOImpl.h
@@ -73,8 +73,8 @@ private:
 	void UpdateModelsVBOElementCount();
 	size_t ModelsVBOImpl();
 
-	void InstanceBufferCheckAndFormatCheck(int attrID, const char* func);
-	void InstanceBufferCheck(int attrID, const char* func);
+	inline void InstanceBufferCheck(int attrID, const char* func);
+	inline void InstanceBufferCheckAndFormatCheck(int attrID, const char* func);
 
 	template<typename TObj>
 	static SInstanceData InstanceDataFromGetData(int id, int attrID, uint8_t defTeamID);

--- a/rts/Lua/LuaVBOImpl.h
+++ b/rts/Lua/LuaVBOImpl.h
@@ -32,6 +32,7 @@ public:
 
 	size_t Upload(const sol::stack_table& luaTblData, sol::optional<int> attribIdxOpt, sol::optional<int> elemOffsetOpt, sol::optional<int> luaStartIndexOpt, sol::optional<int> luaFinishIndexOpt);
 	sol::as_table_t<std::vector<lua_Number>> Download(sol::optional<int> attribIdxOpt, sol::optional<int> elemOffsetOpt, sol::optional<int> elemCountOpt, sol::optional<bool> forceGPUReadOpt);
+	void Clear();
 
 	size_t ModelsVBO();
 

--- a/rts/lib/headlessStubs/glewstub.h
+++ b/rts/lib/headlessStubs/glewstub.h
@@ -106,6 +106,7 @@ extern "C" {
 #define GLEW_EXT_texture_array GL_FALSE
 #define GLEW_ARB_draw_indirect GL_FALSE
 #define GLEW_ARB_base_instance GL_FALSE
+#define GLEW_ARB_direct_state_access GL_FALSE
 
 #define GLXEW_SGI_video_sync GL_FALSE
 

--- a/rts/lib/headlessStubs/glewstub.h
+++ b/rts/lib/headlessStubs/glewstub.h
@@ -106,7 +106,6 @@ extern "C" {
 #define GLEW_EXT_texture_array GL_FALSE
 #define GLEW_ARB_draw_indirect GL_FALSE
 #define GLEW_ARB_base_instance GL_FALSE
-#define GLEW_ARB_direct_state_access GL_FALSE
 
 #define GLXEW_SGI_video_sync GL_FALSE
 

--- a/rts/lib/headlessStubs/glstub.c
+++ b/rts/lib/headlessStubs/glstub.c
@@ -264,6 +264,7 @@ GLAPI void APIENTRY glBufferStorage(GLenum target, GLsizeiptr size, const void* 
 GLAPI void APIENTRY glBufferData(GLenum target, GLsizeiptr size, const GLvoid* data, GLenum usage) {}
 GLAPI void APIENTRY glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, const void* data) {}
 GLAPI void APIENTRY glCopyBufferSubData(GLenum readtarget, GLenum writetarget, GLintptr readoffset, GLintptr writeoffset, GLsizeiptr size) {}
+GLAPI void APIENTRY glClearBufferData(GLenum target, GLenum internalformat, GLenum format, GLenum type, const void* data) {}
 GLAPI void APIENTRY glBindBufferBase(GLenum target, GLuint index, GLuint buffer) {}
 GLAPI void APIENTRY glBindBufferRange(GLenum target, GLuint index, GLuint buffer, GLintptr offset, GLsizeiptr size) {}
 GLAPI GLboolean APIENTRY glIsBuffer(GLuint buffer) { return GL_TRUE; }

--- a/rts/lib/headlessStubs/glstub.c
+++ b/rts/lib/headlessStubs/glstub.c
@@ -264,6 +264,8 @@ GLAPI void APIENTRY glBufferStorage(GLenum target, GLsizeiptr size, const void* 
 GLAPI void APIENTRY glBufferData(GLenum target, GLsizeiptr size, const GLvoid* data, GLenum usage) {}
 GLAPI void APIENTRY glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, const void* data) {}
 GLAPI void APIENTRY glCopyBufferSubData(GLenum readtarget, GLenum writetarget, GLintptr readoffset, GLintptr writeoffset, GLsizeiptr size) {}
+GLAPI void APIENTRY glClearBufferData(GLenum target, GLenum internalformat, GLenum format, GLenum type, const void* data) {}
+GLAPI void APIENTRY glClearNamedBufferData(GLuint buffer, GLenum internalformat, GLenum format, GLenum type, const void* data) {}
 GLAPI void APIENTRY glBindBufferBase(GLenum target, GLuint index, GLuint buffer) {}
 GLAPI void APIENTRY glBindBufferRange(GLenum target, GLuint index, GLuint buffer, GLintptr offset, GLsizeiptr size) {}
 GLAPI GLboolean APIENTRY glIsBuffer(GLuint buffer) { return GL_TRUE; }

--- a/rts/lib/headlessStubs/glstub.c
+++ b/rts/lib/headlessStubs/glstub.c
@@ -264,8 +264,6 @@ GLAPI void APIENTRY glBufferStorage(GLenum target, GLsizeiptr size, const void* 
 GLAPI void APIENTRY glBufferData(GLenum target, GLsizeiptr size, const GLvoid* data, GLenum usage) {}
 GLAPI void APIENTRY glBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, const void* data) {}
 GLAPI void APIENTRY glCopyBufferSubData(GLenum readtarget, GLenum writetarget, GLintptr readoffset, GLintptr writeoffset, GLsizeiptr size) {}
-GLAPI void APIENTRY glClearBufferData(GLenum target, GLenum internalformat, GLenum format, GLenum type, const void* data) {}
-GLAPI void APIENTRY glClearNamedBufferData(GLuint buffer, GLenum internalformat, GLenum format, GLenum type, const void* data) {}
 GLAPI void APIENTRY glBindBufferBase(GLenum target, GLuint index, GLuint buffer) {}
 GLAPI void APIENTRY glBindBufferRange(GLenum target, GLuint index, GLuint buffer, GLintptr offset, GLsizeiptr size) {}
 GLAPI GLboolean APIENTRY glIsBuffer(GLuint buffer) { return GL_TRUE; }


### PR DESCRIPTION
Add Clear function to VBO. Sets whole buffer to 0.

Cosmetic change to vbo existence check. Replace repetitive code with a function, put it into an unnamed namespace to avoid flooding header with private utils.