### PR TITLE
gamesetup: warn instead of fail when missing startpos in map configuration

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -62,7 +62,11 @@ Game Setup:
  - removed `mapSeed` parameter and `new_map_x`, `new_map_y` map generation options. Map is now generated
    blank via 'initBlank' parameter (either 1 or 0) and specifying `blank_map_x`, `blank_map_y`,
    `blank_map_height` map options.
-
+ - Emit a warning instead of immediately failing when MapParser does not find startpos defined in
+   the map config for all teamIDs present in start script. This gives a chance to the game to remedy
+   the situation and handle startpos itself. In the worst case, teams without a startpos will spawn
+   in the corner -- giving an obvious hint that something is amiss and the map is unable to support
+   this number of players by itself without assistance from the game.
 
 Misc:
  - Add `/debugvisibility` command for debugging the visible quadfield quads

--- a/rts/Game/GameSetup.cpp
+++ b/rts/Game/GameSetup.cpp
@@ -272,10 +272,11 @@ void CGameSetup::LoadStartPositions(bool withoutMap)
 	LoadStartPositionsFromMap(teamStartingData.size(), [&](MapParser& mapParser, int teamNum) {
 		float3 pos;
 
-		// don't fail when playing with more players than
-		// start positions and we didn't use them anyway
+		// try to parse start position for teamNum, emit a warning if none found but
+		// do not block on this, in case this is explicitly desired so as to let the
+		// game handle the missing startpos
 		if (!mapParser.GetStartPos(teamStartingData[teamNum].teamStartNum, pos)) {
-			throw content_error(mapParser.GetErrorLog());
+			LOG_L(L_WARNING, "%s", mapParser.GetErrorLog().c_str());
 			return false;
 		}
 


### PR DESCRIPTION
Previously, we failed immediately when trying to start a game on a map with insufficient startpos defined in its configuration to support the number of teams specified in the start script. This behaviour was denying the game a chance to handle start positions itself at a later stage.

Now, we emit a warning instead when MapParser does not find startpos defined in the map config for all teamIDs present in start script, but continue to start the game normally anyway. This gives a chance to the game to remedy the situation and handle startpos itself.

In the worst case, teams without a startpos will spawn in the corner -- giving an obvious hint that something is amiss and the map is unable to support this number of players by itself without assistance from the game.