### PR TITLE
rework SimpleParticleSystem to use data driven design

### DIFF
--- a/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
@@ -4,6 +4,10 @@
 
 #include "Game/Camera.h"
 #include "Game/GlobalUnsynced.h"
+#include "Sim/Misc/GlobalSynced.h"
+#include "Sim/Misc/TeamHandler.h"
+#include "Sim/Misc/LosHandler.h"
+#include "Sim/Units/Unit.h"
 #include "Rendering/GlobalRendering.h"
 #include "Rendering/Env/Particles/ProjectileDrawer.h"
 #include "Rendering/GL/RenderBuffers.h"
@@ -14,6 +18,49 @@
 #include "System/float3.h"
 #include "System/Log/ILog.h"
 #include "System/SpringMath.h"
+#include "Rendering/Colors.h"
+#include "Game/CameraHandler.h"
+
+#include "System/BranchPrediction.h"
+
+
+CSimpleParticleSystemCollection simpleParticleSystem; 
+
+void AddEffectsQuad(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl,
+					const float3& animParams, const float& animProgress)
+{
+	float minS = std::numeric_limits<float>::max()   ; float minT = std::numeric_limits<float>::max()   ;
+	float maxS = std::numeric_limits<float>::lowest(); float maxT = std::numeric_limits<float>::lowest();
+	std::invoke([&](auto&&... arg) {
+		((minS = std::min(minS, arg.s)), ...);
+		((minT = std::min(minT, arg.t)), ...);
+		((maxS = std::max(maxS, arg.s)), ...);
+		((maxT = std::max(maxT, arg.t)), ...);
+	}, tl, tr, br, bl);
+
+	
+	auto& rb = CProjectile::GetPrimaryRenderBuffer();
+
+	const auto uvInfo = float4{ minS, minT, maxS - minS, maxT - minT };
+	const auto animInfo = float3{ animParams.x, animParams.y, animProgress };
+	constexpr float layer = 0.0f; //for future texture arrays
+
+	//pos, uvw, uvmm, col
+	rb.AddQuadTriangles(
+		{ tl.pos, float3{ tl.s, tl.t, layer }, uvInfo, animInfo, tl.c },
+		{ tr.pos, float3{ tr.s, tr.t, layer }, uvInfo, animInfo, tr.c },
+		{ br.pos, float3{ br.s, br.t, layer }, uvInfo, animInfo, br.c },
+		{ bl.pos, float3{ bl.s, bl.t, layer }, uvInfo, animInfo, bl.c }
+	);
+}
+
+void AddQuadOrder(uint64_t order)
+{
+	auto& rb = CProjectile::GetPrimaryRenderBuffer();
+	if (rb.GetSortMode()) {
+		rb.AddQuadOrder(order);
+	}
+}
 
 CR_BIND_DERIVED(CSimpleParticleSystem, CProjectile, )
 
@@ -115,7 +162,7 @@ void CSimpleParticleSystem::Draw()
 			 ydir * size - xdir * size
 		};
 
-		if (math::fabs(p->rotVal) > 0.01f) {
+		if (std::fabs(p->rotVal) > 0.01f) {
 			float3::rotate<false>(p->rotVal, zdir, bounds);
 		}
 		AddEffectsQuad(
@@ -258,3 +305,355 @@ bool CSimpleParticleSystem::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo
 CR_BIND_DERIVED(CSphereParticleSpawner, CSimpleParticleSystem, )
 
 CR_REG_METADATA(CSphereParticleSpawner, )
+
+void CSphereParticleSpawner::Draw()
+{
+}
+
+void CSphereParticleSpawner::Update()
+{
+}
+
+int CSphereParticleSpawner::GetProjectilesCount() const
+{
+	return 0;
+}
+
+void CSphereParticleSpawner::Init(const CUnit* owner, const float3& offset)
+{
+	CProjectile::Init(owner, offset);
+	
+	// FIXME: should catch these earlier and for more projectile-types
+	if (colorMap == nullptr) {
+		colorMap = CColorMap::LoadFromFloatVector(std::vector<float>(8, 1.0f));
+		LOG_L(L_WARNING, "[CSphereParticleSpawner::%s] no color-map specified", __FUNCTION__);
+	}
+	if (texture == nullptr) {
+		texture = &projectileDrawer->textureAtlas->GetTexture("sphereparticle");
+		LOG_L(L_WARNING, "[CSphereParticleSpawner::%s] no texture specified", __FUNCTION__);
+	}
+	
+	drawRadius = (particleSpeed + particleSpeedSpread) * (particleLife * particleLifeSpread);
+	
+	this->GenerateParticles(offset);
+	deleteMe = true;
+}
+
+bool CSphereParticleSpawner::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
+{
+	return CSimpleParticleSystem::GetMemberInfo(memberInfo);
+}
+
+CSphereParticleSpawner::CSphereParticleSpawner()
+{
+}
+
+void CSphereParticleSpawner::GenerateParticles(const float3& pos)
+{
+	simpleParticleSystem.Add(*this, pos);
+}
+
+void CSimpleParticleSystemCollection::Add(CSimpleParticleSystem& p, float3 offset) {
+	const float3 up = p.emitVector;
+	const float3 right = up.cross(float3(up.y, up.z, -up.x));
+	const float3 forward = up.cross(right);
+	
+	for (int i = 0 ; i < p.numParticles; ++i) {
+		float az = guRNG.NextFloat() * math::TWOPI;
+		float ay = (p.emitRot + (p.emitRotSpread * guRNG.NextFloat())) * math::DEG_TO_RAD;
+		
+		auto& e = d.emplace_back();
+
+		e.pos = offset;
+		e.speed =((up * p.emitMul.y) * fastmath::cos(ay) - ((right * p.emitMul.x) * fastmath::cos(az) - (forward * p.emitMul.z) * fastmath::sin(az)) * fastmath::sin(ay)) * (p.particleSpeed + (guRNG.NextFloat() * p.particleSpeedSpread));
+		
+		e.rotVal = (p.rotParams.z);
+		e.rotVel = (p.rotParams.x); //initial rotation velocity
+		e.rotParams = (p.rotParams.y);
+		
+		e.life=(0.0f);
+		e.decayrate=(1.0f / (p.particleLife + (guRNG.NextFloat() * p.particleLifeSpread)));
+		
+		e.size=(p.particleSize + guRNG.NextFloat()*p.particleSizeSpread);
+		e.sizeGrowth=(p.sizeGrowth);
+		e.sizeMod=(p.sizeMod);
+		
+		e.gravity=(p.gravity);
+		e.airdrag=(p.airdrag);
+		
+		e.visible=(true);
+		e.visibleShadow=(true);
+		e.visibleRefraction=(true);
+		e.visibleReflection=(true);
+		e.allyTeam=(p.allyteamID);
+					
+		// draw
+		e.colorMap=(p.colorMap);
+		
+		e.texture=(p.texture);
+		
+		e.anims=(p.animParams);
+		e.aprogress=(p.animProgress);
+		e.createFrame=(p.createFrame);
+		
+		e.drawRadius=(p.drawRadius);
+		e.drawOrder=(p.drawOrder);
+		
+		e.directional=(p.directional);
+		
+		e.alwaysVisible=(p.alwaysVisible);
+		e.castShadow=(p.castShadow);	
+	}
+}
+	
+void CSimpleParticleSystemCollection::Update() {		
+	CheckDead();
+		
+	for (int i =0; i < d.size(); ++i) {
+		auto& e = d[i];
+		e.pos    += e.speed;
+		e.speed  += e.gravity;
+		e.speed  *= e.airdrag;
+
+		e.rotVal += e.rotVel;
+		e.rotVel += e.rotParams;
+
+		e.life += e.decayrate;
+		
+		e.size = e.size * e.sizeMod + e.sizeGrowth;	
+	}
+
+}
+	
+void CSimpleParticleSystemCollection::CheckDead() {
+	for (int i =0; i < d.size();) {
+		auto& e = d[i];
+		if unlikely(e.life >= 1.0) {
+			this->Erase(i);		
+		} else 
+		{
+			++i;
+		}			
+	}
+}
+
+template <typename T>
+void remove_from_container(int idx, T&& cont) {
+	cont[idx] = cont.back();
+	cont.pop_back();
+}
+
+void CSimpleParticleSystemCollection::Erase(int idx) {
+	remove_from_container(idx, d);
+}
+
+void CSimpleParticleSystemCollection::PreDraw() {
+	auto spectatingFullView = gu->spectatingFullView;
+	auto myAllyTeam = gu->myAllyTeam;
+	auto& th = teamHandler;
+	auto& lh = losHandler;
+	
+	const CCamera* cameras[] = {
+		CCameraHandler::GetCamera(CCamera::CAMTYPE_PLAYER),
+		CCameraHandler::GetCamera(CCamera::CAMTYPE_UWREFL),
+		CCameraHandler::GetCamera(CCamera::CAMTYPE_SHADOW)
+	};
+	
+	float timeOffset = globalRendering->timeOffset;
+	for (int i =0; i < d.size(); ++i) {
+		auto& e = d[i];
+		e.colorMap->GetColor(e.color.data(), e.life);
+		e.interPos = e.pos + e.speed * timeOffset;
+	
+		this->UpdateAnimParams(i);	
+
+		e.visible = 
+			e.alwaysVisible || (spectatingFullView || (th.IsValidAllyTeam(e.allyTeam) && 
+						th.Ally(e.allyTeam, myAllyTeam) ||
+						(lh->InLos(e.pos, myAllyTeam) || 
+						 lh->InAirLos(e.pos, myAllyTeam))));			
+
+		e.visibleRefraction = e.visible && e.interPos.y <= e.drawRadius && cameras[0]->InView(e.interPos, e.drawRadius);
+		e.visibleReflection = e.visible && cameras[1]->InView(e.interPos, e.drawRadius);
+		e.visibleShadow = e.castShadow && e.visible && cameras[2]->InView(e.interPos, e.drawRadius);	
+	}
+}
+
+void CSimpleParticleSystemCollection::Draw(bool drawRefraction)
+{
+	bool drawReflection = !drawRefraction;
+
+	auto* cam = camera;
+
+	// streflop faster alternative
+	const static auto safeANormalize = [&](const auto& ydir) {	
+		const float sql = ydir.SqLength();
+		if likely(sql > float3::nrm_eps()) {
+			return ydir * fastmath::isqrt_nosse(sql);
+		}
+		return ydir;
+	};
+
+	auto cpos = cam->GetPos();
+	auto fwd = camera->GetForward();
+	
+	// TODO branchless processing?
+	for (int i =0; i < d.size(); ++i) {
+		auto& e = d[i];
+		
+		if (drawRefraction && !e.visibleRefraction) {
+			continue;
+		} else if (drawReflection && !e.visibleReflection) {
+			continue;
+		}
+		
+		const float3 zdir = safeANormalize(e.pos - cpos);
+		float3 ydir = zdir.cross(e.speed);
+		float yDirLen2 = ydir.SqLength();
+		ydir = safeANormalize(ydir);
+		const float3 xdir = ydir.cross(zdir);
+
+		if (e.directional && yDirLen2 > 0.001f)
+		{
+			e.bounds = {
+				-ydir * e.size - xdir * e.size,
+				-ydir * e.size + xdir * e.size,
+				 ydir * e.size + xdir * e.size,
+				 ydir * e.size - xdir * e.size
+			};
+			if (std::fabs(e.rotVal) > 0.01f) {
+				float3::rotate<false>(e.rotVal, zdir, e.bounds);
+			}
+		}
+		else
+		{
+			const float3 cameraRight = camera->GetRight() * e.size;
+			const float3 cameraUp    = camera->GetUp()    * e.size;				
+			e.bounds = {
+				-cameraRight - cameraUp,
+				 cameraRight - cameraUp,
+				 cameraRight + cameraUp,
+				-cameraRight + cameraUp
+			};
+			if (std::fabs(e.rotVal) > 0.01f) {
+				float3::rotate<false>(e.rotVal, fwd, e.bounds);
+			}
+		}
+
+		AddEffectsQuad(
+			{ e.interPos + e.bounds[0], e.texture->xstart, e.texture->ystart, e.color.data() },
+			{ e.interPos + e.bounds[1], e.texture->xend,   e.texture->ystart, e.color.data() },
+			{ e.interPos + e.bounds[2], e.texture->xend,   e.texture->yend,   e.color.data() },
+			{ e.interPos + e.bounds[3], e.texture->xstart, e.texture->yend,   e.color.data() },
+			e.anims, e.aprogress
+		);
+		
+		
+		// add order so we can sort them later
+		// TODO drawOrder can be negative?
+		if (rb.GetSortMode()) {
+			uint64_t order (static_cast<uint64_t>(e.drawOrder) << 32 | static_cast<uint32_t>(-cam->ProjectedDistance(e.pos)));
+			AddQuadOrder(order);		
+		}
+	}	
+}
+
+void CSimpleParticleSystemCollection::DrawShadow() {
+	// visibility
+	const bool shadowPass = (camera->GetCamType() == CCamera::CAMTYPE_SHADOW);
+	assert(shadowPass);
+	
+	auto* cam = camera;
+	
+	// streflop alternative
+	const static auto safeANormalize = [&](const auto& ydir) {	
+		const float sql = ydir.SqLength();
+		if likely(sql > float3::nrm_eps()) {
+			return ydir * fastmath::isqrt_nosse(sql);
+		}
+		return ydir;
+	};
+
+	auto cpos = cam->GetPos();
+	auto fwd = camera->GetForward();
+	
+	for (int i =0; i < d.size(); ++i) {
+		auto& e = d[i];
+		if (!e.visibleShadow) {
+			continue;
+		}
+		const float3 zdir = safeANormalize(e.pos - cpos);
+		float3 ydir = zdir.cross(e.speed);
+		ydir = safeANormalize(ydir);
+
+
+		const float3 cameraRight = camera->GetRight() * e.size;
+		const float3 cameraUp    = camera->GetUp()    * e.size;				
+		e.bounds = {
+			-cameraRight - cameraUp,
+			 cameraRight - cameraUp,
+			 cameraRight + cameraUp,
+			-cameraRight + cameraUp
+		};
+		if (std::fabs(e.rotVal) > 0.01f) {
+			float3::rotate<false>(e.rotVal, fwd, e.bounds);
+		}
+
+
+		AddEffectsQuad(
+			{ e.interPos + e.bounds[0], e.texture->xstart, e.texture->ystart, e.color.data() },
+			{ e.interPos + e.bounds[1], e.texture->xend,   e.texture->ystart, e.color.data() },
+			{ e.interPos + e.bounds[2], e.texture->xend,   e.texture->yend,   e.color.data() },
+			{ e.interPos + e.bounds[3], e.texture->xstart, e.texture->yend,   e.color.data() },
+			e.anims, e.aprogress
+		);
+		
+		// shadow not sorted
+	}	
+}
+
+void AddMiniMapVertices(VA_TYPE_C&& v1, VA_TYPE_C&& v2)
+{
+	auto& mmLnsRB = CProjectile::GetMiniMapLinesRB();
+	auto& mmPtsRB = CProjectile::GetMiniMapPointsRB();
+	if (v1.pos.equals(v2.pos)) {
+		mmPtsRB.AddVertex(std::move(v1));
+	}
+	else {
+		mmLnsRB.AddVertex(std::move(v1));
+		mmLnsRB.AddVertex(std::move(v2));
+	}
+}
+
+void CSimpleParticleSystemCollection::DrawOnMinimap() {
+	for (int i =0; i < d.size(); ++i) {
+		auto& e = d[i];
+		if (!e.visible)
+			continue;
+		AddMiniMapVertices({ e.pos, color4::whiteA }, { e.pos + e.speed, color4::whiteA });
+	}
+}
+	
+void CSimpleParticleSystemCollection::UpdateAnimParams(int idx) {
+	int gameFrame = gs->frameNum;
+	float timeOffset = globalRendering->timeOffset;
+	
+	auto& e = d[idx];
+
+	auto& animParams = e.anims;
+	auto& animProgress = e.aprogress;
+	if (static_cast<int>(animParams.x) <= 1 && static_cast<int>(animParams.y) <= 1) {
+		animProgress = 0.0f;
+		return;
+	}
+
+	const float t = (gameFrame + timeOffset - e.createFrame);
+	const float animSpeed = std::fabs(animParams.z);
+
+	if (animParams.z < 0.0f) {
+		animProgress = 1.0f - std::fabs(std::fmod(t, 2.0f * animSpeed) / animSpeed - 1.0f);
+	}
+	else {
+		animProgress = std::fmod(t, animSpeed) / animSpeed;
+	}
+}

--- a/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.h
+++ b/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.h
@@ -16,6 +16,7 @@ class CSimpleParticleSystem : public CProjectile
 	CR_DECLARE_SUB(Particle)
 
 public:
+	friend class CSimpleParticleSystemCollection;
 	CSimpleParticleSystem();
 	virtual ~CSimpleParticleSystem() { particles.clear(); }
 
@@ -81,10 +82,82 @@ protected:
 class CSphereParticleSpawner : public CSimpleParticleSystem {
 	CR_DECLARE_DERIVED(CSphereParticleSpawner)
 public:
-	CSphereParticleSpawner() {}
-	static bool GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo) {
-		return CSimpleParticleSystem::GetMemberInfo(memberInfo);
-	}
+	CSphereParticleSpawner();
+
+	void Draw() override;
+	void Update() override;
+	int GetProjectilesCount() const override;
+	void Init(const CUnit* owner, const float3& offset) override;
+
+	static bool GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo);
+private:
+	void GenerateParticles(const float3& pos);
 };
+
+class CSimpleParticleSystemCollection
+{
+public:
+	void Update();
+	void Draw(bool drawRefraction);
+	void DrawShadow();
+	void PreDraw();
+	void DrawOnMinimap();
+	void Add(CSimpleParticleSystem& p, float3 offset); // TODO use thinner CSimpleParticleSystem
+	size_t NumParticles() const { return d.size(); }
+private:
+	void CheckDead();	
+	void Erase(int idx);	
+	void UpdateAnimParams(int idx);
+	
+	// update data
+	struct Data {
+		// update data
+		float3 pos;
+		float3 speed;
+	
+		float rotVal;
+		float rotVel;
+		float rotParams; // rotParams.y; //rot accel
+	
+		float life;
+		float decayrate;
+		
+		float size;
+		float sizeGrowth;
+		float sizeMod;
+		
+		float3 gravity;
+		float airdrag;
+		
+		bool visible;
+		bool visibleShadow;
+		bool visibleRefraction;
+		bool visibleReflection;
+		int allyTeam;
+		
+		float drawRadius;
+		int drawOrder;
+		
+		bool directional;
+		
+		// draw data
+		bool castShadow;
+		bool alwaysVisible;
+		
+		CColorMap* colorMap;
+		std::array<unsigned char, 4> color;
+		float3 interPos;
+		
+		std::array<float3, 4> bounds;
+		AtlasedTexture* texture;
+		
+		float3 anims;
+		float aprogress;
+		int createFrame;
+	};
+	std::vector<Data> d;
+};
+
+extern CSimpleParticleSystemCollection simpleParticleSystem;
 
 #endif // SIMPLE_PARTICLE_SYSTEM_H

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -167,8 +167,7 @@ private:
 	/// projectiles with a model
 	std::array<ModelRenderContainer<CProjectile>, MODELTYPE_CNT> modelRenderers;
 
-	/// used to render particle effects in back-to-front order
-	std::vector<CProjectile*> sortedProjectiles;
+    /// projectiles rendered last
 	std::vector<CProjectile*> unsortedProjectiles;
 
 	bool drawSorted = true;

--- a/rts/Sim/Projectiles/ExpGenSpawnable.h
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.h
@@ -18,9 +18,6 @@ class CExpGenSpawnable : public CWorldObject
 {
 	CR_DECLARE(CExpGenSpawnable)
 public:
-	using AllocFunc = CExpGenSpawnable*(*)();
-	using GetMemberInfoFunc = bool(*)(SExpGenSpawnableMemberInfo&);
-	using SpawnableTuple = std::tuple<std::string, GetMemberInfoFunc, AllocFunc>;
 
 	CExpGenSpawnable(const float3& pos, const float3& spd);
 
@@ -35,6 +32,10 @@ public:
 	//Memory handled in projectileHandler
 	static CExpGenSpawnable* CreateSpawnable(int spawnableID);
 	static TypedRenderBuffer<VA_TYPE_PROJ>& GetPrimaryRenderBuffer();
+	
+	int drawOrder = 0;
+	float sortDist = 0.0f;
+	
 protected:
 	CExpGenSpawnable();
 
@@ -55,8 +56,6 @@ protected:
 	float rotVel;
 
 	int createFrame;
-
-	static std::array<SpawnableTuple, 14> spawnables;
 };
 
 #endif //EXP_GEN_SPAWNABLE_H

--- a/rts/Sim/Projectiles/Projectile.cpp
+++ b/rts/Sim/Projectiles/Projectile.cpp
@@ -35,14 +35,12 @@ CR_REG_METADATA(CProjectile,
 	CR_MEMBER_BEGINFLAG(CM_Config),
 		CR_MEMBER(castShadow),
 		CR_MEMBER(dir),
-		CR_MEMBER(drawOrder),
 	CR_MEMBER_ENDFLAG(CM_Config),
 
 	CR_MEMBER(drawPos),
 
 	CR_MEMBER(myrange),
 	CR_MEMBER(mygravity),
-	CR_IGNORED(sortDist),
 	CR_MEMBER(sortDistOffset),
 
 	CR_MEMBER(validTextures),
@@ -182,7 +180,6 @@ bool CProjectile::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 
 	CHECK_MEMBER_INFO_BOOL(CProjectile, castShadow)
 	CHECK_MEMBER_INFO_FLOAT3(CProjectile, dir)
-	CHECK_MEMBER_INFO_INT(CProjectile, drawOrder)
 
 	return false;
 }

--- a/rts/Sim/Projectiles/Projectile.h
+++ b/rts/Sim/Projectiles/Projectile.h
@@ -118,10 +118,8 @@ public:
 	float myrange = 0.0f;          // used by WeaponProjectile::TraveledRange
 	float mygravity = 0.0f;
 
-	float sortDist = 0.0f;         // distance used for z-sorting when rendering
 	float sortDistOffset = 0.0f;   // an offset used for z-sorting
 
-	int drawOrder = 0;
 
 	inline static spring::mutex mut = {};
 protected:

--- a/rts/Sim/Projectiles/ProjectileHandler.cpp
+++ b/rts/Sim/Projectiles/ProjectileHandler.cpp
@@ -18,6 +18,7 @@
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Rendering/Env/Particles/Classes/NanoProjectile.h"
+#include "Rendering/Env/Particles/Classes/SimpleParticleSystem.h"
 #include "Sim/Projectiles/WeaponProjectiles/WeaponProjectile.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitDef.h"
@@ -326,6 +327,8 @@ void CProjectileHandler::Update()
 				std::stable_sort(fpc.begin(), fpc.end());
 			}
 		}
+		
+		simpleParticleSystem.Update();
 	}
 
 	// precache part of particles count calculation that else becomes very heavy
@@ -743,6 +746,7 @@ int CProjectileHandler::GetCurrentParticles() const
 		}
 	}
 	partCount += groundFlashes.size();
+	partCount += simpleParticleSystem.NumParticles();
 	return partCount;
 }
 


### PR DESCRIPTION
example of application of DDD to unsynced projectile with drawSorting done in render index buffer instead.
TODO:
- better integration with existing projectiles (use collections for each particle types?)
- prerequisite for ddd particles is to have depth sorting working. existing approach sorts `CProjectile*` . Other approaches are: a) sorting index buffer b) create separate `RenderBuffers` for each drawOrder layer and sort using `WBOIT` technique
- improve interface for sorting in RenderBuffer
- consider ECS
- use thin spawner class 