### PR TITLE
github: update docker-build scripts

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -77,23 +77,24 @@ jobs:
           echo "Build info:"
           echo "Git commit hash: ${{ github.sha }}"
           echo "Repository: ${{ github.repository }}"
+          df -h
         shell: bash
         
       - name: Checkout Source Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get Random Number
         id: get-random-number
         run: |
           number=$(head /dev/random -c 32 | sha1sum | awk '{ print $1 }')
           echo "Generated random number: $number"
-          echo "::set-output name=number::$number"
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Download ccache Data
         if: github.event.inputs.use-caches == 'true'
         id: cache-dl
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/ccache_archive
           key: ccache-${{ matrix.config.os }}-${{ steps.get-random-number.outputs.number }}
@@ -104,7 +105,7 @@ jobs:
         id: cache
         run: |
           CACHE_FILENAME="/tmp/ccache_archive/${{ matrix.config.os }}.tgz"
-          echo "::set-output name=cache-filename::${CACHE_FILENAME}"
+          echo "cache-filename=${CACHE_FILENAME}" >> "$GITHUB_OUTPUT"
 
           if [ -f "${CACHE_FILENAME}" ]; then
             echo "Found build ccache: ${CACHE_FILENAME}"
@@ -112,15 +113,16 @@ jobs:
               echo "Deleting ccache: ${CACHE_FILENAME}"
               rm -rf "${CACHE_FILENAME}"
             else
-              echo "::set-output name=cache-hit::true"
+              echo "cache-hit=true" >> "$GITHUB_OUTPUT"
               echo "Extracting..."
               mkdir -p /tmp/ccache
               tar -I pigz -xf "${CACHE_FILENAME}" -C /tmp/ccache
             fi
           else
             echo "Not found ccache data"
-            echo "::set-output name=cache-hit::false"
+            echo "cache-hit=false" >> "$GITHUB_OUTPUT"
           fi
+          df -h
         shell: bash
 
       - name: Build engine via docker
@@ -140,23 +142,26 @@ jobs:
           docker-image: "${{ github.event.inputs.docker-image }}"
 
       - name: Upload Bin as Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.run-docker-build.outputs.bin_name }}
           path: ${{ github.workspace }}/artifacts/${{ steps.run-docker-build.outputs.bin_name }}
+          if-no-files-found: error
 
       - name: Upload Dbg Artifacts
         if: github.event.inputs.strip-symbols == 'true'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.run-docker-build.outputs.dbg_name }}
           path: ${{ github.workspace }}/artifacts/${{ steps.run-docker-build.outputs.dbg_name }}
+          if-no-files-found: error
       
       - name: Upload Build Options Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: buildoptions_${{ matrix.config.os }}.txt
           path: ${{ github.workspace }}/artifacts/buildoptions_${{ matrix.config.os }}.txt
+          if-no-files-found: error
 
       - name: Pack ccache Data
         if: github.event.inputs.use-caches == 'true'
@@ -170,8 +175,22 @@ jobs:
           echo "Archived ccache size: $(du -h "${CACHE_FILENAME}" | cut -f1)"
 
       - name: Upload ccache Debug Data
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: github.event.inputs.debug-ccache == 'true'
         with:
           name: ccache_debug_${{ matrix.config.os }}.tgz
           path: ${{ github.workspace }}/artifacts/${{ steps.run-docker-build.outputs.ccache_dbg }}
+          if-no-files-found: error
+
+      - name: Free Filesystem Space
+        id: freefsspace
+        run: |
+          echo "Filesystem before cleanup:"
+          df -h
+          docker system df
+          echo "Pruning docker images..."
+          docker image prune -a -f
+          echo "Filesystem after cleanup:"
+          df -h
+          docker system df
+        shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,9 @@ jobs:
           if [ "${{ github.event.inputs.release-tag }}" == "" ]; then
             filename=$(ls | grep spring | head -n 1)
             release_tag=$(echo $filename | cut -d'_' -f1,2,3)
-            echo "::set-output name=release_tag::$release_tag"
+            echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
           else
-            echo "::set-output name=release_tag::${{ github.event.inputs.release-tag }}"
+            echo "release_tag=${{ github.event.inputs.release-tag }}" >> "$GITHUB_OUTPUT"
           fi
         shell: bash
 

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -77,13 +77,13 @@ runs:
           RANDOMNUMB=$(head /dev/random -c 32 | sha1sum | awk '{ print $1 }')
           CACHEKEY+="-${RANDOMNUMB}"
         fi
-        echo "::set-output name=cachekey::$CACHEKEY"
+        echo "cachekey=$CACHEKEY" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Download Cache Data
       if: inputs.use-cache == 'true' && inputs.docker-image == '*'
       id: cache-dl-docker
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/docker
         key: ${{ steps.get-prim-cache-key.outputs.cachekey }}
@@ -116,7 +116,7 @@ runs:
     - name: Run Docker Build
       run: |
         # Docker args
-        ARGS=(run -v /tmp/ccache:/ccache -v "${{ github.workspace }}/artifacts:/publish")
+        ARGS=(run --name recoilbuilder -v /tmp/ccache:/ccache -v "${{ github.workspace }}/artifacts:/publish")
 
         if [ "${{ inputs.debug-ccache }}" == "true" ]; then
           ARGS+=(-v "${{ github.workspace }}/ccache_dbg:/ccache_dbg" )
@@ -154,6 +154,9 @@ runs:
           echo "tmate debugging enabled. Skipping docker run command. Connect via SSH now..."
         else
           docker "${ARGS[@]}"
+
+          echo "bin_name=$(docker cp recoilbuilder:/output-data/bin_name - | tar -xO)" >> "$GITHUB_OUTPUT"
+          echo "dbg_name=$(docker cp recoilbuilder:/output-data/dbg_name - | tar -xO)" >> "$GITHUB_OUTPUT"
         fi
       shell: bash
       id: docker-run

--- a/docker-build/scripts/07_pack_build_artifacts.sh
+++ b/docker-build/scripts/07_pack_build_artifacts.sh
@@ -6,6 +6,8 @@ bin_name=spring_bar_$tag_name-minimal-portable.7z
 dbg_name=spring_bar_$tag_name-minimal-symbols.tgz
 ccache_dbg_name=ccache_dbg.tgz
 
+mkdir -p /output-data
+
 cd "${INSTALL_DIR}"
 
 # Compute md5 hashes of all files in archive. We additionally gzip it as gzip adds
@@ -15,7 +17,7 @@ find . -type f ! -name '*.dbg' ! -name files.md5.gz -exec md5sum {} \; | gzip > 
 rm -f ../$bin_name
 7z a -t7z -m0=lzma -mx=9 -mfb=64 -md=32m -ms=on ../$bin_name ./* -xr\!*.dbg
 # export github output variables
-echo "::set-output name=bin_name::${bin_name}"
+echo ${bin_name} > /output-data/bin_name
 
 
 if [ "${STRIP_SYMBOLS}" == "1" ]; then
@@ -23,14 +25,15 @@ if [ "${STRIP_SYMBOLS}" == "1" ]; then
     # touch empty.dbg - was is it good for??
     DEBUGFILES=$(find ./ -name '*.dbg')
     tar cvfz $dbg_name ${DEBUGFILES}
-    echo "::set-output name=dbg_name::${dbg_name}"
+    echo ${dbg_name} > /output-data/dbg_name
 fi
 
 if [ -d /ccache_dbg ]; then
     echo "Packing ccache debug data..."
 
-    echo "::set-output name=ccache_dbg::${ccache_dbg_name}"
+    echo ${ccache_dbg_name} > /output-data/ccache_dbg_name
     tar cvfz "${PUBLISH_DIR}/${ccache_dbg_name}" -C /ccache_dbg /ccache_dbg > /dev/null 2>&1
 else
+    touch /output-data/ccache_dbg
     echo "No ccache debug data, so skipping packing it..."
 fi

--- a/docker-build/scripts/build.sh
+++ b/docker-build/scripts/build.sh
@@ -11,8 +11,8 @@ if [ "${DUMMY}" == "1" ]; then
 
     touch "${PUBLISH_DIR}/${bin_name}"
     touch "${PUBLISH_DIR}/${dbg_name}"
-    echo "::set-output name=bin_name::${bin_name}"
-    echo "::set-output name=dbg_name::${dbg_name}"
+    echo "bin_name=${bin_name}" >> "$GITHUB_OUTPUT"
+    echo "dbg_name=${dbg_name}" >> "$GITHUB_OUTPUT"
 
     echo "*** Finished"
 


### PR DESCRIPTION
* migrate deprecated set-output command to env variable: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* update deprecated github actions versions
* add step to cleanup filesystem by deleting docker image to free up space for post steps