### PR TITLE
feature: add Patrolling FILTER to select command

### DIFF
--- a/doc/site/articles/select-command.markdown
+++ b/doc/site/articles/select-command.markdown
@@ -84,6 +84,10 @@ Here are the filters. Note that "units" generally means both buildings and mobil
 
   Keep only units that currently have a **Guard** order.
 
+### `Patrolling`
+
+  Keep only units that currently have a **Patrol** order.
+
 ### `IdMatches_<string>`
 
   Keep only units whose internal name (unitDef name) matches `<string>` **exactly**.

--- a/rts/Game/UI/SelectionKeyHandler.cpp
+++ b/rts/Game/UI/SelectionKeyHandler.cpp
@@ -124,6 +124,7 @@ namespace {
 	DECLARE_FILTER(Idle, unit->commandAI->commandQue.empty())
 	DECLARE_FILTER(Waiting, !unit->commandAI->commandQue.empty() && (unit->commandAI->commandQue.front().GetID() == CMD_WAIT))
 	DECLARE_FILTER(Guarding, !unit->commandAI->commandQue.empty() && (unit->commandAI->commandQue.front().GetID() == CMD_GUARD))
+	DECLARE_FILTER(Patrolling, !unit->commandAI->commandQue.empty() && (unit->commandAI->commandQue.front().GetID() == CMD_PATROL))
 	DECLARE_FILTER(InHotkeyGroup, unit->GetGroup() != nullptr)
 	DECLARE_FILTER(Radar, (unit->radarRadius > 0 || unit->sonarRadius > 0))
 	DECLARE_FILTER(Jammer, (unit->jammerRadius > 0))


### PR DESCRIPTION
This PR adds support for filtering units based on whether they are patrolling or not when using select commands.

The benefit of this change is that it becomes possible to exclude units with long-running patrol tasks (e.g., defending expansions without LLTs) from select commands. For example, `AllMap+_Not_Builder_Not_Building_Not_Patrolling+_ClearSelection_SelectAll+`.

For some small addition context/discussion, see [this](https://discord.com/channels/549281623154229250/1018861299939168288/1169735003630997524) Discord thread.