### PR TITLE
Allow games to customize shared unit orders

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -105,6 +105,7 @@ Misc:
    in conjunction with `Spring.GetPlayerInfo` poisoning.
  - Add new `/remove` cheat-only command, it removes selected units similar to
    `/destroy` except no death script is run (so no explosion nor wreckage).
+ - Units no longer clear command queue when shared. This can be implemented gameside with UnitGiven callin.
 
 Sim:
  - Improved performance of long-range path finding requests (TKPFS)

--- a/doc/site/changelogs/running-changelog.markdown
+++ b/doc/site/changelogs/running-changelog.markdown
@@ -35,6 +35,7 @@ The extras are considered to start in the (0, 0) corner and it is now up to the 
 Use the `TeamChanged` call-in to make a replacement if you want it to be public.
 * the `acceleration` and `brakeRate` unit def entries are scheduled for a unit change from elmo/frame to elmo/second. There is no change yet,
 but if you prefer not to have to add processing later you might want to change to `maxAcc` and `maxDec` respectively.
+* manually shared units no longer receive the Stop command. Use the `UnitGiven` callin to get back the previous behaviour.
 
 # QTPFS
 

--- a/doc/site/migrating-from-spring.markdown
+++ b/doc/site/migrating-from-spring.markdown
@@ -89,6 +89,17 @@ Instead use the second return value, e.g.:
 + local counts, unitDefsCount = Spring.GetSelectedUnitsCounts()
 ```
 
+## Stop command on manual share
+Manually shared units no longer receive the Stop command.
+Replicate the previous behaviour via the `UnitGiven` callin:
+```lua
+function wupget:UnitGiven(unitID, unitDefID, newTeam)
+	if newTeam == Spring.GetMyTeamID() then -- if unsynced
+    Spring.GiveOrderToUnit(unitID, CMD.STOP, 0, 0)
+  end
+end
+```
+
 ## Defs
 
 - Hovercraft and ships brought out of water no longer forced to be upright.

--- a/doc/site/migrating-from-spring.markdown
+++ b/doc/site/migrating-from-spring.markdown
@@ -94,9 +94,9 @@ Manually shared units no longer receive the Stop command.
 Replicate the previous behaviour via the `UnitGiven` callin:
 ```lua
 function wupget:UnitGiven(unitID, unitDefID, newTeam)
-	if newTeam == Spring.GetMyTeamID() then -- if unsynced
-    Spring.GiveOrderToUnit(unitID, CMD.STOP, 0, 0)
-  end
+	if newTeam == Spring.GetMyTeamID() then -- if doing in unsynced
+		Spring.GiveOrderToUnit(unitID, CMD.STOP, 0, 0)
+	end
 end
 ```
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2657,7 +2657,7 @@ int LuaUnsyncedCtrl::AssignMouseCursor(lua_State* L)
  *
  * @function Spring.ReplaceMouseCursor
  * @string oldFileName
- * @string newFileName
+ * @string newFileName 
  * @bool[opt=false] hotSpotTopLeft
  * @treturn ?nil|bool assigned
  */
@@ -3521,7 +3521,6 @@ int LuaUnsyncedCtrl::ShareResources(lua_State* L)
 	const char* type = lua_tostring(L, 2);
 	if (type[0] == 'u') {
 		clientNet->Send(CBaseNetProtocol::Get().SendShare(gu->myPlayerNum, teamID, 1, 0.0f, 0.0f));
-		// update the selection
 		selectedUnitsHandler.ClearSelected();
 		return 0;
 	}
@@ -3552,7 +3551,7 @@ int LuaUnsyncedCtrl::ShareResources(lua_State* L)
  * @number x
  * @number y
  * @number z
- * @treturn nil
+ * @treturn nil 
  */
 int LuaUnsyncedCtrl::SetLastMessagePosition(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2643,7 +2643,7 @@ int LuaUnsyncedCtrl::AssignMouseCursor(lua_State* L)
  *
  * @function Spring.ReplaceMouseCursor
  * @string oldFileName
- * @string newFileName 
+ * @string newFileName
  * @bool[opt=false] hotSpotTopLeft
  * @treturn ?nil|bool assigned
  */
@@ -3506,9 +3506,8 @@ int LuaUnsyncedCtrl::ShareResources(lua_State* L)
 
 	const char* type = lua_tostring(L, 2);
 	if (type[0] == 'u') {
-		// update the selection, and clear the unit command queues
-		selectedUnitsHandler.GiveCommand(Command(CMD_STOP), false);
 		clientNet->Send(CBaseNetProtocol::Get().SendShare(gu->myPlayerNum, teamID, 1, 0.0f, 0.0f));
+		// update the selection
 		selectedUnitsHandler.ClearSelected();
 		return 0;
 	}
@@ -3539,7 +3538,7 @@ int LuaUnsyncedCtrl::ShareResources(lua_State* L)
  * @number x
  * @number y
  * @number z
- * @treturn nil 
+ * @treturn nil
  */
 int LuaUnsyncedCtrl::SetLastMessagePosition(lua_State* L)
 {


### PR DESCRIPTION
Engine should leave issuing a stop command to game side so that they can customize unit behavior when units are shared. It can be easily implemented by issuing a stop command in the UnitGiven callback, if game developers desire that behavior.

Reference implementation: 
```lua
function widget:UnitGiven(unitID, unitDefID, newTeam, oldTeam)
	if newTeam ~= Spring.GetMyTeamID() then return end
	Spring.GiveOrderToUnit(unitID, CMD.STOP, {}, {})
end
```