### PR TITLE
gamecommands: add new `/remove` cheat-only command

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -69,7 +69,8 @@ Misc:
  - add `system.allowEnginePlayerlist` modrule, defaults to true. If false,
    the built-in `/info` playerlist won't display. Use for anonymous modes
    in conjunction with `Spring.GetPlayerInfo` poisoning.
- 
+ - Add new `/remove` cheat-only command, it removes selected units similar to
+   `/destroy` except no death script is run (so no explosion nor wreckage).
 
 Sim:
  - Improved performance of long-range path finding requests (TKPFS)

--- a/rts/Game/SyncedGameCommands.cpp
+++ b/rts/Game/SyncedGameCommands.cpp
@@ -195,33 +195,45 @@ public:
 };
 
 
-class DestroyActionExecutor : public ISyncedActionExecutor {
+class BaseDestroyActionExecutor : public ISyncedActionExecutor {
 public:
-	DestroyActionExecutor() : ISyncedActionExecutor("Destroy", "Destroys one or multiple units by unit-ID, instantly", true) {
-	}
+	BaseDestroyActionExecutor(const std::string& command, const std::string& description, bool runDeathScript)
+		: ISyncedActionExecutor(command, description, true), runDeathScript(runDeathScript) {}
 
-	bool Execute(const SyncedAction& action) const final {
-		std::stringstream argsStream(action.GetArgs());
-		LOG("Killing units: %s", action.GetArgs().c_str());
+	bool Execute(const SyncedAction& action) const {
+		const std::vector<std::string>& args = CSimpleParser::Tokenize(action.GetArgs(), 0);
+		if (args.size() == 0) {
+			LOG_L(L_WARNING, "not enough arguments (\"/%s <unitID:int...>\")", this->GetCommand().c_str());
+			return false;
+		}
 
-		unsigned int unitId;
-		do {
-			argsStream >> unitId;
-
-			if (!argsStream)
-				break;
-
-			CUnit* unit = unitHandler.GetUnit(unitId);
+		LOG("[%s] unitIDs: %s", this->GetCommand().c_str(), action.GetArgs().c_str());
+		for (const auto& it : args) {
+			int unitId = StringToInt<int>(it);
+			CUnit *unit = unitHandler.GetUnit(unitId);
 
 			if (unit != nullptr) {
-				unit->KillUnit(nullptr, false, false);
+				unit->KillUnit(nullptr, false, !this->runDeathScript);
 			} else {
-				LOG("Wrong unitID: %i", unitId);
+				LOG("[%s] Wrong unitID: %i", this->GetCommand().c_str(), unitId);
 			}
-		} while (true);
+		}
 
 		return true;
 	}
+private:
+	bool runDeathScript;
+};
+
+class DestroyActionExecutor : public BaseDestroyActionExecutor {
+public:
+	DestroyActionExecutor() : BaseDestroyActionExecutor("Destroy", "Destroys one or multiple units by unitID immediately", true) {}
+};
+
+
+class RemoveActionExecutor : public BaseDestroyActionExecutor {
+public:
+	RemoveActionExecutor() : BaseDestroyActionExecutor("Remove", "Removes one or multiple units by unitID immediately, bypassing death sequence", false) {}
 };
 
 
@@ -575,6 +587,7 @@ void SyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<NoCostActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<GiveActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DestroyActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<RemoveActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<NoSpectatorChatActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<ReloadCobActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<ReloadCegsActionExecutor>());

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -3422,20 +3422,20 @@ public:
 	}
 };
 
-class DestroyActionExecutor : public IUnsyncedActionExecutor {
+
+class BaseDestroyActionExecutor : public IUnsyncedActionExecutor {
 public:
-	DestroyActionExecutor() : IUnsyncedActionExecutor("Destroy", "Destroys one or multiple units by unit-ID, instantly", true) {
-	}
+	BaseDestroyActionExecutor(const std::string& command, const std::string& description)
+		: IUnsyncedActionExecutor(command, description, true) {}
 
 	bool Execute(const UnsyncedAction& action) const final {
-		if (selectedUnitsHandler.selectedUnits.empty())
+		if (selectedUnitsHandler.selectedUnits.empty()) {
 			return false;
+		}
 
-		// kill selected units
 		std::stringstream ss;
-		ss << GetCommand();
-
-		for (const int unitID: selectedUnitsHandler.selectedUnits) {
+		ss << action.GetCmd();
+		for (const int unitID : selectedUnitsHandler.selectedUnits) {
 			ss << " " << unitID;
 		}
 
@@ -3445,6 +3445,17 @@ public:
 	}
 };
 
+
+class DestroyActionExecutor : public BaseDestroyActionExecutor {
+public:
+	DestroyActionExecutor() : BaseDestroyActionExecutor("Destroy", "Destroys one or multiple units by unitID immediately") {}
+};
+
+
+class RemoveActionExecutor : public BaseDestroyActionExecutor {
+public:
+	RemoveActionExecutor() : BaseDestroyActionExecutor("Remove", "Removes one or multiple units by unitID immediately, bypassing death sequence") {}
+};
 
 
 class SendActionExecutor : public IUnsyncedActionExecutor {
@@ -4005,6 +4016,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<DivByZeroActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<GiveActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DestroyActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<RemoveActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SendActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DumpStateActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DumpRNGActionExecutor>());


### PR DESCRIPTION
This new command allows to remove units similar to `/destroy` except no death script is run (so no explosion nor wreckage).

It works in exactly the same way as `/destroy`:

- As unsynced, `/remove` will remove selected units.
- As synced, `/remove <unitID...>` will remove all unitIDs provided.

Due to the fact only the last call to `KillUnit` differs between `/destroy` and `/remove`, we refactor both to use the same base action executor and only differentiate them by description and a boolean flag.