### PR TITLE
Fix compatibility for old blank map gen

### DIFF
--- a/doc/site/changelogs/running-changelog.markdown
+++ b/doc/site/changelogs/running-changelog.markdown
@@ -40,6 +40,8 @@ No changes yet, but these will happen in the future and possibly break things.
 but if you prefer not to have to add processing later you might want to change to `maxAcc` and `maxDec` respectively (which will stay elmo/frame).
 * the `CSphereParticleSpawner` (alias `simpleparticlespawner`) CEG class is scheduled for removal. It can be entirely drop-in replaced with `CSimpleParticleSystem` (alias `simpleparticlesystem`)
 since it has always had the same behaviour, just different internal implementation. Known games using the class will receive PRs before this happens.
+* there are now explicit facilities for generating a blank map (see below). Existing "random" map generator (that always produced a blank map) stays as-is,
+but may be repurposed into a "real" random map generator sometime in the future (not immediately planned though).
 
 # QTPFS
 
@@ -248,6 +250,11 @@ An explicit numerical value always sets the timer to that many seconds.
 * added the following `GL` constants for use in `gl.BlendEquation`: `FUNC_ADD`, `FUNC_SUBTRACT`, `FUNC_REVERSE_SUBTRACT`, `MIN` and `MAX`.
 * added `Spring.GetWindowDisplayMode() → number width, number height, number bitsPerPixel, number refreshRateHz, string pixelFormatName`.
 The pixel format name is something like, for example, "SDL_PIXELFORMAT_RGB565".
+
+### Blank map generation
+* new way to specify blank map colour: `blank_map_color_{r,g,b}`, number 0-255.
+* a new start-script entry, `InitBlank` (at root level). Alias for existing `MapSeed`.
+* new built-in mapoptions, `blank_map_x` and `blank_map_y`, aliases for existing `new_map_x/y`.
 
 ### Weapon fixes
 * fix `Cannon` type weapons aiming at the (0, 0) corner of the world if they can't find a physical firing solution due to target leading

--- a/rts/Game/GameSetup.cpp
+++ b/rts/Game/GameSetup.cpp
@@ -585,7 +585,13 @@ bool CGameSetup::Init(const std::string& buf)
 	}
 	#endif
 
-	file.GetDef(initBlank, "0", "GAME\\InitBlank");
+	/* Don't be afraid to reuse MapSeed for something sensible if you're
+	 * implementing a proper random map generator. It's just used here
+	 * since historically the "random" map generator produced blank maps. */
+	int legacyMapSeed;
+	file.GetTDef(legacyMapSeed, 0, "GAME\\MapSeed");
+
+	file.GetTDef(initBlank, bool (legacyMapSeed != 0), "GAME\\InitBlank");
 
 	file.GetTDef(fixedRNGSeed, unsigned(0), "GAME\\FixedRNGSeed"); // 0 means use random seed
 	gameID      = file.SGetValueDef("",  "GAME\\GameID");

--- a/rts/Map/Generation/BlankMapGenerator.cpp
+++ b/rts/Map/Generation/BlankMapGenerator.cpp
@@ -31,8 +31,9 @@ CBlankMapGenerator::CBlankMapGenerator(const CGameSetup* setup)
 		LOG_L(L_WARNING, "[MapGen::%s] modOpt<%s,%s>", __func__, modOpt.first.c_str(), modOpt.second.c_str());
 	}
 
-	const std::string* blankMapXStr = mapOpts.try_get("blank_map_x");
-	const std::string* blankMapYStr = mapOpts.try_get("blank_map_y");
+	// `new_map` are legacy keys; see the comment at InitBlank in GameSetup
+	const std::string* blankMapXStr = mapOpts.try_get("blank_map_x") ?: mapOpts.try_get("new_map_x");
+	const std::string* blankMapYStr = mapOpts.try_get("blank_map_y") ?: mapOpts.try_get("new_map_y");
 	const std::string* blankMapHeightStr = mapOpts.try_get("blank_map_height");
 
 	if (blankMapXStr != nullptr && blankMapYStr != nullptr) {

--- a/rts/Map/Generation/BlankMapGenerator.cpp
+++ b/rts/Map/Generation/BlankMapGenerator.cpp
@@ -21,6 +21,7 @@ CBlankMapGenerator::CBlankMapGenerator(const CGameSetup* setup)
 	: setup(setup)
 	, mapSize(1, 1)
 	, mapHeight(50)
+	, mapColor(0x00, 0xFF, 0x00)
 {
 	const auto& mapOpts = setup->GetMapOptionsCont();
 
@@ -60,6 +61,17 @@ CBlankMapGenerator::CBlankMapGenerator(const CGameSetup* setup)
 		} catch (...) {
 			// leaving default value
 		}
+	}
+
+	const auto blankMapR = mapOpts.try_get("blank_map_color_r");
+	const auto blankMapG = mapOpts.try_get("blank_map_color_g");
+	const auto blankMapB = mapOpts.try_get("blank_map_color_b");
+	if (blankMapR && blankMapG && blankMapB) {
+		try {
+			std::get <0> (mapColor) = std::stoi(*blankMapR);
+			std::get <1> (mapColor) = std::stoi(*blankMapG);
+			std::get <2> (mapColor) = std::stoi(*blankMapB);
+		} catch (...) { }
 	}
 }
 
@@ -233,9 +245,9 @@ void CBlankMapGenerator::GenerateSMT(CVirtualFile* fileSMT)
 	int32_t tilePos = 0;
 	for (int32_t x = 0; x < TILE_SIZE; x++) {
 		for (int32_t y = 0; y < TILE_SIZE; y++) {
-			tileData[tilePos++] = 0;
-			tileData[tilePos++] = 0xFF;
-			tileData[tilePos++] = 0;
+			tileData[tilePos++] = std::get <0> (mapColor);
+			tileData[tilePos++] = std::get <1> (mapColor);
+			tileData[tilePos++] = std::get <2> (mapColor);
 		}
 	}
 

--- a/rts/Map/Generation/BlankMapGenerator.h
+++ b/rts/Map/Generation/BlankMapGenerator.h
@@ -37,6 +37,8 @@ private:
 	int mapHeight;
 	std::string mapDescription;
 	std::vector<int2> startPositions;
+
+	std::tuple <uint8_t, uint8_t, uint8_t> mapColor;
 };
 
 #endif // _BLANK_MAP_GENERATOR_H_


### PR DESCRIPTION
The old keys can still be reused for a "proper" random mapgen in the future, but no reason to break existing projects until then.