### PR TITLE
add `Spring.SetAllyTeamStartBox` synced control

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -56,6 +56,8 @@ Lua:
    matches in subdirs, recursively.
  - `gadget:AllowUnitCreation` now accepts a second return value that controls whether to drop the order.
    If set to false, the builder or factory will keep retrying. Defaults to true (drops order; current behavior).
+ - add `Spring.SetAllyTeamStartBox(allyTeamID, xMin, zMin, xMax, zMax) -> nil`, allowing to set
+   start box (in elmos) for an ally team.
  
 
 Game Setup:

--- a/rts/Game/UI/StartPosSelecter.cpp
+++ b/rts/Game/UI/StartPosSelecter.cpp
@@ -101,8 +101,7 @@ void CStartPosSelecter::DrawStartBox(GL::RenderDataBufferC* buffer, Shader::IPro
 {
 	glAttribStatePtr->EnableDepthTest();
 
-	const std::vector<AllyTeam>& allyStartData = CGameSetup::GetAllyStartingData();
-	const AllyTeam& myStartData = allyStartData[gu->myAllyTeam];
+	const AllyTeam& myStartData = teamHandler.GetAllyTeam(gu->myAllyTeam);
 
 	const float by = myStartData.startRectTop * mapDims.mapy * SQUARE_SIZE;
 	const float bx = myStartData.startRectLeft * mapDims.mapx * SQUARE_SIZE;

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -136,6 +136,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 
 
 	REGISTER_LUA_CFUNC(SetAlly);
+	REGISTER_LUA_CFUNC(SetAllyTeamStartBox);
 	REGISTER_LUA_CFUNC(KillTeam);
 	REGISTER_LUA_CFUNC(AssignPlayerToTeam);
 	REGISTER_LUA_CFUNC(GameOver);
@@ -796,6 +797,38 @@ int LuaSyncedCtrl::SetAlly(lua_State* L)
 		return 0;
 
 	teamHandler.SetAlly(firstAllyTeamID, secondAllyTeamID, luaL_checkboolean(L, 3));
+	return 0;
+}
+
+
+/*** Changes the start box position of an allyTeam.
+ *
+ * @function Spring.SetAllyTeamStartBox
+ * @number allyTeamID
+ * @number xMin left start box boundary (elmos)
+ * @number zMin top start box boundary (elmos)
+ * @number xMax right start box boundary (elmos)
+ * @number zMax bottom start box boundary (elmos)
+ * @treturn nil
+ */
+int LuaSyncedCtrl::SetAllyTeamStartBox(lua_State* L)
+{
+	const unsigned int allyTeamID = luaL_checkint(L, 1);
+	const float xMin = luaL_checkfloat(L, 2);
+	const float zMin = luaL_checkfloat(L, 3);
+	const float xMax = luaL_checkfloat(L, 4);
+	const float zMax = luaL_checkfloat(L, 5);
+
+	if (!teamHandler.IsValidAllyTeam(allyTeamID)) {
+		return 0;
+	}
+
+	const float startRectLeft   = xMin / (mapDims.mapx * SQUARE_SIZE);
+	const float startRectTop    = zMin / (mapDims.mapy * SQUARE_SIZE);
+	const float startRectRight  = xMax / (mapDims.mapx * SQUARE_SIZE);
+	const float startRectBottom = zMax / (mapDims.mapy * SQUARE_SIZE);
+
+	teamHandler.SetAllyTeamStartBox(allyTeamID, startRectLeft, startRectTop, startRectRight, startRectBottom);
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -35,6 +35,7 @@ class LuaSyncedCtrl
 	private:
 		// all LuaHandleSynced
 		static int SetAlly(lua_State* L);
+		static int SetAllyTeamStartBox(lua_State* L);
 		static int KillTeam(lua_State* L);
 		static int AssignPlayerToTeam(lua_State* L);
 		static int GameOver(lua_State* L);

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -1462,16 +1462,16 @@ int LuaSyncedRead::GetGaiaTeamID(lua_State* L)
  */
 int LuaSyncedRead::GetAllyTeamStartBox(lua_State* L)
 {
-	const std::vector<AllyTeam>& allyData = CGameSetup::GetAllyStartingData();
-	const unsigned int allyTeam = luaL_checkint(L, 1);
+	const unsigned int allyTeamID = luaL_checkint(L, 1);
 
-	if (allyTeam >= allyData.size())
+	if (!teamHandler.IsValidAllyTeam(allyTeamID))
 		return 0;
 
-	const float xmin = (mapDims.mapx * SQUARE_SIZE) * allyData[allyTeam].startRectLeft;
-	const float zmin = (mapDims.mapy * SQUARE_SIZE) * allyData[allyTeam].startRectTop;
-	const float xmax = (mapDims.mapx * SQUARE_SIZE) * allyData[allyTeam].startRectRight;
-	const float zmax = (mapDims.mapy * SQUARE_SIZE) * allyData[allyTeam].startRectBottom;
+	const AllyTeam& allyTeam = teamHandler.GetAllyTeam(allyTeamID);
+	const float xmin = (mapDims.mapx * SQUARE_SIZE) * allyTeam.startRectLeft;
+	const float zmin = (mapDims.mapy * SQUARE_SIZE) * allyTeam.startRectTop;
+	const float xmax = (mapDims.mapx * SQUARE_SIZE) * allyTeam.startRectRight;
+	const float zmax = (mapDims.mapy * SQUARE_SIZE) * allyTeam.startRectBottom;
 
 	lua_pushnumber(L, xmin);
 	lua_pushnumber(L, zmin);

--- a/rts/Sim/Misc/Team.cpp
+++ b/rts/Sim/Misc/Team.cpp
@@ -78,12 +78,10 @@ CTeam::CTeam():
 void CTeam::SetDefaultStartPos()
 {
 	const int allyTeam = teamHandler.AllyTeam(teamNum);
-	const std::vector<AllyTeam>& allyStartData = CGameSetup::GetAllyStartingData();
 
-	assert(!allyStartData.empty());
 	assert(allyTeam == teamAllyteam);
 
-	const AllyTeam& allyTeamData = allyStartData[allyTeam];
+	const AllyTeam& allyTeamData = teamHandler.GetAllyTeam(allyTeam);
 	// pick a spot near the center of our startbox
 	const float xmin = (mapDims.mapx * SQUARE_SIZE) * allyTeamData.startRectLeft;
 	const float zmin = (mapDims.mapy * SQUARE_SIZE) * allyTeamData.startRectTop;
@@ -102,8 +100,7 @@ void CTeam::SetDefaultStartPos()
 void CTeam::ClampStartPosInStartBox(float3* pos) const
 {
 	const int allyTeam = teamHandler.AllyTeam(teamNum);
-	const std::vector<AllyTeam>& allyStartData = CGameSetup::GetAllyStartingData();
-	const AllyTeam& allyTeamData = allyStartData[allyTeam];
+	const AllyTeam& allyTeamData = teamHandler.GetAllyTeam(allyTeam);
 	const SRectangle rect(
 		allyTeamData.startRectLeft   * mapDims.mapx * SQUARE_SIZE,
 		allyTeamData.startRectTop    * mapDims.mapy * SQUARE_SIZE,

--- a/rts/Sim/Misc/TeamHandler.h
+++ b/rts/Sim/Misc/TeamHandler.h
@@ -107,6 +107,23 @@ public:
 	 */
 	void SetAlly(int allyteamA, int allyteamB, bool allied) { allyTeams[allyteamA].allies[allyteamB] = allied; }
 
+	/**
+	 * @brief set ally team start box
+	 * @param allyteam ally team to edit
+	 * @param startRectLeft left start box boundary (range: [0.0f, 1.0f])
+	 * @param startRectTop top start box boundary (range: [0.0f, 1.0f])
+	 * @param startRectRight right start box boundary (range: [0.0f, 1.0f])
+	 * @param startRectBottom bottom start box boundary (range: [0.0f, 1.0f])
+	 *
+	 * Sets start box for an ally team
+	 */
+	void SetAllyTeamStartBox(int allyteam, float startRectLeft, float startRectTop, float startRectRight, float startRectBottom) {
+		allyTeams[allyteam].startRectLeft   = std::clamp(startRectLeft, 0.0f, 1.0f);
+		allyTeams[allyteam].startRectTop    = std::clamp(startRectTop, 0.0f, 1.0f);
+		allyTeams[allyteam].startRectRight  = std::clamp(startRectRight, 0.0f, 1.0f);
+		allyTeams[allyteam].startRectBottom = std::clamp(startRectBottom, 0.0f, 1.0f);
+	}
+
 	// accessors
 	int GaiaTeamID() const { return gaiaTeamID; }
 	int GaiaAllyTeamID() const { return gaiaAllyTeamID; }


### PR DESCRIPTION
This new control allows to change an ally team's start box from a synchronized context, thereby opening up the possibility for Lua gadgets to reposition start boxes as needed.

> [!NOTE] 
> This PR depends on #954 to be merged first: #954 fixes a behaviour discovered while adding this new control, where after repositioning boxes via `Spring.SetAllyTeamStartBox` some things were working as intended (e.g. display of the startbox is correctly relocated) and some others were not (e.g. clamping of teams start position inside of the ally team startbox), because of the fact `AllyTeam` data is coming from multiple source.