### PR TITLE
Get rid of `{u,bi}nary_function` functor inheritance

### DIFF
--- a/rts/Menu/alphanum.hpp
+++ b/rts/Menu/alphanum.hpp
@@ -265,7 +265,7 @@ namespace doj {
 	implement "std::ostream operator<< (std::ostream&, const Ty&)".
 	*/
 	template<class Ty>
-	struct alphanum_less : public spring::binary_function<Ty, Ty, bool> {
+	struct alphanum_less {
 		bool operator()(const Ty& left, const Ty& right) const {
 			return alphanum_comp(left, right) < 0;
 		}

--- a/rts/Rendering/Shaders/Shader.h
+++ b/rts/Rendering/Shaders/Shader.h
@@ -16,7 +16,7 @@
 #include "System/Cpp11Compat.hpp"
 #include "Rendering/GL/VertexArrayTypes.h"
 
-struct fast_hash : public spring::unary_function<int, size_t>
+struct fast_hash
 {
 	size_t operator()(const int a) const
 	{

--- a/rts/Sim/Path/HAPFS/PathDataTypes.h
+++ b/rts/Sim/Path/HAPFS/PathDataTypes.h
@@ -35,7 +35,7 @@ struct PathNode {
 
 
 /// functor to define node priority
-struct lessCost: public spring::binary_function<PathNode*, PathNode*, bool> {
+struct lessCost {
 	inline bool operator() (const PathNode* x, const PathNode* y) const {
 		return (x->fCost == y->fCost) ? (x->gCost < y->gCost) : (x->fCost > y->fCost);
 	}

--- a/rts/Sim/Units/Scripts/CobEngine.h
+++ b/rts/Sim/Units/Scripts/CobEngine.h
@@ -33,7 +33,7 @@ public:
 		int wt;
 	};
 
-	struct CCobThreadComp: public spring::binary_function<const SleepingThread&, const SleepingThread&, bool> {
+	struct CCobThreadComp {
 	public:
 		bool operator() (const SleepingThread& a, const SleepingThread& b) const {
 			return a.wt > b.wt || (a.wt == b.wt && a.id > b.id);

--- a/rts/System/Cpp11Compat.hpp
+++ b/rts/System/Cpp11Compat.hpp
@@ -3,12 +3,7 @@
 #ifndef CPP11COMPAT_H
 #define CPP11COMPAT_H
 
-#include <functional>
-
 namespace spring {
-	template <typename ArgumentType, typename ResultType> using unary_function = std::function< ResultType(ArgumentType) >;
-	template <typename Arg1, typename Arg2, typename Result> using binary_function = std::function< Result(Arg1, Arg2) >;
-
 	// https://en.cppreference.com/w/cpp/algorithm/random_shuffle
 	template<class RandomIt, class RandomFunc>
 	void random_shuffle(RandomIt first, RandomIt last, RandomFunc&& r)


### PR DESCRIPTION
No longer needed, containers/algorithms use concepts nowadays.