### PR TITLE
check for null in pathmanager

### DIFF
--- a/rts/Sim/Path/HAPFS/PathManager.cpp
+++ b/rts/Sim/Path/HAPFS/PathManager.cpp
@@ -692,7 +692,7 @@ float3 CPathManager::NextWayPoint(
 	}
 
 	MultiPath* multiPath = localMultiPath.moveDef != nullptr ? &localMultiPath : nullptr;
-	if (multiPath->moveDef == nullptr)
+	if (!multiPath || multiPath->moveDef == nullptr)
 		return noPathPoint;
 
 	// if (numRetries > MAX_PATH_REFINEMENT_DEPTH)


### PR DESCRIPTION
`multiPath` can be assigned to `nullptr` in the line directly above, then causing a segfault on dereference.