### PR TITLE
Bugger off to better target locations

### DIFF
--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -1034,9 +1034,9 @@ void CMobileCAI::NonMoving()
 	if (buggerOffAttempts > 4) {
 		// previous move commands failed, just try random locations
 		for (int i = 0; i < 16 && !buggerPos.IsInMap(); i++) {
-				buggerVec = gsRNG.NextVector2D();
-				buggerPos = buggerOffPos + buggerVec.Normalize() * buggerOffRadius * 1.5f;
-			}
+			buggerVec = gsRNG.NextVector2D();
+			buggerPos = buggerOffPos + buggerVec.Normalize() * buggerOffRadius * 1.5f;
+		}
 	}
 	else {
 		size_t i = 0;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -998,11 +998,15 @@ void CMobileCAI::BuggerOff(const float3& pos, float radius)
 		return;
 	}
 
+	if (lastBuggerOffTime <= (gs->frameNum - BUGGER_OFF_TTL)) {
+		buggerOffAttempts = 0;
+	}
+
 	lastBuggerOffTime = gs->frameNum;
 	// numNonMovingCalls = 0;
 
 	buggerOffPos = pos;
-	buggerOffRadius = radius + owner->radius;
+	buggerOffRadius = radius;
 }
 
 void CMobileCAI::NonMoving()
@@ -1018,35 +1022,75 @@ void CMobileCAI::NonMoving()
 	if (lastBuggerOffTime <= (gs->frameNum - BUGGER_OFF_TTL))
 		return;
 
-	if (((owner->pos - buggerOffPos) * XZVector).SqLength() >= Square(buggerOffRadius * 1.5f))
+	// increase the target distance if continuing to fail to clear
+	float targetDistance = buggerOffRadius + owner->radius*(1 + 0.3*buggerOffAttempts);
+	if (((owner->pos - buggerOffPos) * XZVector).SqLength() >= Square(targetDistance))
 		return;
 
-	float3 buggerVec;
+	float3 buggerVec = ZeroVector;
 	float3 buggerPos = -OnesVector;
+	float3 buggerDirection = ZeroVector;
 
-	if (HasMoreMoveCommands()) {
+	if (buggerOffAttempts > 4) {
+		// previous move commands failed, just try random locations
+		for (int i = 0; i < 16 && !buggerPos.IsInMap(); i++) {
+				buggerVec = gsRNG.NextVector2D();
+				buggerPos = buggerOffPos + buggerVec.Normalize() * buggerOffRadius * 1.5f;
+			}
+	}
+	else {
 		size_t i = 0;
 		size_t j = 0;
 
 		for (i =     0; (i < commandQue.size() && !commandQue[i].IsMoveCommand()); i++) {}
 		for (j = i + 1; (j < commandQue.size() && !commandQue[j].IsMoveCommand()); j++) {}
 
+		// if the next command is a move command, should move towards it
 		if (i < commandQue.size() && j < commandQue.size()) {
-			buggerVec = commandQue[j].GetPos(0) - commandQue[i].GetPos(0);
-			buggerPos = buggerOffPos + buggerVec.Normalize() * buggerOffRadius * 1.25f;
+			buggerDirection = (commandQue[j].GetPos(0) - commandQue[i].GetPos(0)).Normalize2D();
+
+			// move perpendicular to the next build command, so that unit doesnt move onto it
+			if (commandQue[j].IsBuildCommand()) {
+				buggerDirection = float3(buggerDirection.z, 0, -buggerDirection.x);
+			}
+
+			buggerPos = buggerOffPos + (buggerDirection * (targetDistance));
+			if (!owner->moveDef->TestMoveSquare(nullptr, buggerPos, buggerVec) || !buggerPos.IsInMap()) {
+				buggerPos = -OnesVector;
+			}
+			if (commandQue[j].IsBuildCommand()) {
+				// try the other side
+				buggerPos = buggerOffPos + (-buggerDirection * (targetDistance));
+				if (!owner->moveDef->TestMoveSquare(nullptr, buggerPos, buggerVec) || !buggerPos.IsInMap()) {
+					buggerPos = -OnesVector;
+				}
+			}
 		}
 
-		// check if buggerPos is (still) reachable; aircraft
-		// (or all units) might want to ask the GBOM instead
-		if (owner->moveDef != nullptr && !owner->moveDef->TestMoveSquare(nullptr, buggerPos, buggerVec))
-			buggerPos = -OnesVector;
-	}
-
-	if (buggerPos.x == -1.0f) {
-		// pick a random perimeter point and hope for the best
-		for (int i = 0; i < 16 && !buggerPos.IsInMap(); i++) {
-			buggerVec = gsRNG.NextVector2D();
-			buggerPos = buggerOffPos + buggerVec.Normalize() * buggerOffRadius * 1.5f;
+		if (buggerPos.x == -1.0f) {
+			// head in the opposite direction of the center. since the buggeroff is a circle,
+			// this is the shortest distance out. future optimization would be to make rectangular buggerOffs
+			buggerVec = buggerOffPos - owner->pos;
+			buggerDirection = buggerVec;
+			buggerDirection = -(buggerDirection).Normalize2D();
+			if (buggerDirection == buggerVec) {
+				// unit was directly on top of buggerOffPos, so zero length direction
+				buggerDirection = RgtVector;
+			}
+			// if closest position isn't acceptable, then search rotations for better positions
+			constexpr float3 rotation45deg = {0.7071067811865475, 0, 0.7071067811865475};
+			for (int i = 0; i < 10; i++) {
+				buggerPos = buggerOffPos + (buggerDirection * (targetDistance));
+				if (owner->moveDef->TestMoveSquare(nullptr, buggerPos, buggerVec) && buggerPos.IsInMap()) {
+					break;
+				}
+				if (i == 0) {
+					// everything is on a grid anyways, just search 45 degree rotations from nearest axis
+					buggerDirection = buggerDirection.snapToAxis();
+				} else {
+					buggerDirection = buggerDirection.rotate2D(rotation45deg);
+				}
+			}
 		}
 	}
 
@@ -1055,6 +1099,7 @@ void CMobileCAI::NonMoving()
 	c.SetTimeOut(gs->frameNum + BUGGER_OFF_TTL);
 	commandQue.push_front(c);
 
+	buggerOffAttempts++;
 	numNonMovingCalls = 0;
 }
 

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -1027,9 +1027,9 @@ void CMobileCAI::NonMoving()
 	if (((owner->pos - buggerOffPos) * XZVector).SqLength() >= Square(targetDistance))
 		return;
 
-	float3 buggerVec = ZeroVector;
 	float3 buggerPos = -OnesVector;
-	float3 buggerDirection = ZeroVector;
+	float3 buggerVec;
+	float3 buggerDirection;
 
 	if (buggerOffAttempts > 4) {
 		// previous move commands failed, just try random locations

--- a/rts/Sim/Units/CommandAI/MobileCAI.h
+++ b/rts/Sim/Units/CommandAI/MobileCAI.h
@@ -104,6 +104,7 @@ protected:
 	int lastBuggerOffTime = -BUGGER_OFF_TTL;
 	int lastIdleCheck = 0;
 	int numNonMovingCalls = 0;
+	int buggerOffAttempts = 0;
 
 	static constexpr int MAX_CLOSE_IN_RETRY_TICKS = 30;
 	static constexpr int BUGGER_OFF_TTL = 200;

--- a/rts/Sim/Units/CommandAI/MobileCAI.h
+++ b/rts/Sim/Units/CommandAI/MobileCAI.h
@@ -103,7 +103,6 @@ protected:
 	int lastCloseInTry = -1;
 	int lastBuggerOffTime = -BUGGER_OFF_TTL;
 	int lastIdleCheck = 0;
-	int numNonMovingCalls = 0;
 	int buggerOffAttempts = 0;
 
 	static constexpr int MAX_CLOSE_IN_RETRY_TICKS = 30;

--- a/rts/System/float3.cpp
+++ b/rts/System/float3.cpp
@@ -70,3 +70,16 @@ bool float3::equals(const float3& f, const float3& eps) const
 	return (epscmp(x, f.x, eps.x) && epscmp(y, f.y, eps.y) && epscmp(z, f.z, eps.z));
 }
 
+float3 float3::snapToAxis() const {
+		// https://gamedev.stackexchange.com/questions/83601/from-3d-rotation-snap-to-nearest-90-directions/183342#183342
+    float nx = std::abs(x);
+    float ny = std::abs(y);
+    float nz = std::abs(z);
+    if (nx > ny && nx > nz) {
+        return float3(Sign(x), 0, 0);
+    } else if (ny > nx && ny > nz) {
+        return float3(0, Sign(y), 0);
+    } else {
+        return float3(0, 0, Sign(z));
+    }
+	}

--- a/rts/System/float3.cpp
+++ b/rts/System/float3.cpp
@@ -71,15 +71,15 @@ bool float3::equals(const float3& f, const float3& eps) const
 }
 
 float3 float3::snapToAxis() const {
-		// https://gamedev.stackexchange.com/questions/83601/from-3d-rotation-snap-to-nearest-90-directions/183342#183342
-    float nx = std::abs(x);
-    float ny = std::abs(y);
-    float nz = std::abs(z);
-    if (nx > ny && nx > nz) {
-        return float3(Sign(x), 0, 0);
-    } else if (ny > nx && ny > nz) {
-        return float3(0, Sign(y), 0);
-    } else {
-        return float3(0, 0, Sign(z));
-    }
+	// https://gamedev.stackexchange.com/questions/83601/from-3d-rotation-snap-to-nearest-90-directions/183342#183342
+	float nx = std::abs(x);
+	float ny = std::abs(y);
+	float nz = std::abs(z);
+	if (nx > ny && nx > nz) {
+		return float3(Sign(x), 0, 0);
+	} else if (ny > nx && ny > nz) {
+		return float3(0, Sign(y), 0);
+	} else {
+		return float3(0, 0, Sign(z));
 	}
+}

--- a/rts/System/float3.h
+++ b/rts/System/float3.h
@@ -422,6 +422,25 @@ public:
 		};
 	}
 
+
+	/**
+	 * Rotate a vector by the angle between rotationVector and RgtVector.
+	 * The result is only normalized if the input vector and self are normalized.
+	 * @return new vector with the result
+	 */
+	float3 rotate2D(const float3& rotationVector) const {
+		// https://blog.demofox.org/2014/12/27/using-imaginary-numbers-to-rotate-2d-vectors/
+		float nx = x * rotationVector.x - z * rotationVector.z;
+		float nz = x * rotationVector.z + z * rotationVector.x;
+		return float3{ nx, y, nz };
+	}
+
+	/**
+	 * Snaps the vector to the closest world axis.
+	 * @return new vector with the result
+	 */
+	float3 snapToAxis() const;
+
 	/**
 	 * @brief distance between float3s
 	 * @param f float3 to compare against


### PR DESCRIPTION
This branch is mainly looking to solve #905, with a few other changes attempting to get better bugger off target positions. 

Currently if the next command is a movement command, the target location will be towards that command position. Here we additionally check if the next movement command is a build command, and then move perpendicular so that the next building is not blocked. 

If there are no additional commands in the queue, then we attempt to move directly out of the circle as proposed in the issue. If that location is blocked, then rotations from the nearest axis are checked, as buildings are usually on a grid. Then if after a few buggeroff attempts we still haven't gotten out of the buggeroffradius, we fall back to just picking random locations as it works currently.

I tried a version that got the path cost from the pathmanager, but it was too slow to issue the number of path checks I wanted. I am curious if there are better ways to check if the path is blocked than how I am using `TestMoveSquare`, maybe issue a couple testmovesquares in a line to the target position?