### PR TITLE
Drop alpha channel when saving texture as opaque

### DIFF
--- a/rts/Rendering/Textures/Bitmap.cpp
+++ b/rts/Rendering/Textures/Bitmap.cpp
@@ -1439,6 +1439,10 @@ bool CBitmap::Save(const std::string& filename, bool opaque, bool logged, unsign
 
 	ITexMemPool::texMemPool->FreeRaw(buf, xsize * ysize * 4);
 
+	if (opaque) {
+		ilConvertImage(IL_RGB, IL_UNSIGNED_BYTE);
+		assert(ilGetError() == IL_NO_ERROR);
+	}
 
 	const std::string& fsImageExt = FileSystem::GetExtension(filename);
 	const std::string& fsFullPath = dataDirsAccess.LocateFile(filename, FileQueryFlags::WRITE);


### PR DESCRIPTION
This saves some small amount of storage in output file when alpha channel doesn't contain any information anyway.

Resolves #928