### PR TITLE
Add mempooltypes tests

### DIFF
--- a/rts/System/MemPoolTypes.h
+++ b/rts/System/MemPoolTypes.h
@@ -162,7 +162,8 @@ public:
 	void* allocMem(size_t size) {
 		uint8_t* ptr = nullptr;
 
-		if (indcs.empty()) {
+		if (free_page_count == 0) {
+			assert(free_page_index = -1);
 			// pool is full
 			if (num_chunks == N)
 				return ptr;
@@ -170,21 +171,29 @@ public:
 			assert(chunks[num_chunks] == nullptr);
 			chunks[num_chunks].reset(new t_chunk_mem());
 
+			free_page_count = NUM_PAGES();
+			free_page_index = num_chunks * NUM_PAGES();
+
 			// reserve new indices; in reverse order since each will be popped from the back
-			indcs.reserve(K);
-
-			for (size_t j = 0; j < K; j++) {
-				indcs.push_back(static_cast<uint32_t>((num_chunks + 1) * K - j - 1));
+			uint32_t incIdx = free_page_index;
+			for (auto& chunk : *chunks[num_chunks]) {
+				chunk.index = ++incIdx;
 			}
-
+			chunks[num_chunks]->back().index = -1;
 			num_chunks += 1;
 		}
 
-		const uint32_t idx = spring::VectorBackPop(indcs);
-
+		assert(free_page_count);
+		assert(free_page_index != -1);
+		
+		--free_page_count;
+		page_index = free_page_index;	
+		Chunk* chunk = get_chunk(page_index);		
+		free_page_index = chunk->index;
+				
 		assert(size <= PAGE_SIZE());
-		memcpy(ptr = page_mem(page_index = idx), &idx, sizeof(idx));
-		return (ptr + sizeof(idx));
+		chunk->index = page_index;
+		return chunk->data;
 	}
 
 
@@ -202,23 +211,30 @@ public:
 
 		// zero-fill page
 		assert(idx < (N * K));
-		memset(page_mem(idx), 0, sizeof(idx) + S);
+		memset(page_mem(idx), 0, sizeof(Chunk));
 
-		indcs.push_back(idx);
+		auto* chunk = get_chunk(idx);
+		chunk->index = free_page_index;
+		free_page_index = idx;
+		++free_page_count;
 	}
 
 
-	void reserve(size_t n) { indcs.reserve(n); }
+	void reserve(size_t n) { }
 	void clear() {
-		indcs.clear();
-
+		free_page_count = num_chunks * NUM_PAGES();
+		free_page_index = (num_chunks > 0) ? 0 : -1;
 		// for every allocated chunk, add back all indices
 		// (objects are assumed to have already been freed)
-		for (size_t i = 0; i < num_chunks; i++) {
-			for (size_t j = 0; j < K; j++) {
-				indcs.push_back(static_cast<uint32_t>((i + 1) * K - j - 1));
+		
+		uint32_t free_index = 0;		
+		for (auto i = 0; i < num_chunks; ++i) {
+			for (auto& chunk : *chunks[i]) {
+				chunk.index = ++free_index;				
 			}
 		}
+        if (num_chunks)
+            chunks[num_chunks-1]->back().index = -1;
 
 		page_index = 0;
 	}
@@ -231,39 +247,50 @@ public:
 	const uint8_t* page_mem(size_t idx, size_t ofs = 0) const {
 		const t_chunk_ptr& chunk_ptr = chunks[idx / K];
 		const t_chunk_mem& chunk_mem = *chunk_ptr;
-		return (&chunk_mem[idx % K][0] + ofs);
+		return (reinterpret_cast<const uint8_t*>(&chunk_mem[idx % K]) + ofs);
 	}
 	uint8_t* page_mem(size_t idx, size_t ofs = 0) {
 		t_chunk_ptr& chunk_ptr = chunks[idx / K];
 		t_chunk_mem& chunk_mem = *chunk_ptr;
-		return (&chunk_mem[idx % K][0] + ofs);
+		return (reinterpret_cast<uint8_t*>(&chunk_mem[idx % K]) + ofs);
 	}
 
 	uint32_t page_idx(void* ptr) const {
 		const uint8_t* raw_ptr = reinterpret_cast<const uint8_t*>(ptr);
-		const uint8_t* idx_ptr = raw_ptr - sizeof(uint32_t);
+		const Chunk* chunk = reinterpret_cast<const Chunk*>(raw_ptr - sizeof(Chunk::index));
 
-		return (*reinterpret_cast<const uint32_t*>(idx_ptr));
+		return chunk->index;
 	}
 
 	size_t alloc_size() const { return (num_chunks * NUM_PAGES() * PAGE_SIZE()); } // size of total number of pages added over the pool's lifetime
-	size_t freed_size() const { return (indcs.size() * PAGE_SIZE()); } // size of number of pages that were freed and are awaiting reuse
+	size_t freed_size() const { return (free_page_count * PAGE_SIZE()); } // size of number of pages that were freed and are awaiting reuse
 
 	bool mapped(void* ptr) const { return ((page_idx(ptr) < (num_chunks * K)) && (page_mem(page_idx(ptr), sizeof(uint32_t)) == ptr)); }
 	bool alloced(void* ptr) const { return ((page_index < (num_chunks * K)) && (page_mem(page_index, sizeof(uint32_t)) == ptr)); }
-	bool can_alloc() const { return num_chunks < N || !indcs.empty() ; }
-	bool can_free() const { return indcs.size() < (NUM_CHUNKS() * NUM_PAGES()); }
+	bool can_alloc() const { return num_chunks < N || free_page_count > 0; }
+	bool can_free() const { return free_page_count < (NUM_CHUNKS() * NUM_PAGES()); }
 
 private:
+	#pragma pack()
+	struct Chunk {
+		uint32_t index;
+		uint8_t data[S];
+	};	
+	
+	Chunk* get_chunk(size_t idx) {
+		return reinterpret_cast<Chunk*>(page_mem(idx));
+	}
+	
 	// first sizeof(uint32_t) bytes are reserved for index
-	typedef std::array<uint8_t[sizeof(uint32_t) + S], K> t_chunk_mem;
+	typedef std::array<Chunk, K> t_chunk_mem;
 	typedef std::unique_ptr<t_chunk_mem> t_chunk_ptr;
 
 	std::array<t_chunk_ptr, N> chunks;
-	std::vector<uint32_t> indcs;
 
 	size_t num_chunks = 0;
-	size_t page_index = 0;
+	size_t page_index = 0; // idx of last allocated page
+	size_t free_page_count = 0;
+	size_t free_page_index = -1;
 };
 
 

--- a/rts/System/MemPoolTypes.h
+++ b/rts/System/MemPoolTypes.h
@@ -122,6 +122,8 @@ public:
 
 	bool mapped(void* p) const { return (table.find(p) != table.end()); }
 	bool alloced(void* p) const { return ((curr_page_index < pages.size()) && (pages[curr_page_index].data() == p)); }
+	bool can_alloc() const { return true; }
+	bool can_free() const { return indcs.size() < pages.size(); }
 
 	void clear() {
 		pages.clear();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -498,7 +498,7 @@ endif()
 		)
 
 	# add_spring_test(${test_name} "${test_src}" "${test_libs}" "${test_flags}")
-	target_include_directories(test_${test_name} PRIVATE ${ENGINE_SOURCE_DIR}/lib/)
+	# target_include_directories(test_${test_name} PRIVATE ${ENGINE_SOURCE_DIR}/lib/)
 
 ################################################################################
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -477,6 +477,16 @@ endif()
 	target_include_directories(test_${test_name} PRIVATE ${ENGINE_SOURCE_DIR}/lib/lua/include)
 
 ################################################################################
+### MemPoolTypes
+	set(test_name MemPoolTypes)
+	set(test_src
+			"${CMAKE_CURRENT_SOURCE_DIR}/other/testMemPoolTypes.cpp"
+			${test_Log_sources}
+		)
+	add_spring_test(${test_name} "${test_src}" "${test_libs}" "${test_flags}")
+	target_include_directories(test_${test_name} PRIVATE ${ENGINE_SOURCE_DIR}/lib/)
+
+################################################################################
 
 
 add_subdirectory(headercheck)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -487,6 +487,20 @@ endif()
 	target_include_directories(test_${test_name} PRIVATE ${ENGINE_SOURCE_DIR}/lib/)
 
 ################################################################################
+### BenchmarkMemPoolTypes
+	set(test_name benchmarkMemPoolTypes)
+	set(test_src
+			"${CMAKE_CURRENT_SOURCE_DIR}/other/benchmarkMemPoolTypes.cpp"
+			${test_Log_sources}
+		)
+	set(test_libs
+			benchmark
+		)
+
+	# add_spring_test(${test_name} "${test_src}" "${test_libs}" "${test_flags}")
+	target_include_directories(test_${test_name} PRIVATE ${ENGINE_SOURCE_DIR}/lib/)
+
+################################################################################
 
 
 add_subdirectory(headercheck)

--- a/test/other/benchmarkMemPoolTypes.cpp
+++ b/test/other/benchmarkMemPoolTypes.cpp
@@ -8,19 +8,18 @@
 #include <vector>
 
 namespace {
-    namespace objsizes {
-        // common structs used in the engine
-        constexpr size_t micro=64; // CMatrix44f
-        constexpr size_t small=128; // SolidObjectGroundDecal
-        constexpr size_t medium=752; // PlasmaRepulser
-        constexpr size_t large=1472; // CFeature
-    }
+	namespace objsizes {
+		// common structs used in the engine
+		constexpr size_t micro=64; // CMatrix44f
+		constexpr size_t small=128; // SolidObjectGroundDecal
+		constexpr size_t medium=752; // PlasmaRepulser
+		constexpr size_t large=1472; // CFeature
+	}
 }
 
 template <size_t T>
 struct ArrayData {
-	char Data[T-8];
-	size_t idx=0;
+	std::array<char, T> data={};
 };
 
 template <typename TMempool>
@@ -32,7 +31,6 @@ static void BenchStaticMemPoolAllocation(benchmark::State& state) {
 	using AD = ArrayData<page_size>;
 	std::vector<AD*> allocated;
 
-	size_t idx =0;
 	for (auto _ : state) {
 		if (!mempool.can_alloc()) {
 			state.PauseTiming();
@@ -41,7 +39,6 @@ static void BenchStaticMemPoolAllocation(benchmark::State& state) {
 			state.ResumeTiming();
 		}
 		auto* obj = mempool.template alloc<AD>();
-		obj->idx = ++idx;
 		benchmark::DoNotOptimize(obj);
 		allocated.push_back(obj);
 		benchmark::ClobberMemory();
@@ -79,7 +76,6 @@ static void BenchStaticMemPoolAllocationDeallocation(benchmark::State& state) {
 	using AD = ArrayData<page_size>;
 	std::vector<AD*> allocated;
 
-	size_t idx =0;
 	for (auto _ : state) {
 		if (!mempool.can_alloc()) {
 			for (auto* obj : allocated) {
@@ -88,7 +84,6 @@ static void BenchStaticMemPoolAllocationDeallocation(benchmark::State& state) {
 			allocated.clear();
 		}
 		auto* obj = mempool.template alloc<AD>();
-		obj->idx = ++idx;
 		benchmark::DoNotOptimize(obj);
 		allocated.push_back(obj);
 		benchmark::ClobberMemory();

--- a/test/other/benchmarkMemPoolTypes.cpp
+++ b/test/other/benchmarkMemPoolTypes.cpp
@@ -9,8 +9,8 @@
 
 template <size_t T>
 struct ArrayData {
-    char Data[T-8];
-    size_t idx=0;
+	char Data[T-8];
+	size_t idx=0;
 };
 
 template <typename TMempool>
@@ -18,20 +18,20 @@ static void BenchStaticMemPoolAllocation(benchmark::State& state) {
 	static TMempool mempool;
 	mempool.clear();
 
-    constexpr size_t page_size = mempool.PAGE_SIZE();
-    using AD = ArrayData<page_size>;
+	constexpr size_t page_size = mempool.PAGE_SIZE();
+	using AD = ArrayData<page_size>;
 	std::vector<AD*> allocated;
 
-    size_t idx =0;
+	size_t idx =0;
 	for (auto _ : state) {
 		if (!mempool.can_alloc()) {
-            state.PauseTiming();
+			state.PauseTiming();
 			mempool.clear();
-            allocated.clear();
-            state.ResumeTiming();
+			allocated.clear();
+			state.ResumeTiming();
 		}
 		auto* obj = mempool.template alloc<AD>();
-        obj->idx = ++idx;
+		obj->idx = ++idx;
 		benchmark::DoNotOptimize(obj);
 		allocated.push_back(obj);
 		benchmark::ClobberMemory();
@@ -54,20 +54,20 @@ static void BenchStaticMemPoolAllocationDeallocation(benchmark::State& state) {
 	static TMempool mempool;
 	mempool.clear();
 
-    constexpr size_t page_size = mempool.PAGE_SIZE();
-    using AD = ArrayData<page_size>;
+	constexpr size_t page_size = mempool.PAGE_SIZE();
+	using AD = ArrayData<page_size>;
 	std::vector<AD*> allocated;
 
-    size_t idx =0;
+	size_t idx =0;
 	for (auto _ : state) {
 		if (!mempool.can_alloc()) {
-            for (auto* obj : allocated) {
-                mempool.free(obj);
-            }
-            allocated.clear();
+			for (auto* obj : allocated) {
+				mempool.free(obj);
+			}
+			allocated.clear();
 		}
 		auto* obj = mempool.template alloc<AD>();
-        obj->idx = ++idx;
+		obj->idx = ++idx;
 		benchmark::DoNotOptimize(obj);
 		allocated.push_back(obj);
 		benchmark::ClobberMemory();

--- a/test/other/benchmarkMemPoolTypes.cpp
+++ b/test/other/benchmarkMemPoolTypes.cpp
@@ -9,10 +9,11 @@
 
 namespace {
 	namespace objsizes {
-		// common structs used in the engine
+		// Allocators' page sizes are set to the largest object in particular category (e.g. Weapons)
+		// These are the page sizes that are commonly used in the engine
 		constexpr size_t micro=64; // CMatrix44f
 		constexpr size_t small=128; // SolidObjectGroundDecal
-		constexpr size_t medium=752; // PlasmaRepulser
+		constexpr size_t medium=752; // CWeapon,PlasmaRepulser
 		constexpr size_t large=1472; // CFeature
 	}
 }

--- a/test/other/benchmarkMemPoolTypes.cpp
+++ b/test/other/benchmarkMemPoolTypes.cpp
@@ -1,0 +1,87 @@
+#include "System/MemPoolTypes.h"
+#include "System/Log/ILog.h"
+
+#include <benchmark/benchmark.h>
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+template <size_t T>
+struct ArrayData {
+    char Data[T-8];
+    size_t idx=0;
+};
+
+template <typename TMempool>
+static void BenchStaticMemPoolAllocation(benchmark::State& state) {
+	static TMempool mempool;
+	mempool.clear();
+
+    constexpr size_t page_size = mempool.PAGE_SIZE();
+    using AD = ArrayData<page_size>;
+	std::vector<AD*> allocated;
+
+    size_t idx =0;
+	for (auto _ : state) {
+		if (!mempool.can_alloc()) {
+            state.PauseTiming();
+			mempool.clear();
+            allocated.clear();
+            state.ResumeTiming();
+		}
+		auto* obj = mempool.template alloc<AD>();
+        obj->idx = ++idx;
+		benchmark::DoNotOptimize(obj);
+		allocated.push_back(obj);
+		benchmark::ClobberMemory();
+	}
+}
+
+
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<10240, 512>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<10240, 1024>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<102400, 512>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<102400, 1024>>);
+
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<512, 16, 256>>);
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<1024, 32, 1024>>);
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<512, 16, 256>>);
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<1024, 32, 1024>>);
+
+template <typename TMempool>
+static void BenchStaticMemPoolAllocationDeallocation(benchmark::State& state) {
+	static TMempool mempool;
+	mempool.clear();
+
+    constexpr size_t page_size = mempool.PAGE_SIZE();
+    using AD = ArrayData<page_size>;
+	std::vector<AD*> allocated;
+
+    size_t idx =0;
+	for (auto _ : state) {
+		if (!mempool.can_alloc()) {
+            for (auto* obj : allocated) {
+                mempool.free(obj);
+            }
+            allocated.clear();
+		}
+		auto* obj = mempool.template alloc<AD>();
+        obj->idx = ++idx;
+		benchmark::DoNotOptimize(obj);
+		allocated.push_back(obj);
+		benchmark::ClobberMemory();
+	}
+}
+
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<10240, 512>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<10240, 1024>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<102400, 512>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<102400, 1024>>);
+
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<512, 16, 256>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<1024, 32, 1024>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<512, 16, 256>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<1024, 32, 1024>>);
+
+BENCHMARK_MAIN();

--- a/test/other/benchmarkMemPoolTypes.cpp
+++ b/test/other/benchmarkMemPoolTypes.cpp
@@ -7,6 +7,16 @@
 #include <cstddef>
 #include <vector>
 
+namespace {
+    namespace objsizes {
+        // common structs used in the engine
+        constexpr size_t micro=64; // CMatrix44f
+        constexpr size_t small=128; // SolidObjectGroundDecal
+        constexpr size_t medium=752; // PlasmaRepulser
+        constexpr size_t large=1472; // CFeature
+    }
+}
+
 template <size_t T>
 struct ArrayData {
 	char Data[T-8];
@@ -38,16 +48,27 @@ static void BenchStaticMemPoolAllocation(benchmark::State& state) {
 	}
 }
 
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<1024, objsizes::micro>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<1024, objsizes::small>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<1024, objsizes::medium>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<1024, objsizes::large>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<10240, objsizes::micro>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<10240, objsizes::small>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<10240, objsizes::medium>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<10240, objsizes::large>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<102400, objsizes::micro>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<102400, objsizes::small>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<102400, objsizes::medium>>);
+BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<102400, objsizes::large>>);
 
-BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<10240, 512>>);
-BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<10240, 1024>>);
-BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<102400, 512>>);
-BENCHMARK(BenchStaticMemPoolAllocation<StaticMemPool<102400, 1024>>);
-
-BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<512, 16, 256>>);
-BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<1024, 32, 1024>>);
-BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<512, 16, 256>>);
-BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<1024, 32, 1024>>);
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<512, 16, objsizes::micro>>);
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<512, 16, objsizes::small>>);
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<512, 16, objsizes::medium>>);
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<512, 16, objsizes::large>>);
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<1024, 32, objsizes::micro>>);
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<1024, 32, objsizes::small>>);
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<1024, 32, objsizes::medium>>);
+BENCHMARK(BenchStaticMemPoolAllocation<FixedDynMemPool<1024, 32, objsizes::large>>);
 
 template <typename TMempool>
 static void BenchStaticMemPoolAllocationDeallocation(benchmark::State& state) {
@@ -74,14 +95,26 @@ static void BenchStaticMemPoolAllocationDeallocation(benchmark::State& state) {
 	}
 }
 
-BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<10240, 512>>);
-BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<10240, 1024>>);
-BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<102400, 512>>);
-BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<102400, 1024>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<1024, objsizes::micro>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<1024, objsizes::small>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<1024, objsizes::medium>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<1024, objsizes::large>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<10240, objsizes::micro>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<10240, objsizes::small>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<10240, objsizes::medium>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<10240, objsizes::large>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<102400, objsizes::micro>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<102400, objsizes::small>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<102400, objsizes::medium>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<StaticMemPool<102400, objsizes::large>>);
 
-BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<512, 16, 256>>);
-BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<1024, 32, 1024>>);
-BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<512, 16, 256>>);
-BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<1024, 32, 1024>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<512, 16, objsizes::micro>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<512, 16, objsizes::small>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<512, 16, objsizes::medium>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<512, 16, objsizes::large>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<1024, 32, objsizes::micro>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<1024, 32, objsizes::small>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<1024, 32, objsizes::medium>>);
+BENCHMARK(BenchStaticMemPoolAllocationDeallocation<FixedDynMemPool<1024, 32, objsizes::large>>);
 
 BENCHMARK_MAIN();

--- a/test/other/testMemPoolTypes.cpp
+++ b/test/other/testMemPoolTypes.cpp
@@ -1,0 +1,110 @@
+#include "System/MemPoolTypes.h"
+#include "System/Log/ILog.h"
+
+#include <vector>
+#include <cstddef>
+
+#define CATCH_CONFIG_MAIN
+#include "lib/catch.hpp"
+
+namespace {
+struct TestData
+{
+    TestData(uint64_t& counter) :
+        counter(++counter) { }
+    ~TestData() {
+        --counter;
+    }
+    uint64_t& counter;
+};
+
+template <typename T>
+struct AllocFixture {
+    AllocFixture() : mempool(std::make_unique<T>()) {}
+
+    TestData* alloc() {
+        return mempool->template alloc<TestData>(instanceCounter);
+    }
+
+    void free(TestData* obj) {
+        return mempool->free(obj);
+    }
+
+    std::unique_ptr<T> mempool;
+    uint64_t instanceCounter=0;
+};
+
+TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator when full", "[class][template]",
+        (StaticMemPool<1,sizeof(TestData)>),
+        (FixedDynMemPool<sizeof(TestData), 1, 1>))
+{
+    AllocFixture<TestType> inst;
+    auto& mempool = *inst.mempool;
+    auto* obj = inst.alloc();
+    REQUIRE(obj);
+    REQUIRE(!mempool.can_alloc());
+
+    // StaticMemPool silently fails
+    //auto* obj2 = mempool.allocMem(1);
+    //REQUIRE(!obj2);
+}
+
+TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator base functionality", "[class][template]",
+        (StaticMemPool<1024,sizeof(TestData)>),
+        (FixedDynMemPool<sizeof(TestData), 1, 1024>))
+{
+    AllocFixture<TestType> inst;
+    auto& mempool = *inst.mempool;
+
+    REQUIRE(mempool.can_alloc());
+
+    std::vector<TestData*> allocated;
+
+    for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
+        REQUIRE(mempool.can_alloc());
+        auto obj = inst.alloc();
+        REQUIRE(mempool.alloced(obj));
+        allocated.push_back(obj);
+    }
+
+    REQUIRE(inst.instanceCounter == mempool.NUM_PAGES());
+
+    REQUIRE(!mempool.can_alloc());
+
+    for (auto* obj : allocated) {
+        REQUIRE(mempool.can_free());
+        mempool.free(obj);
+    }
+    REQUIRE(inst.instanceCounter == 0);
+    REQUIRE(!mempool.can_free());
+}
+
+TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class][template]",
+        (StaticMemPool<1024,sizeof(TestData)>),
+        (FixedDynMemPool<sizeof(TestData), 1, 1024>))
+{
+    AllocFixture<TestType> inst;
+    auto& mempool = *inst.mempool;
+
+    std::vector<TestData*> allocated;
+    for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
+        auto obj = inst.alloc();
+        allocated.push_back(obj);
+    }
+
+    std::for_each(allocated.rbegin(), allocated.rend(), [&](auto* obj) {
+        mempool.free(obj);
+    });
+
+    // verify that new elements reuse previous memory
+    for (size_t i = 0; i < mempool.NUM_PAGES(); ++i) {
+        auto obj = inst.alloc();
+        REQUIRE(obj == allocated[i]);
+    }
+
+    for (auto* obj : allocated) {
+        mempool.free(obj);
+    }
+}
+
+} // unnamed namespace

--- a/test/other/testMemPoolTypes.cpp
+++ b/test/other/testMemPoolTypes.cpp
@@ -120,7 +120,7 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator's clear method", "[class
         auto obj = inst.alloc();
     }
 
-    mempool.clear(); // might not call destructors
+    mempool.clear(); // current implementations do not call destructors. TODO maybe they should?
 
     for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
         REQUIRE(mempool.can_alloc());

--- a/test/other/testMemPoolTypes.cpp
+++ b/test/other/testMemPoolTypes.cpp
@@ -10,185 +10,185 @@
 namespace {
 struct TestData
 {
-    TestData(uint64_t& counter) :
-        counter(++counter) { }
-    ~TestData() {
-        --counter;
-    }
-    uint64_t& counter;
+	TestData(uint64_t& counter) :
+		counter(++counter) { }
+	~TestData() {
+		--counter;
+	}
+	uint64_t& counter;
 };
 
 constexpr size_t TEST_ALLOCATOR_SIZE = 1024;
 
 template <typename T>
-struct AllocFixture {
-    AllocFixture() : mempool(std::make_unique<T>()) {}
+	struct AllocFixture {
+		AllocFixture() : mempool(std::make_unique<T>()) {}
 
-    TestData* alloc() {
-        return mempool->template alloc<TestData>(instanceCounter);
-    }
+		TestData* alloc() {
+			return mempool->template alloc<TestData>(instanceCounter);
+		}
 
-    void free(TestData* obj) {
-        return mempool->free(obj);
-    }
+		void free(TestData* obj) {
+			return mempool->free(obj);
+		}
 
-    std::unique_ptr<T> mempool;
-    uint64_t instanceCounter=0;
-};
+		std::unique_ptr<T> mempool;
+		uint64_t instanceCounter=0;
+	};
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator when full", "[class][template]",
-        (StaticMemPool<1,sizeof(TestData)>),
-        (FixedDynMemPool<sizeof(TestData), 1, 1>))
+		(StaticMemPool<1,sizeof(TestData)>),
+		(FixedDynMemPool<sizeof(TestData), 1, 1>))
 {
-    AllocFixture<TestType> inst;
-    auto& mempool = *inst.mempool;
-    auto* obj = inst.alloc();
-    REQUIRE(obj);
-    REQUIRE(!mempool.can_alloc());
+	AllocFixture<TestType> inst;
+	auto& mempool = *inst.mempool;
+	auto* obj = inst.alloc();
+	REQUIRE(obj);
+	REQUIRE(!mempool.can_alloc());
 
-    // StaticMemPool silently fails
-    //auto* obj2 = mempool.allocMem(1);
-    //REQUIRE(!obj2);
+	// StaticMemPool silently fails
+	//auto* obj2 = mempool.allocMem(1);
+	//REQUIRE(!obj2);
 }
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test bounded allocator base functionality", "[class][template]",
-        (StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
-        (FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>))
+		(StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
+		(FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>))
 {
-    AllocFixture<TestType> inst;
-    auto& mempool = *inst.mempool;
+	AllocFixture<TestType> inst;
+	auto& mempool = *inst.mempool;
 
-    REQUIRE(mempool.can_alloc());
+	REQUIRE(mempool.can_alloc());
 
-    std::vector<TestData*> allocated;
+	std::vector<TestData*> allocated;
 
-    for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
-        REQUIRE(mempool.can_alloc());
-        auto obj = inst.alloc();
-        REQUIRE(mempool.alloced(obj));
-        allocated.push_back(obj);
-    }
+	for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
+		REQUIRE(mempool.can_alloc());
+		auto obj = inst.alloc();
+		REQUIRE(mempool.alloced(obj));
+		allocated.push_back(obj);
+	}
 
-    REQUIRE(inst.instanceCounter == mempool.NUM_PAGES());
+	REQUIRE(inst.instanceCounter == mempool.NUM_PAGES());
 
-    REQUIRE(!mempool.can_alloc());
+	REQUIRE(!mempool.can_alloc());
 
-    for (auto* obj : allocated) {
-        REQUIRE(mempool.can_free());
-        mempool.free(obj);
-    }
-    REQUIRE(inst.instanceCounter == 0);
-    REQUIRE(!mempool.can_free());
+	for (auto* obj : allocated) {
+		REQUIRE(mempool.can_free());
+		mempool.free(obj);
+	}
+	REQUIRE(inst.instanceCounter == 0);
+	REQUIRE(!mempool.can_free());
 }
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test unbounded allocator base functionality", "[class][template]",
-        (DynMemPool<sizeof(TestData)>))
+		(DynMemPool<sizeof(TestData)>))
 {
-    AllocFixture<TestType> inst;
-    auto& mempool = *inst.mempool;
+	AllocFixture<TestType> inst;
+	auto& mempool = *inst.mempool;
 
-    REQUIRE(mempool.can_alloc());
+	REQUIRE(mempool.can_alloc());
 
-    std::vector<TestData*> allocated;
+	std::vector<TestData*> allocated;
 
-    for (size_t i =0; i < TEST_ALLOCATOR_SIZE; ++i) {
-        REQUIRE(mempool.can_alloc());
-        auto obj = inst.alloc();
-        REQUIRE(mempool.alloced(obj));
-        allocated.push_back(obj);
-    }
+	for (size_t i =0; i < TEST_ALLOCATOR_SIZE; ++i) {
+		REQUIRE(mempool.can_alloc());
+		auto obj = inst.alloc();
+		REQUIRE(mempool.alloced(obj));
+		allocated.push_back(obj);
+	}
 
-    REQUIRE(inst.instanceCounter == TEST_ALLOCATOR_SIZE);
+	REQUIRE(inst.instanceCounter == TEST_ALLOCATOR_SIZE);
 
-    REQUIRE(mempool.can_alloc()); // unbounded allocator can always alloc
+	REQUIRE(mempool.can_alloc()); // unbounded allocator can always alloc
 
-    for (auto* obj : allocated	) {
-        REQUIRE(mempool.can_free());
-        mempool.free(obj);
-    }
-    REQUIRE(inst.instanceCounter == 0);
-    REQUIRE(!mempool.can_free());
+	for (auto* obj : allocated	) {
+		REQUIRE(mempool.can_free());
+		mempool.free(obj);
+	}
+	REQUIRE(inst.instanceCounter == 0);
+	REQUIRE(!mempool.can_free());
 }
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class][template]",
-        (StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
-        (FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>),
-        (DynMemPool<sizeof(TestData)>))
+		(StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
+		(FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>),
+		(DynMemPool<sizeof(TestData)>))
 {
-    AllocFixture<TestType> inst;
-    auto& mempool = *inst.mempool;
+	AllocFixture<TestType> inst;
+	auto& mempool = *inst.mempool;
 
-    std::unordered_map<TestData*, int> allocated;
-    for (size_t i =0; i < TEST_ALLOCATOR_SIZE; ++i) {
-        auto obj = inst.alloc();
-        allocated[obj]++;
-    }
+	std::unordered_map<TestData*, int> allocated;
+	for (size_t i =0; i < TEST_ALLOCATOR_SIZE; ++i) {
+		auto obj = inst.alloc();
+		allocated[obj]++;
+	}
 
-    for (auto& pair : allocated) {
-        TestData* ptr = pair.first;
-        mempool.free(ptr);
-    };
+	for (auto& pair : allocated) {
+		TestData* ptr = pair.first;
+		mempool.free(ptr);
+	};
 
-    for (size_t i = 0; i < TEST_ALLOCATOR_SIZE; ++i) {
-        auto obj = inst.alloc();
-        REQUIRE(allocated[obj] == 1);
-    }
+	for (size_t i = 0; i < TEST_ALLOCATOR_SIZE; ++i) {
+		auto obj = inst.alloc();
+		REQUIRE(allocated[obj] == 1);
+	}
 
-    for (auto& pair : allocated) {
-        TestData* ptr = pair.first;
-        mempool.free(ptr);
-    };
+	for (auto& pair : allocated) {
+		TestData* ptr = pair.first;
+		mempool.free(ptr);
+	};
 }
 
 // obeying the order is not a functional requirement of allocator
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory in LIFO order", "[class][template]",
-        (StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
-        (FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>),
-        (DynMemPool<sizeof(TestData)>))
+		(StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
+		(FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>),
+		(DynMemPool<sizeof(TestData)>))
 {
-    AllocFixture<TestType> inst;
-    auto& mempool = *inst.mempool;
+	AllocFixture<TestType> inst;
+	auto& mempool = *inst.mempool;
 
-    std::vector<TestData*> allocated;
-    for (size_t i =0; i < TEST_ALLOCATOR_SIZE; ++i) {
-        auto obj = inst.alloc();
-        allocated.push_back(obj);
-    }
+	std::vector<TestData*> allocated;
+	for (size_t i =0; i < TEST_ALLOCATOR_SIZE; ++i) {
+		auto obj = inst.alloc();
+		allocated.push_back(obj);
+	}
 
-    std::for_each(allocated.rbegin(), allocated.rend(), [&](auto* obj) {
-        mempool.free(obj);
-    });
+	std::for_each(allocated.rbegin(), allocated.rend(), [&](auto* obj) {
+			mempool.free(obj);
+			});
 
-    // verify that new elements reuse previous memory
-    // in LIFO order
-    for (size_t i = 0; i < TEST_ALLOCATOR_SIZE; ++i) {
-        auto obj = inst.alloc();
-        REQUIRE(obj == allocated[i]);
-    }
+	// verify that new elements reuse previous memory
+	// in LIFO order
+	for (size_t i = 0; i < TEST_ALLOCATOR_SIZE; ++i) {
+		auto obj = inst.alloc();
+		REQUIRE(obj == allocated[i]);
+	}
 
-    for (auto* obj : allocated) {
-        mempool.free(obj);
-    }
+	for (auto* obj : allocated) {
+		mempool.free(obj);
+	}
 }
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator's clear method", "[class][template]",
-        (StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
-        (FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>))
+		(StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
+		(FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>))
 {
-    AllocFixture<TestType> inst;
-    auto& mempool = *inst.mempool;
+	AllocFixture<TestType> inst;
+	auto& mempool = *inst.mempool;
 
-    for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
-        auto obj = inst.alloc();
-    }
+	for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
+		auto obj = inst.alloc();
+	}
 
-    // allocators do not call destructors as they do not know object underlying type
-    mempool.clear();
+	// allocators do not call destructors as they do not know object underlying type
+	mempool.clear();
 
-    for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
-        REQUIRE(mempool.can_alloc());
-        auto obj = inst.alloc();
-    }
+	for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
+		REQUIRE(mempool.can_alloc());
+		auto obj = inst.alloc();
+	}
 }
 
 } // unnamed namespace

--- a/test/other/testMemPoolTypes.cpp
+++ b/test/other/testMemPoolTypes.cpp
@@ -79,7 +79,8 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator base functionality", "[c
     REQUIRE(!mempool.can_free());
 }
 
-TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class][template]",
+// obeying the order is not a functional requirement of allocator
+TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory in LIFO order", "[class][template]",
         (StaticMemPool<1024,sizeof(TestData)>),
         (FixedDynMemPool<sizeof(TestData), 1, 1024>))
 {
@@ -97,6 +98,7 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class
     });
 
     // verify that new elements reuse previous memory
+    // in LIFO order
     for (size_t i = 0; i < mempool.NUM_PAGES(); ++i) {
         auto obj = inst.alloc();
         REQUIRE(obj == allocated[i]);

--- a/test/other/testMemPoolTypes.cpp
+++ b/test/other/testMemPoolTypes.cpp
@@ -183,7 +183,8 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator's clear method", "[class
         auto obj = inst.alloc();
     }
 
-    mempool.clear(); // current implementations do not call destructors. TODO maybe they should?
+    // allocators do not call destructors as they do not know object underlying type
+    mempool.clear();
 
     for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
         REQUIRE(mempool.can_alloc());

--- a/test/other/testMemPoolTypes.cpp
+++ b/test/other/testMemPoolTypes.cpp
@@ -18,6 +18,8 @@ struct TestData
     uint64_t& counter;
 };
 
+constexpr size_t TEST_ALLOCATOR_SIZE = 1024;
+
 template <typename T>
 struct AllocFixture {
     AllocFixture() : mempool(std::make_unique<T>()) {}
@@ -50,8 +52,8 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator when full", "[class][tem
 }
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test bounded allocator base functionality", "[class][template]",
-        (StaticMemPool<1024,sizeof(TestData)>),
-        (FixedDynMemPool<sizeof(TestData), 1, 1024>))
+        (StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
+        (FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>))
 {
     AllocFixture<TestType> inst;
     auto& mempool = *inst.mempool;
@@ -83,21 +85,20 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test unbounded allocator base functiona
         (DynMemPool<sizeof(TestData)>))
 {
     AllocFixture<TestType> inst;
-    const size_t test_size = 1024;
     auto& mempool = *inst.mempool;
 
     REQUIRE(mempool.can_alloc());
 
     std::vector<TestData*> allocated;
 
-    for (size_t i =0; i < test_size; ++i) {
+    for (size_t i =0; i < TEST_ALLOCATOR_SIZE; ++i) {
         REQUIRE(mempool.can_alloc());
         auto obj = inst.alloc();
         REQUIRE(mempool.alloced(obj));
         allocated.push_back(obj);
     }
 
-    REQUIRE(inst.instanceCounter == test_size);
+    REQUIRE(inst.instanceCounter == TEST_ALLOCATOR_SIZE);
 
     REQUIRE(mempool.can_alloc()); // unbounded allocator can always alloc
 
@@ -110,16 +111,15 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test unbounded allocator base functiona
 }
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class][template]",
-        (StaticMemPool<1024,sizeof(TestData)>),
-        (FixedDynMemPool<sizeof(TestData), 1, 1024>),
+        (StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
+        (FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>),
         (DynMemPool<sizeof(TestData)>))
 {
     AllocFixture<TestType> inst;
     auto& mempool = *inst.mempool;
-    const size_t test_size = 1024;
 
     std::unordered_map<TestData*, int> allocated;
-    for (size_t i =0; i < test_size; ++i) {
+    for (size_t i =0; i < TEST_ALLOCATOR_SIZE; ++i) {
         auto obj = inst.alloc();
         allocated[obj]++;
     }
@@ -129,7 +129,7 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class
         mempool.free(ptr);
     };
 
-    for (size_t i = 0; i < test_size; ++i) {
+    for (size_t i = 0; i < TEST_ALLOCATOR_SIZE; ++i) {
         auto obj = inst.alloc();
         REQUIRE(allocated[obj] == 1);
     }
@@ -142,16 +142,15 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class
 
 // obeying the order is not a functional requirement of allocator
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory in LIFO order", "[class][template]",
-        (StaticMemPool<1024,sizeof(TestData)>),
-        (FixedDynMemPool<sizeof(TestData), 1, 1024>),
+        (StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
+        (FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>),
         (DynMemPool<sizeof(TestData)>))
 {
     AllocFixture<TestType> inst;
     auto& mempool = *inst.mempool;
-	const size_t test_size = 1024;
 
     std::vector<TestData*> allocated;
-    for (size_t i =0; i < test_size; ++i) {
+    for (size_t i =0; i < TEST_ALLOCATOR_SIZE; ++i) {
         auto obj = inst.alloc();
         allocated.push_back(obj);
     }
@@ -162,7 +161,7 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory in LIFO o
 
     // verify that new elements reuse previous memory
     // in LIFO order
-    for (size_t i = 0; i < test_size; ++i) {
+    for (size_t i = 0; i < TEST_ALLOCATOR_SIZE; ++i) {
         auto obj = inst.alloc();
         REQUIRE(obj == allocated[i]);
     }
@@ -173,8 +172,8 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory in LIFO o
 }
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator's clear method", "[class][template]",
-        (StaticMemPool<1024,sizeof(TestData)>),
-        (FixedDynMemPool<sizeof(TestData), 1, 1024>))
+        (StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
+        (FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>))
 {
     AllocFixture<TestType> inst;
     auto& mempool = *inst.mempool;

--- a/test/other/testMemPoolTypes.cpp
+++ b/test/other/testMemPoolTypes.cpp
@@ -107,4 +107,23 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class
     }
 }
 
+TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator's clear method", "[class][template]",
+        (StaticMemPool<1024,sizeof(TestData)>),
+        (FixedDynMemPool<sizeof(TestData), 1, 1024>))
+{
+    AllocFixture<TestType> inst;
+    auto& mempool = *inst.mempool;
+
+    for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
+        auto obj = inst.alloc();
+    }
+
+    mempool.clear(); // might not call destructors
+
+    for (size_t i =0; i < mempool.NUM_PAGES(); ++i) {
+        REQUIRE(mempool.can_alloc());
+        auto obj = inst.alloc();
+    }
+}
+
 } // unnamed namespace


### PR DESCRIPTION
I was working with allocators and experimenting with changes to free list. Freed object indices can be stored in local (unused) page memory instead separate freelist but that unexpectedly did not bring any performance benefit. So basically it was
```
struct Page {
union {
size_t next_free_page_index;
char data[100];
}
```

instead 
```
std::array<Page, x> pages;
std::array<size_t, x> free_list;
```
I'm leaving tests & benchmarks in the repo for the future benefit.
Not sure what to do about benchmark as we don't have google bench in rts/lib/ but I know vcpkg/conan is around the corner so I disabled this test explicitly for now.