### PR TITLE
TextureFormat.h fail fix

### DIFF
--- a/rts/Rendering/Textures/TextureFormat.h
+++ b/rts/Rendering/Textures/TextureFormat.h
@@ -5,7 +5,7 @@
 
 namespace GL
 {
-	GLenum GetInternalFormatDataFormat(GLenum internalFormat) {
+	inline GLenum GetInternalFormatDataFormat(GLenum internalFormat) {
 		GLenum dataFormat;
 		switch (internalFormat) {
 			case GL_R8UI:
@@ -60,7 +60,7 @@ namespace GL
 		return dataFormat;
 	}
 
-	GLenum GetInternalFormatDataType(GLenum internalFormat) {
+	inline GLenum GetInternalFormatDataType(GLenum internalFormat) {
 		GLenum dataType;
 		switch (internalFormat) {
 			case GL_RGBA16F:


### PR DESCRIPTION
Quick fix of an oversight
Need inline to avoid link errors, **_when_** this file gets used more than once obviously.

It is currently used in 1 file only, so inline itself is not a problem. I will be updating it when I learn which way is better.