### PR TITLE
Switch from `inline static` to regular `static` to fix clang issue

### DIFF
--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -42,7 +42,7 @@
 
 static CGameHelper gGameHelper;
 CGameHelper* helper = &gGameHelper;
-
+std::vector<CGameHelper::TestUnitBuildSquareCache> CGameHelper::TestUnitBuildSquareCache::testUnitBuildSquareCache;
 
 void CGameHelper::Init()
 {

--- a/rts/Game/GameHelper.h
+++ b/rts/Game/GameHelper.h
@@ -296,7 +296,7 @@ private:
 		 * too quickly and not to stale the state for too long. */
 		static constexpr int CACHE_VALIDITY_PERIOD[] = { 1, GAME_SPEED / 5 };
 
-		inline static std::vector<TestUnitBuildSquareCache> testUnitBuildSquareCache;
+		static std::vector<TestUnitBuildSquareCache> testUnitBuildSquareCache;
 	};
 
 	std::array<std::vector<WaitingDamage>, 128> waitingDamages;


### PR DESCRIPTION
In C++20, std::vector::~vector() is constrexpr, due to the way clang instantiates constrexpr functions[1], anything like

struct D { std::vector<std::pair<D, D>> t; };
struct D { inline static std::vector<D> t; };

doesn't compile becuase D is not complete at the point of vector destructor intiailisation unlike in MSVC or GCC that do it at a different point of time.

[1]: https://github.com/llvm/llvm-project/issues/59966