### PR TITLE
Streamline finding docbook.xsl

### DIFF
--- a/rts/build/cmake/FindAsciiDoc.cmake
+++ b/rts/build/cmake/FindAsciiDoc.cmake
@@ -44,12 +44,9 @@ find_file(DOCBOOK_XSL
 		xml/docbook/stylesheet/nwalsh/1.79.0/manpages
 		sgml/docbook/xsl-stylesheets/manpages
 		xsl/docbook/manpages
+  		xml/docbook/xsl-stylesheets-*/manpages
 	DOC "DocBook XSL Style-Sheet"
 	)
-
-IF    (NOT DOCBOOK_XSL)
-	file(GLOB DOCBOOK_XSL / /usr/share/xml/docbook/xsl-stylesheets-*/manpages/docbook.xsl)
-ENDIF (NOT DOCBOOK_XSL)
 
 # handle the QUIETLY and REQUIRED arguments and set ASCIIDOC_FOUND to TRUE if
 # all listed variables are TRUE


### PR DESCRIPTION
There was a book that could result in a list of items getting found by `GLOB` which would break the call to `make_manpages.sh` because it expects a single items.

For instance, my system has
usr/share/xml/docbook/xsl-stylesheets-1.79.2-nons/manpages/docbook.xsl usr/share/xml/docbook/xsl-stylesheets-1.79.2/manpages/docbook.xsl and it would output both.

This will instead use the pre-existing `find_file()` and remove the second mechanism.