### PR TITLE
Fix Constructors to use unit radius in build range check for new units

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -46,6 +46,9 @@ Lua:
    and `beingBuilt` from `GetUnitIsStunned`, but as you can see it wasn't terribly convenient/intuitive.
  - rules params now support the boolean type. Skirmish AI and the rules param selection filter can
    read them via existing numerical interface by using 0 and 1.
+ - add `Spring.GetUnitEffectiveBuildRange(builderID, buildeeDefID)`. Returns the effective build range
+   for building given target, counted from the center of the prospective target's center. Useful for
+   setting move goals manually.
  - add `Script.DelayByFrames(frameDelay, function, args...)`. Runs `function(args...)` after a delay
    of the specified number of frames (at least 1). Multiple functions can be queued onto the same frame
    and run in the order they were added, just before that frame's GameFrame call-in.

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -131,6 +131,7 @@ class LuaSyncedRead {
 		static int GetUnitBuildFacing(lua_State* L);
 		static int GetUnitIsBuilding(lua_State* L);
 		static int GetUnitWorkerTask(lua_State* L);
+		static int GetUnitEffectiveBuildRange(lua_State* L);
 		static int GetUnitCurrentBuildPower(lua_State* L);
 		static int GetUnitHarvestStorage(lua_State* L);
 		static int GetUnitBuildParams(lua_State* L);

--- a/rts/Rendering/Textures/Bitmap.cpp
+++ b/rts/Rendering/Textures/Bitmap.cpp
@@ -1439,6 +1439,10 @@ bool CBitmap::Save(const std::string& filename, bool opaque, bool logged, unsign
 
 	ITexMemPool::texMemPool->FreeRaw(buf, xsize * ysize * 4);
 
+	if (opaque) {
+		ilConvertImage(IL_RGB, IL_UNSIGNED_BYTE);
+		assert(ilGetError() == IL_NO_ERROR);
+	}
 
 	const std::string& fsImageExt = FileSystem::GetExtension(filename);
 	const std::string& fsFullPath = dataDirsAccess.LocateFile(filename, FileQueryFlags::WRITE);

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -250,23 +250,6 @@ void CBuilderCAI::PostLoad()
 	}
 }
 
-
-
-float CBuilderCAI::GetBuildRange(const float targetRadius) const
-{
-	// for immobile:
-	// only use `buildDistance + radius` iff radius > buildDistance,
-	// and so it would be impossible to get in buildrange (collision detection with units/features)
-	//
-	// what does this even mean?? IMMOBILE units cannot "get in range" of anything
-	if (owner->immobile)
-		return (ownerBuilder->buildDistance + std::max(targetRadius - ownerBuilder->buildDistance, 0.0f));
-
-	return (ownerBuilder->buildDistance + targetRadius);
-}
-
-
-
 bool CBuilderCAI::IsInBuildRange(const CWorldObject* obj) const
 {
 	return IsInBuildRange(obj->pos, obj->radius);

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -622,9 +622,10 @@ void CBuilderCAI::ExecuteBuildCmd(Command& c)
 	assert(build.def != nullptr);
 	assert(build.def->id == -c.GetID() && build.def->id != 0);
 
+	auto* model = build.def->LoadModel();
+
 	if (building) {
 		// keep moving until 3D distance to buildPos is LEQ our buildDistance
-		auto* model = build.def->LoadModel();
 		MoveInBuildRange(build.pos, std::max(0.f, model->radius));
 
 		if (ownerBuilder->curBuild == nullptr && !ownerBuilder->terraforming) {
@@ -636,7 +637,7 @@ void CBuilderCAI::ExecuteBuildCmd(Command& c)
 	}
 
 	// keep moving until 3D distance to buildPos is LEQ our buildDistance
-	if (MoveInBuildRange(build.pos = CGameHelper::Pos2BuildPos(build, true), 0.0f, true)) {
+	if (MoveInBuildRange(build.pos = CGameHelper::Pos2BuildPos(build, true), std::max(0.f, model->radius), true)) {
 		if (IsBuildPosBlocked(build)) {
 			StopMoveAndFinishCommand();
 			return;

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -250,6 +250,11 @@ void CBuilderCAI::PostLoad()
 	}
 }
 
+float CBuilderCAI::GetBuildRange(const float targetRadius) const
+{
+	return (ownerBuilder->buildDistance + targetRadius);
+}
+
 bool CBuilderCAI::IsInBuildRange(const CWorldObject* obj) const
 {
 	return IsInBuildRange(obj->pos, obj->radius);

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -624,7 +624,8 @@ void CBuilderCAI::ExecuteBuildCmd(Command& c)
 
 	if (building) {
 		// keep moving until 3D distance to buildPos is LEQ our buildDistance
-		MoveInBuildRange(build.pos, 0.0f);
+		auto* model = build.def->LoadModel();
+		MoveInBuildRange(build.pos, std::max(0.f, model->radius));
 
 		if (ownerBuilder->curBuild == nullptr && !ownerBuilder->terraforming) {
 			building = false;

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -252,7 +252,7 @@ void CBuilderCAI::PostLoad()
 
 
 
-inline float CBuilderCAI::GetBuildRange(const float targetRadius) const
+float CBuilderCAI::GetBuildRange(const float targetRadius) const
 {
 	// for immobile:
 	// only use `buildDistance + radius` iff radius > buildDistance,

--- a/rts/Sim/Units/CommandAI/BuilderCAI.h
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.h
@@ -61,7 +61,7 @@ public:
 
 	bool IsInBuildRange(const CWorldObject* obj) const;
 	bool IsInBuildRange(const float3& pos, const float radius) const;
-	float GetBuildRange(const float targetRadius) const;
+	float GetBuildRange(const float targetRadius) const { return (ownerBuilder->buildDistance + targetRadius); };
 
 public:
 	spring::unordered_set<int> buildOptions;

--- a/rts/Sim/Units/CommandAI/BuilderCAI.h
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.h
@@ -61,7 +61,7 @@ public:
 
 	bool IsInBuildRange(const CWorldObject* obj) const;
 	bool IsInBuildRange(const float3& pos, const float radius) const;
-	float GetBuildRange(const float targetRadius) const { return (ownerBuilder->buildDistance + targetRadius); };
+	float GetBuildRange(const float targetRadius) const;
 
 public:
 	spring::unordered_set<int> buildOptions;

--- a/rts/Sim/Units/CommandAI/BuilderCAI.h
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.h
@@ -61,6 +61,7 @@ public:
 
 	bool IsInBuildRange(const CWorldObject* obj) const;
 	bool IsInBuildRange(const float3& pos, const float radius) const;
+	float GetBuildRange(const float targetRadius) const;
 
 public:
 	spring::unordered_set<int> buildOptions;
@@ -109,7 +110,6 @@ private:
 
 	int FindReclaimTarget(const float3& pos, float radius, unsigned char cmdopt, ReclaimOption recoptions, float bestStartDist = 1.0e30f) const;
 
-	float GetBuildRange(const float targetRadius) const;
 	bool MoveInBuildRange(const CWorldObject* obj, const bool checkMoveTypeForFailed = false);
 	bool MoveInBuildRange(const float3& pos, float radius, const bool checkMoveTypeForFailed = false);
 


### PR DESCRIPTION
Constructors consider unit radius into build range even before the unit is created. They do this once the unit exists, but they haven't been doing this before the unit exists. This change fixes that. Before, there have been issues with constructors getting too close and then having to back off so that they can start building a unit.

The unit radius is declared in the unit's model data.