### PR TITLE
Add blending equation constants to Lua GL API

### DIFF
--- a/doc/site/changelogs/running-changelog.markdown
+++ b/doc/site/changelogs/running-changelog.markdown
@@ -236,6 +236,7 @@ The weapon number is optional if the unit has a single shield. The timer value i
 Note that a weapon hit (both via `nil` here, and "real" hits) will never decrease the remaining timer, though it can increase it.
 An explicit numerical value always sets the timer to that many seconds.
 * added `GL.DEPTH_COMPONENT{16,24,32,32F}` constants.
+* added the following `GL` constants for use in `gl.BlendEquation`: `FUNC_ADD`, `FUNC_SUBTRACT`, `FUNC_REVERSE_SUBTRACT`, `MIN` and `MAX`.
 * added `Spring.GetWindowDisplayMode() → number width, number height, number bitsPerPixel, number refreshRateHz, string pixelFormatName`.
 The pixel format name is something like, for example, "SDL_PIXELFORMAT_RGB565".
 

--- a/rts/Lua/LuaConstGL.cpp
+++ b/rts/Lua/LuaConstGL.cpp
@@ -103,6 +103,24 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	PUSH_GL(ONE_MINUS_DST_COLOR);
 	PUSH_GL(SRC_ALPHA_SATURATE);
 
+
+	/***
+	 * BlendEquation
+	 * @section blendequation
+	 *
+	 * @table GL
+	 * @number FUNC_ADD
+	 * @number FUNC_SUBTRACT
+	 * @number FUNC_REVERSE_SUBTRACT
+	 * @number MIN
+	 * @number MAX
+	 */
+	PUSH_GL(FUNC_ADD);
+	PUSH_GL(FUNC_SUBTRACT);
+	PUSH_GL(FUNC_REVERSE_SUBTRACT);
+	PUSH_GL(MIN);
+	PUSH_GL(MAX);
+
 /***
  * AlphaFunction and DepthFunction
  * @section alphadepth


### PR DESCRIPTION
For use in `gl.BlendEquation`.