### PR TITLE
Drop LuaUtils::{Backup,Restore}

### DIFF
--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -34,7 +34,6 @@
 
 
 static const int maxDepth = 16;
-int LuaUtils::exportedDataSize = 0;
 
 Json::Value LuaUtils::LuaStackDumper::root  = {};
 
@@ -179,6 +178,12 @@ int LuaUtils::CopyData(lua_State* dst, lua_State* src, int count)
 /******************************************************************************/
 /******************************************************************************/
 
+// The functions below are not used anymore for anything in the engine.
+// There are left behind here disabled for archival purposes.
+#if 0
+
+int LuaUtils::exportedDataSize = 0;
+
 static bool BackupData(LuaUtils::DataDump& d, lua_State* src, int index, int depth);
 static bool RestoreData(const LuaUtils::DataDump& d, lua_State* dst, int depth);
 static bool BackupTable(LuaUtils::DataDump& d, lua_State* src, int index, int depth);
@@ -309,6 +314,7 @@ int LuaUtils::Restore(const std::vector<LuaUtils::DataDump>& backup, lua_State* 
 	return count;
 }
 
+#endif
 
 /******************************************************************************/
 /******************************************************************************/

--- a/rts/Lua/LuaUtils.h
+++ b/rts/Lua/LuaUtils.h
@@ -4,8 +4,6 @@
 #define LUA_UTILS_H
 
 #include <string>
-#include <vector>
-#include <unordered_map>
 
 #include "lib/fmt/printf.h"
 
@@ -79,21 +77,6 @@ class LuaUtils {
 		};
 
 	public:
-		struct DataDump {
-			int type;
-			std::string str;
-			float num;
-			bool bol;
-			std::vector<std::pair<DataDump, DataDump> > table;
-		};
-		struct ShallowDataDump {
-			int type;
-			union {
-				std::string *str;
-				float num;
-				bool bol;
-			} data;
-		};
 		// 0 and positive numbers are teams (not allyTeams)
 		enum UnitAllegiance {
 			AllUnits = -1,
@@ -102,11 +85,22 @@ class LuaUtils {
 			EnemyUnits = -4
 		};
 
-	public:
+// The functions below are not used anymore for anything in the engine.
+// There are left behind here disabled for archival purposes.
+#if 0
+		struct DataDump {
+			int type;
+			std::string str;
+			float num;
+			bool bol;
+			std::vector<std::pair<DataDump, DataDump> > table;
+		};
+
 		// Backups lua data into a c++ vector and restores it from it
 		static int exportedDataSize; //< performance stat
 		static int Backup(std::vector<DataDump> &backup, lua_State* src, int count);
 		static int Restore(const std::vector<DataDump> &backup, lua_State* dst);
+#endif
 
 		// Copies lua data between 2 lua_States
 		static int CopyData(lua_State* dst, lua_State* src, int count);


### PR DESCRIPTION
Those functions are not referenced anywhere at the moment so it should be save to drop them.