### PR TITLE
consistently use `TeamHandler` for `AllyTeam` data

### DIFF
--- a/rts/Game/UI/StartPosSelecter.cpp
+++ b/rts/Game/UI/StartPosSelecter.cpp
@@ -101,8 +101,7 @@ void CStartPosSelecter::DrawStartBox(GL::RenderDataBufferC* buffer, Shader::IPro
 {
 	glAttribStatePtr->EnableDepthTest();
 
-	const std::vector<AllyTeam>& allyStartData = CGameSetup::GetAllyStartingData();
-	const AllyTeam& myStartData = allyStartData[gu->myAllyTeam];
+	const AllyTeam& myStartData = teamHandler.GetAllyTeam(gu->myAllyTeam);
 
 	const float by = myStartData.startRectTop * mapDims.mapy * SQUARE_SIZE;
 	const float bx = myStartData.startRectLeft * mapDims.mapx * SQUARE_SIZE;

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -1462,16 +1462,16 @@ int LuaSyncedRead::GetGaiaTeamID(lua_State* L)
  */
 int LuaSyncedRead::GetAllyTeamStartBox(lua_State* L)
 {
-	const std::vector<AllyTeam>& allyData = CGameSetup::GetAllyStartingData();
-	const unsigned int allyTeam = luaL_checkint(L, 1);
+	const unsigned int allyTeamID = luaL_checkint(L, 1);
 
-	if (allyTeam >= allyData.size())
+	if (!teamHandler.IsValidAllyTeam(allyTeamID))
 		return 0;
 
-	const float xmin = (mapDims.mapx * SQUARE_SIZE) * allyData[allyTeam].startRectLeft;
-	const float zmin = (mapDims.mapy * SQUARE_SIZE) * allyData[allyTeam].startRectTop;
-	const float xmax = (mapDims.mapx * SQUARE_SIZE) * allyData[allyTeam].startRectRight;
-	const float zmax = (mapDims.mapy * SQUARE_SIZE) * allyData[allyTeam].startRectBottom;
+	const AllyTeam& allyTeam = teamHandler.GetAllyTeam(allyTeamID);
+	const float xmin = (mapDims.mapx * SQUARE_SIZE) * allyTeam.startRectLeft;
+	const float zmin = (mapDims.mapy * SQUARE_SIZE) * allyTeam.startRectTop;
+	const float xmax = (mapDims.mapx * SQUARE_SIZE) * allyTeam.startRectRight;
+	const float zmax = (mapDims.mapy * SQUARE_SIZE) * allyTeam.startRectBottom;
 
 	lua_pushnumber(L, xmin);
 	lua_pushnumber(L, zmin);

--- a/rts/Sim/Misc/Team.cpp
+++ b/rts/Sim/Misc/Team.cpp
@@ -78,12 +78,10 @@ CTeam::CTeam():
 void CTeam::SetDefaultStartPos()
 {
 	const int allyTeam = teamHandler.AllyTeam(teamNum);
-	const std::vector<AllyTeam>& allyStartData = CGameSetup::GetAllyStartingData();
 
-	assert(!allyStartData.empty());
 	assert(allyTeam == teamAllyteam);
 
-	const AllyTeam& allyTeamData = allyStartData[allyTeam];
+	const AllyTeam& allyTeamData = teamHandler.GetAllyTeam(allyTeam);
 	// pick a spot near the center of our startbox
 	const float xmin = (mapDims.mapx * SQUARE_SIZE) * allyTeamData.startRectLeft;
 	const float zmin = (mapDims.mapy * SQUARE_SIZE) * allyTeamData.startRectTop;
@@ -102,8 +100,7 @@ void CTeam::SetDefaultStartPos()
 void CTeam::ClampStartPosInStartBox(float3* pos) const
 {
 	const int allyTeam = teamHandler.AllyTeam(teamNum);
-	const std::vector<AllyTeam>& allyStartData = CGameSetup::GetAllyStartingData();
-	const AllyTeam& allyTeamData = allyStartData[allyTeam];
+	const AllyTeam& allyTeamData = teamHandler.GetAllyTeam(allyTeam);
 	const SRectangle rect(
 		allyTeamData.startRectLeft   * mapDims.mapx * SQUARE_SIZE,
 		allyTeamData.startRectTop    * mapDims.mapy * SQUARE_SIZE,


### PR DESCRIPTION
`AllyTeam` data is first loaded in `CGameSetup` from the start script, and is later passed down to `TeamHandler` from `CGameSetup`.

Since `TeamHandler` is responsible for storing dynamic information during the game, whereas `CGameSetup` only stores the initial data as loaded from the start script, we remove all calls to `CGameSetup::GetAllyStartingData` in favor of information coming from `TeamHandler` to ensure that we consistently retrieve up-to-date data.