### PR TITLE
LuaVAO Instanced Models

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -54,6 +54,8 @@ Lua:
    and run in the order they were added, just before that frame's GameFrame call-in.
  - add a new 4th boolean parameter to `VFS.DirList` and `VFS.SubDirs`, controls whether to also return
    matches in subdirs, recursively.
+ - add Bin calls to gl vao: `UpdateUnitBins`,`UpdateFeatureBins`,`SubmitBins`. Performs fully instanced
+   drawing of models.
  
 
 Game Setup:

--- a/rts/Lua/LuaVAO.cpp
+++ b/rts/Lua/LuaVAO.cpp
@@ -56,7 +56,10 @@ bool LuaVAOs::PushEntries(lua_State* L)
 
 		"UpdateUnitBins", &LuaVAOImpl::UpdateUnitBins,
 		"UpdateFeatureBins", &LuaVAOImpl::UpdateFeatureBins,
-		"SubmitBins", &LuaVAOImpl::SubmitBins
+		"SubmitBins", sol::overload(
+			sol::resolve<void()>(&LuaVAOImpl::SubmitBins),
+			sol::resolve<void(const sol::function)>(&LuaVAOImpl::SubmitBins)
+		)
 	);
 
 	gl.set("VAO", sol::lua_nil); // don't want this to be accessible directly without gl.GetVAO

--- a/rts/Lua/LuaVAO.cpp
+++ b/rts/Lua/LuaVAO.cpp
@@ -52,7 +52,11 @@ bool LuaVAOs::PushEntries(lua_State* L)
 			sol::resolve<int(const sol::stack_table&)>(&LuaVAOImpl::AddFeatureDefsToSubmission)
 		),
 		"RemoveFromSubmission", & LuaVAOImpl::RemoveFromSubmission,
-		"Submit", &LuaVAOImpl::Submit
+		"Submit", &LuaVAOImpl::Submit,
+
+		"ModifyUnitBins", &LuaVAOImpl::ModifyUnitBins,
+		"ModifyFeatureBins", &LuaVAOImpl::ModifyFeatureBins,
+		"SubmitBins", &LuaVAOImpl::SubmitBins
 	);
 
 	gl.set("VAO", sol::lua_nil); // don't want this to be accessible directly without gl.GetVAO

--- a/rts/Lua/LuaVAO.cpp
+++ b/rts/Lua/LuaVAO.cpp
@@ -54,8 +54,8 @@ bool LuaVAOs::PushEntries(lua_State* L)
 		"RemoveFromSubmission", & LuaVAOImpl::RemoveFromSubmission,
 		"Submit", &LuaVAOImpl::Submit,
 
-		"ModifyUnitBins", &LuaVAOImpl::ModifyUnitBins,
-		"ModifyFeatureBins", &LuaVAOImpl::ModifyFeatureBins,
+		"UpdateUnitBins", &LuaVAOImpl::UpdateUnitBins,
+		"UpdateFeatureBins", &LuaVAOImpl::UpdateFeatureBins,
 		"SubmitBins", &LuaVAOImpl::SubmitBins
 	);
 

--- a/rts/Lua/LuaVAOImpl.cpp
+++ b/rts/Lua/LuaVAOImpl.cpp
@@ -95,6 +95,8 @@ void LuaVAOImpl::AttachBufferImpl(const std::shared_ptr<LuaVBOImpl>& luaVBO, std
 
 void LuaVAOImpl::EnsureBinsInit()
 {
+	assert(instLuaVBO->GetAttributeCount() == 1);
+
 	if (!bins) bins = std::make_unique<Bins>(submitCmds);
 }
 
@@ -578,9 +580,9 @@ void LuaVAOImpl::Bins::UpdateImpl(const sol::stack_table& removedObjects, const 
 		#define UnorderedErase(vector, index) \
 			(vector)[index] = (vector).back(); \
 			(vector).pop_back()
-		#define UnorderedMapSubstitute(map, subsitutedKey, substitutionKey, val) \
+		#define UnorderedMapSubstitute(map, substitutedKey, substitutionKey, val) \
 			(map)[substitutionKey] = val; \
-			(map).erase(subsitutedKey)
+			(map).erase(substitutedKey)
 
 		if (bin.objIds.size() == 1) {
 			UnorderedMapSubstitute(modelIdToBinIndex, modelId, bins.back().modelId, binIndex);
@@ -631,7 +633,7 @@ void LuaVAOImpl::Bins::UpdateImpl(const sol::stack_table& removedObjects, const 
 
 		objIdToLocalInstance[objId] = bin.objIds.size();
 		bin.objIds.emplace_back(objId);
-		bin.instanceData.emplace_back(GetObjectInstanceData(obj, obj->team, obj->drawFlag));
+		bin.instanceData.emplace_back(GetObjectInstanceData(obj));
 		++submitCmds[binIndex].instanceCount;
 
 		assert(bin.instanceData.back());

--- a/rts/Lua/LuaVAOImpl.cpp
+++ b/rts/Lua/LuaVAOImpl.cpp
@@ -702,7 +702,7 @@ void LuaVAOImpl::SubmitBins()
 
 		instVBO->Bind();
 		const size_t firstChangedInstance = bins->firstChangedInstance;
-		instVBO->SetBufferSubData(bins->instanceData, firstChangedInstance, firstChangedInstance);
+		instVBO->SetBufferSubData(firstChangedInstance*sizeof(SInstanceData), (bins->instanceData.size() -firstChangedInstance)*sizeof(SInstanceData), &bins->instanceData[firstChangedInstance]);
 		instVBO->Unbind();
 
 		bins->requireInstanceDataUpload = false;

--- a/rts/Lua/LuaVAOImpl.h
+++ b/rts/Lua/LuaVAOImpl.h
@@ -55,6 +55,7 @@ public:
 	void UpdateUnitBins(const sol::stack_table& removedUnits, const sol::stack_table& addedUnits, sol::optional<size_t> removedCount, sol::optional<size_t> addedCount);
 	void UpdateFeatureBins(const sol::stack_table& removedFeatures, const sol::stack_table& addedFeatures, sol::optional<size_t> removedCount, sol::optional<size_t> addedCount);
 	void SubmitBins();
+	void SubmitBins(const sol::function binPrepFunc);
 private:
 	template<typename T>
 	struct DrawCheckType {
@@ -92,6 +93,8 @@ private:
 	static const SIndexAndCount GetDrawIndicesImpl(int id);
 	template <typename TObj>
 	static const SIndexAndCount GetDrawIndicesImpl(const TObj* obj);
+
+	void UpdateBinsGPU();
 private:
 	std::unique_ptr<VAO> vao = nullptr;
 

--- a/rts/Lua/LuaVAOImpl.h
+++ b/rts/Lua/LuaVAOImpl.h
@@ -52,8 +52,8 @@ public:
 	void RemoveFromSubmission(int idx);
 	void Submit();
 
-	void ModifyUnitBins(const sol::stack_table& removedUnits, const sol::stack_table& addedUnits, sol::optional<size_t> removedCount, sol::optional<size_t> addedCount);
-	void ModifyFeatureBins(const sol::stack_table& removedFeatures, const sol::stack_table& addedFeatures, sol::optional<size_t> removedCount, sol::optional<size_t> addedCount);
+	void UpdateUnitBins(const sol::stack_table& removedUnits, const sol::stack_table& addedUnits, sol::optional<size_t> removedCount, sol::optional<size_t> addedCount);
+	void UpdateFeatureBins(const sol::stack_table& removedFeatures, const sol::stack_table& addedFeatures, sol::optional<size_t> removedCount, sol::optional<size_t> addedCount);
 	void SubmitBins();
 private:
 	template<typename T>
@@ -132,7 +132,7 @@ public:
 	std::vector<SDrawElementsIndirectCommand>& submitCmds;
 
 	template <typename TObj>
-	void ModifyImpl(const sol::stack_table& removedObjects, const sol::stack_table& addedObjects, sol::optional<size_t> removedCount, sol::optional<size_t> addedCount);
+	void UpdateImpl(const sol::stack_table& removedObjects, const sol::stack_table& addedObjects, sol::optional<size_t> removedCount, sol::optional<size_t> addedCount);
 };
 
 #endif //LUA_VAO_IMPL_H

--- a/rts/Lua/LuaVAOImpl.h
+++ b/rts/Lua/LuaVAOImpl.h
@@ -87,8 +87,6 @@ private:
 	template <typename TObj>
 	int AddObjectsToSubmissionImpl(const sol::stack_table& ids);
 	template <typename TObj>
-	void RemoveObjectFromBinImpl(int id);
-	template <typename TObj>
 	SDrawElementsIndirectCommand DrawObjectGetCmdImpl(int id);
 	template <typename TObj>
 	static const SIndexAndCount GetDrawIndicesImpl(int id);
@@ -113,6 +111,9 @@ private:
 
 class LuaVAOImpl::Bins {
 public:
+	inline Bins(std::vector<SDrawElementsIndirectCommand>& submitCmds_)
+	:	submitCmds(submitCmds_) {}
+
 	struct Bin {
 		inline Bin(int modelId) : modelId(modelId) {}
 
@@ -128,11 +129,10 @@ public:
 	std::vector<SInstanceData> instanceData;
 	bool requireInstanceDataUpload = false;
 	size_t firstChangedInstance;
+	std::vector<SDrawElementsIndirectCommand>& submitCmds;
 
 	template <typename TObj>
-	void ModifyImpl(const sol::stack_table& removedObjects, const sol::stack_table& addedObjects,
-		sol::optional<size_t> removedCount, sol::optional<size_t> addedCount,
-		std::vector<SDrawElementsIndirectCommand>& submitCmds);
+	void ModifyImpl(const sol::stack_table& removedObjects, const sol::stack_table& addedObjects, sol::optional<size_t> removedCount, sol::optional<size_t> addedCount);
 };
 
 #endif //LUA_VAO_IMPL_H

--- a/rts/Lua/LuaVBOImpl.h
+++ b/rts/Lua/LuaVBOImpl.h
@@ -55,7 +55,8 @@ public:
 public:
 	static bool Supported(GLenum target);
 
-	VBO* GetVBO() const { return vbo; }
+	inline VBO* GetVBO() const { return vbo; }
+	inline size_t GetAttributeCount() const { return (size_t)attributesCount; }
 private:
 	void AllocGLBuffer(size_t byteSize);
 	void CopyAttrMapToVec();

--- a/rts/Lua/LuaVBOImpl.h
+++ b/rts/Lua/LuaVBOImpl.h
@@ -54,6 +54,8 @@ public:
 	void DumpDefinition();
 public:
 	static bool Supported(GLenum target);
+
+	VBO* GetVBO() const { return vbo; }
 private:
 	void AllocGLBuffer(size_t byteSize);
 	void CopyAttrMapToVec();

--- a/rts/Rendering/GL/VBO.h
+++ b/rts/Rendering/GL/VBO.h
@@ -81,7 +81,7 @@ public:
 	// uploads vector of data from dataOffset to size() - 1 at elemOffset
 	template<typename TData>
 	void SetBufferSubData(const std::vector<TData>& data, GLintptr elemOffset = 0, size_t dataOffset = 0) {
-		SetBufferSubData(sizeof(TData) * elemOffset, sizeof(TData) * data.size(), data.data() +sizeof(TData)*dataOffset);
+		SetBufferSubData(sizeof(TData) * elemOffset, sizeof(TData) * (data.size() - dataOffset), data.data() +sizeof(TData)*dataOffset);
 	}
 	void SetBufferSubData(GLintptr offset, GLsizeiptr size, const void* data);
 

--- a/rts/Rendering/GL/VBO.h
+++ b/rts/Rendering/GL/VBO.h
@@ -80,9 +80,7 @@ public:
 
 	// uploads vector of data from dataOffset to size() - 1 at elemOffset
 	template<typename TData>
-	void SetBufferSubData(const std::vector<TData>& data, GLintptr elemOffset = 0, size_t dataOffset = 0) {
-		SetBufferSubData(sizeof(TData) * elemOffset, sizeof(TData) * (data.size() - dataOffset), data.data() +sizeof(TData)*dataOffset);
-	}
+	void SetBufferSubData(const std::vector<TData>& data, GLintptr elemOffset = 0) { SetBufferSubData(sizeof(TData) * elemOffset, sizeof(TData) * data.size(), data.data()); }
 	void SetBufferSubData(GLintptr offset, GLsizeiptr size, const void* data);
 
 	GLuint GetId() const {

--- a/rts/Rendering/GL/VBO.h
+++ b/rts/Rendering/GL/VBO.h
@@ -78,9 +78,11 @@ public:
 		Unbind();
 	}
 
-	// uploads vector of data from 0 to size() - 1 at elemOffset
+	// uploads vector of data from dataOffset to size() - 1 at elemOffset
 	template<typename TData>
-	void SetBufferSubData(const std::vector<TData>& data, GLintptr elemOffset = 0) { SetBufferSubData(sizeof(TData) * elemOffset, sizeof(TData) * data.size(), data.data()); }
+	void SetBufferSubData(const std::vector<TData>& data, GLintptr elemOffset = 0, size_t dataOffset = 0) {
+		SetBufferSubData(sizeof(TData) * elemOffset, sizeof(TData) * data.size(), data.data() +sizeof(TData)*dataOffset);
+	}
 	void SetBufferSubData(GLintptr offset, GLsizeiptr size, const void* data);
 
 	GLuint GetId() const {

--- a/rts/Rendering/GL/glHelpers.h
+++ b/rts/Rendering/GL/glHelpers.h
@@ -6,6 +6,10 @@
 #include "Rendering/Textures/TextureFormat.h"
 #include <algorithm>
 #include <tuple>
+// temp loc?
+#include "Rendering/Models/3DModel.h"
+#include "Rendering/ModelsDataUploader.h"
+#include <type_traits>
 
 
 // Get gl parameter values into a homogenous GL-typed variable (single or array)
@@ -91,4 +95,27 @@ inline void glSetAny(AttribValuesTupleType newValues)
 	{
 		(std::get<0>(newValues) == GL_TRUE? glEnable : glDisable)(GLParamName...);
 	}
+}
+
+
+// temp loc?
+template<class TObj>
+inline SInstanceData GetObjectInstanceData(const TObj* obj, uint8_t teamID, uint8_t drawFlags)
+{
+	uint8_t numPieces;
+	uint32_t bposeIndex;
+	if constexpr(std::is_same_v<TObj, S3DModel>) {
+		numPieces = static_cast<uint8_t>(obj->numPieces);
+		bposeIndex = static_cast<uint32_t>(matrixUploader.GetElemOffset(obj));
+	} else {
+		numPieces = static_cast<uint8_t>(obj->model->numPieces);
+		bposeIndex = static_cast<uint32_t>(matrixUploader.GetElemOffset(obj->model));
+	}
+	return SInstanceData(
+		static_cast<uint32_t>(matrixUploader.GetElemOffset(obj)),
+		teamID,
+		drawFlags,
+		numPieces,
+		static_cast<uint32_t>(modelsUniformsStorage.GetObjOffset(obj)),
+		bposeIndex);
 }

--- a/rts/Rendering/GL/glHelpers.h
+++ b/rts/Rendering/GL/glHelpers.h
@@ -119,3 +119,12 @@ inline SInstanceData GetObjectInstanceData(const TObj* obj, uint8_t teamID, uint
 		static_cast<uint32_t>(modelsUniformsStorage.GetObjOffset(obj)),
 		bposeIndex);
 }
+template<class TObj>
+inline SInstanceData GetObjectInstanceData(const TObj* obj)
+{
+	if constexpr(std::is_same_v<TObj, S3DModel>) {
+		return GetObjectInstanceData<TObj>(obj, 0, 0);
+	} else {
+		return GetObjectInstanceData<TObj>(obj, obj->team, obj->drawFlag);
+	}
+}

--- a/rts/Rendering/GL/myGL.h
+++ b/rts/Rendering/GL/myGL.h
@@ -24,6 +24,7 @@
 #include "System/float4.h"
 #include "System/type2.h"
 #include "System/UnorderedMap.hpp"
+#include "Rendering/Models/ModelsMemStorage.h"
 
 #include "glStateDebug.h"
 
@@ -165,6 +166,13 @@ struct SInstanceData {
 		, info{ teamIndex, drawFlags, 0, numPieces }	// not updated during the following draw frames
 		, bposeMatOffset { bposeMatOffset_ }			// updated during the following draw frames
 	{}
+
+	// validity check
+	inline operator bool() const {
+		return matOffset != MatricesMemStorage::INVALID_INDEX
+			&& bposeMatOffset != MatricesMemStorage::INVALID_INDEX;
+		// no uniOffset check because defs and models don't have it
+	}
 
 	uint32_t matOffset;
 	uint32_t uniOffset;


### PR DESCRIPTION
+vao:ModifyUnitBins
+vao:ModifyFeatureBins
+vao:SubmitBins

Bins are placed in a vector instead of using map directly, it should have some advantages (For one, vector is transparent)

As of now it is simplified: only InstanceData, no other instance attributes. I will be expanding it to work with arbitrary instance data a bit later.

W.I.P.