### PR TITLE
sim: remove redundant `KillUnit()` parameter

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -448,15 +448,15 @@ void CUnit::FinishedBuilding(bool postInit)
 }
 
 
-void CUnit::KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, bool showDeathSequence)
+void CUnit::KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed)
 {
 	if (IsCrashing() && !beingBuilt)
 		return;
 
-	ForcedKillUnit(attacker, selfDestruct, reclaimed, showDeathSequence);
+	ForcedKillUnit(attacker, selfDestruct, reclaimed);
 }
 
-void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, bool showDeathSequence)
+void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed)
 {
 	if (isDead)
 		return;
@@ -477,7 +477,7 @@ void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, b
 		envResHandler.DelGenerator(this);
 
 	blockHeightChanges = false;
-	deathScriptFinished = (!showDeathSequence || reclaimed || beingBuilt);
+	deathScriptFinished = (reclaimed || beingBuilt);
 
 	if (deathScriptFinished)
 		return;

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -239,8 +239,8 @@ public:
 
 public:
 	void KilledScriptFinished(int wreckLevel) { deathScriptFinished = true; delayedWreckLevel = wreckLevel; }
-	void ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, bool showDeathSequence = true);
-	virtual void KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, bool showDeathSequence = true);
+	void ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed);
+	virtual void KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed);
 	virtual void IncomingMissile(CMissileProjectile* missile);
 
 	void TempHoldFire(int cmdID);

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -251,7 +251,7 @@ bool CUnitHandler::QueueDeleteUnit(CUnit* unit)
 	// there are many ways to fiddle with "deathScriptFinished", so a unit may
 	// arrive here not having been properly killed while isDead is still false
 	// make sure we always call Killed; no-op if isDead was already set to true
-	unit->ForcedKillUnit(nullptr, false, true, true);
+	unit->ForcedKillUnit(nullptr, false, true);
 	unitsToBeRemoved.push_back(unit);
 	return true;
 }
@@ -389,7 +389,7 @@ void CUnitHandler::UpdateUnitMoveTypes()
 		// this unit is not coming back, kill it now without any death
 		// sequence (s.t. deathScriptFinished becomes true immediately)
 		if (!unit->pos.IsInBounds() && (unit->speed.w > MAX_UNIT_SPEED))
-			unit->ForcedKillUnit(nullptr, false, true, false);
+			unit->ForcedKillUnit(nullptr, false, true);
 
 		unit->SanityCheck();
 		assert(activeUnits[activeUpdateUnit] == unit);

--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -63,14 +63,14 @@ CFactory::CFactory()
 	, lastBuildUpdateFrame(-1)
 { }
 
-void CFactory::KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, bool showDeathSequence)
+void CFactory::KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed)
 {
 	if (curBuild != nullptr) {
 		curBuild->KillUnit(nullptr, false, true);
 		curBuild = nullptr;
 	}
 
-	CUnit::KillUnit(attacker, selfDestruct, reclaimed, showDeathSequence);
+	CUnit::KillUnit(attacker, selfDestruct, reclaimed);
 }
 
 void CFactory::PreInit(const UnitLoadParams& params)

--- a/rts/Sim/Units/UnitTypes/Factory.h
+++ b/rts/Sim/Units/UnitTypes/Factory.h
@@ -34,7 +34,7 @@ public:
 	/// supply the build piece to speed up
 	float3 CalcBuildPos(int buildPiece = -1);
 
-	void KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, bool showDeathSequence = true);
+	void KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed);
 	void PreInit(const UnitLoadParams& params);
 	bool ChangeTeam(int newTeam, ChangeType type);
 


### PR DESCRIPTION
Previously, `KillUnit()` (and its variants) exposed an optional `showDeathSequence` parameters that defaulted to `true`, and if set to `false` then no death script was run.

In this commit, we remove the parameter as it is entirely redundant:

- The 3rd mandatory parameter `reclaimed` is used for exactly the same purpose: if `reclaimed` is `true`, then no death script is run.
- The default value of `showDeathSequence` is `true` and none of the callers actually set it to `false`, except 1, but this one also sets `reclaimed` to `true`... thereby overriding `showDeathSequence`.