### PR TITLE
Add named constants for color codes

### DIFF
--- a/doc/site/changelogs/running-changelog.markdown
+++ b/doc/site/changelogs/running-changelog.markdown
@@ -216,11 +216,14 @@ These are the counterparts to the existing `Spring.SelectUnitArray` and `Spring.
 * added `Spring.GetModelRootPiece(modelName) → number pieceID` which returns the root piece.
 * added `Spring.GetUnitRootPiece(unitID) → number pieceID` and `Spring.GetFeatureRootPiece(featureID) → number pieceID`, likewise.
 
+### Colored text
+* added an inline colour code `\254`, followed by 8 bytes: RGBARGBA, where the first four describe the following text colour and the next four the text's outline.
+* added the `Game.textColorCodes` table, containing the constants `Color` (`/255`), `ColorAndOutline` (the newly added `/254`), and `Reset` (`\008`).
+
 ### Miscellaneous additions
 * add `Spring.GetFacingFromHeading(number heading) → number facing` and `Spring.GetHeadingFromFacing(number facing) → number heading` for unit conversion.
 * added `wupget:Unit{Entered,Left}Underwater(unitID, unitDefID, teamID) → nil`, similar to existing UnitEnteredWater.
 Note that EnteredWater happens when the unit dips its toes into the water while EnteredUnderwater is when it becomes completely submerged.
-* added an inline colour code `\254`, followed by 8 bytes: RGBARGBA, where the first four describe the following text colour and the next four the text's outline.
 * add new `/remove` cheat-only command, it removes selected units similar to `/destroy` except the units are just removed (no wreck, no death explosion).
 * added new startscript entry: `FixedRNGSeed`. Defaults to 0 which means to generate a random seed for synced RNG (current behaviour).
 Otherwise, given value is used as the seed. Use for reproducible runs (benchmarks, mission cutscenes...).

--- a/rts/Lua/LuaConstGame.cpp
+++ b/rts/Lua/LuaConstGame.cpp
@@ -11,6 +11,7 @@
 #include "Map/MapInfo.h"
 #include "Map/MetalMap.h"
 #include "Map/ReadMap.h"
+#include "Rendering/Fonts/glFont.h"
 #include "Sim/Misc/ModInfo.h"
 #include "Sim/Misc/CategoryHandler.h"
 #include "Sim/Misc/DamageArrayHandler.h"
@@ -301,6 +302,15 @@ bool LuaConstGame::PushEntries(lua_State* L)
 			LuaPushNamedNumber(L, "HitNothing", CScriptMoveType::HitNothing);
 			LuaPushNamedNumber(L, "HitGround" , CScriptMoveType::HitGround );
 			LuaPushNamedNumber(L, "HitLimit"  , CScriptMoveType::HitLimit  );
+		lua_rawset(L, -3);
+	}
+	{
+		// inline color-codes for text fonts
+		lua_pushliteral(L, "textColorCodes");
+		lua_createtable(L, 0, 3);
+			LuaPushNamedChar(L, "Color"          , CglFont::ColorCodeIndicator  );
+			LuaPushNamedChar(L, "ColorAndOutline", CglFont::ColorCodeIndicatorEx);
+			LuaPushNamedChar(L, "Reset"          , CglFont::ColorResetIndicator );
 		lua_rawset(L, -3);
 	}
 

--- a/rts/Lua/LuaUtils.h
+++ b/rts/Lua/LuaUtils.h
@@ -272,6 +272,13 @@ static inline void LuaPushNamedNumber(lua_State* L, const string& key, lua_Numbe
 }
 
 
+static inline void LuaPushNamedChar(lua_State* L, char const *name, char value)
+{
+	lua_pushstring(L, name);
+	lua_pushlstring(L, &value, 1);
+	lua_rawset(L, -3);
+}
+
 static inline void LuaPushNamedString(lua_State* L, const string& key, const string& value)
 {
 	lua_pushsstring(L, key);


### PR DESCRIPTION
So people won't need to put magic `\254` etc in their code.