### PR TITLE
Workaround for SDL audio bug with some soundcards

### DIFF
--- a/rts/System/Sound/OpenAL/Sound.cpp
+++ b/rts/System/Sound/OpenAL/Sound.cpp
@@ -515,11 +515,11 @@ void CSound::OpenLoopbackDevice(const std::string& deviceName)
 	 *
 	 * Note that proper support for 3D surround sounds sounds hard, for example as of 2023 counter-strike has very weak support
 	 * for it, apparently noticeably worse than just stereo according to players, despite being in a more relevant genre. */
+	selectedDeviceName = "";
 	for (int channelsDesired : {2, 1}) {
 		desiredSpec.channels = channelsDesired;
 
 		sdlDeviceID = 0;
-		selectedDeviceName = "";
 
 		if (!deviceName.empty()) {
 			LOG("[Sound::%s] opening configured device \"%s\"", __func__, deviceName.c_str());

--- a/rts/System/Sound/OpenAL/Sound.cpp
+++ b/rts/System/Sound/OpenAL/Sound.cpp
@@ -507,7 +507,14 @@ void CSound::OpenLoopbackDevice(const std::string& deviceName)
 	desiredSpec.samples = 4096;
 	desiredSpec.callback = RenderSDLSamples;
 	desiredSpec.userdata = this;
-
+	
+	/* SDL bug: can return devices with >2 channels (3D surround), even if we ask for just 2.
+ 	* (if tested) This causes the 2 "primary" channels to be moved in the 3D space compared to their "normal" state.
+ 	* (if not tested) We are afraid that this risks the 2 "primary" channels to be moved in the 3D space compared to their "normal" state, but this remains to be tested.
+ 	* For this reason, the engine rejects such devices down the road. Don't let it get that far and retry instead.
+ 	*
+ 	* Note that proper support for 3D surround sounds sounds hard, for example as of 2023 counter-strike has very weak support
+ 	* for it, apparently noticeably worse than just stereo according to players, despite being in a more relevant genre. */
 	for(int channelsDesired = 2; channelsDesired > 0; channelsDesired--) {
 		desiredSpec.channels = channelsDesired;
 

--- a/rts/System/Sound/OpenAL/Sound.cpp
+++ b/rts/System/Sound/OpenAL/Sound.cpp
@@ -515,7 +515,7 @@ void CSound::OpenLoopbackDevice(const std::string& deviceName)
 	 *
 	 * Note that proper support for 3D surround sounds sounds hard, for example as of 2023 counter-strike has very weak support
 	 * for it, apparently noticeably worse than just stereo according to players, despite being in a more relevant genre. */
-	for (int channelDesired : {2, 1}) {
+	for (int channelsDesired : {2, 1}) {
 		desiredSpec.channels = channelsDesired;
 
 		sdlDeviceID = 0;

--- a/rts/System/Sound/OpenAL/Sound.cpp
+++ b/rts/System/Sound/OpenAL/Sound.cpp
@@ -511,6 +511,7 @@ void CSound::OpenLoopbackDevice(const std::string& deviceName)
 
 	sdlDeviceID = 0;
 
+	// 1.attempt - ask for desiredSpec.channels=2 and allow channel changes. We are happy, when we receive 1 or 2 channels.
 	if (!deviceName.empty()) {
 		LOG("[Sound::%s] opening configured device \"%s\"", __func__, deviceName.c_str());
 		sdlDeviceID = SDL_OpenAudioDevice(deviceName.c_str(), 0, &desiredSpec, &obtainedSpec, SDL_AUDIO_ALLOW_ANY_CHANGE);
@@ -527,6 +528,35 @@ void CSound::OpenLoopbackDevice(const std::string& deviceName)
 		LOG("[Sound::%s] failed to open SDL audio, error:  \"%s\"", __func__, SDL_GetError());
 		SDL_QuitSubSystem(SDL_INIT_AUDIO);
 		return;
+	}
+
+	// 2.attempt: Workaround for SDL bug with some soundcards, returning more channels than we asked for (returned 8 in test case)
+	// (Maybe a third attempt should be taken into consideration: Disallow Channel Changes and ask for 1 channel only)
+	if (obtainedSpec.channels > 2) {
+		LOG("[Sound::%s] SDL returned %d channels, when we asked for %d. Closing previously opened device.", __func__, obtainedSpec.channels, desiredSpec.channels);
+		SDL_CloseAudioDevice(sdlDeviceID);
+		selectedDeviceName = "";
+		sdlDeviceID = 0;
+
+		if (!deviceName.empty()) {
+			LOG("[Sound::%s] opening configured device \"%s\" and disallow channel changes", __func__, deviceName.c_str());
+			sdlDeviceID = SDL_OpenAudioDevice(deviceName.c_str(), 0, &desiredSpec, &obtainedSpec, SDL_AUDIO_ALLOW_ANY_CHANGE & ~SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
+			selectedDeviceName = deviceName;
+		}
+
+		if (sdlDeviceID == 0) {
+			LOG("[Sound::%s] opening default device and disallow channel changes", __func__);
+			sdlDeviceID = SDL_OpenAudioDevice(nullptr, 0, &desiredSpec, &obtainedSpec, SDL_AUDIO_ALLOW_ANY_CHANGE & ~SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
+			selectedDeviceName = "default";
+		}
+
+		if (sdlDeviceID == 0) {
+			LOG("[Sound::%s] failed to open SDL audio, error:  \"%s\"", __func__, SDL_GetError());
+			SDL_QuitSubSystem(SDL_INIT_AUDIO);
+			return;
+		}
+
+		LOG("[Sound::%s] opened device \"%s\" with %d channels.", __func__, selectedDeviceName.c_str(), obtainedSpec.channels);
 	}
 
 	// needs to be at least 1 or the callback will divide by 0

--- a/rts/System/Sound/OpenAL/Sound.cpp
+++ b/rts/System/Sound/OpenAL/Sound.cpp
@@ -493,10 +493,10 @@ void CSound::OpenLoopbackDevice(const std::string& deviceName)
 		return;
 	}
 
-    LOG("[Sound::%s] SDL audio device(s): ", __func__);
-    for (int i = 0, n = SDL_GetNumAudioDevices(0); i < n; ++i) {
-        LOG("[Sound::%s]  * \"%d\" \"%s\"", __func__, i, SDL_GetAudioDeviceName(i, 0));
-    }
+	LOG("[Sound::%s] SDL audio device(s): ", __func__);
+	for (int i = 0, n = SDL_GetNumAudioDevices(0); i < n; ++i) {
+		LOG("[Sound::%s]  * \"%d\" \"%s\"", __func__, i, SDL_GetAudioDeviceName(i, 0));
+	}
 
 	SDL_AudioSpec desiredSpec;
 	SDL_AudioSpec obtainedSpec;
@@ -539,7 +539,6 @@ void CSound::OpenLoopbackDevice(const std::string& deviceName)
 		LOG("[Sound::%s] SDL returned %d channels, when we asked for %d. Closing previously opened device.", __func__, obtainedSpec.channels, desiredSpec.channels);
 		SDL_CloseAudioDevice(sdlDeviceID);
 	}
-
 
 	// needs to be at least 1 or the callback will divide by 0
 	if ((frameSize = obtainedSpec.channels * SDL_AUDIO_BITSIZE(obtainedSpec.format) / 8) <= 0) {

--- a/rts/System/Sound/OpenAL/Sound.cpp
+++ b/rts/System/Sound/OpenAL/Sound.cpp
@@ -509,13 +509,13 @@ void CSound::OpenLoopbackDevice(const std::string& deviceName)
 	desiredSpec.userdata = this;
 	
 	/* SDL bug: can return devices with >2 channels (3D surround), even if we ask for just 2.
- 	* This causes the 2 "primary" channels to be moved in the 3D space compared to their "normal" state and directional sound is not working anymore.
-  	* Though loudness changes on distance change still work.
- 	* For this reason, the engine rejects such devices down the road. Don't let it get that far and retry instead.
- 	*
- 	* Note that proper support for 3D surround sounds sounds hard, for example as of 2023 counter-strike has very weak support
- 	* for it, apparently noticeably worse than just stereo according to players, despite being in a more relevant genre. */
-	for(int channelDesired : {2, 1}) {
+	 * This causes the 2 "primary" channels to be moved in the 3D space compared to their "normal" state
+	 * and directional sound doesn't work anymore (though volume change with distance still does).
+	 * For this reason, the engine rejects such devices down the road. Don't let it get that far and retry instead.
+	 *
+	 * Note that proper support for 3D surround sounds sounds hard, for example as of 2023 counter-strike has very weak support
+	 * for it, apparently noticeably worse than just stereo according to players, despite being in a more relevant genre. */
+	for (int channelDesired : {2, 1}) {
 		desiredSpec.channels = channelsDesired;
 
 		sdlDeviceID = 0;


### PR DESCRIPTION
Workaround for SDL bug with some soundcards, returning more channels than we asked for (returned 8 in test case)

closes wrong initialized SDL audio device and disallows channel changes on 2nd attempt

As a result we don't start our audio device with alternative method. And we initialized successfully with SDL "default" device, which enables us to follow switched audio devices
