### PR TITLE
Skip tracy::LuaRemove when TRACY_ENABLE is set

### DIFF
--- a/rts/Lua/LuaParser.cpp
+++ b/rts/Lua/LuaParser.cpp
@@ -236,7 +236,9 @@ bool LuaParser::Execute()
 	char errorBuf[4096] = {0};
 	int errorNum = 0;
 
+#ifndef TRACY_ENABLE
 	tracy::LuaRemove(code.data());
+#endif
 	if ((errorNum = luaL_loadbuffer(L, code.c_str(), code.size(), codeLabel.c_str())) != 0) {
 		SNPRINTF(errorBuf, sizeof(errorBuf), "[loadbuf] error %d (\"%s\") in %s", errorNum, lua_tostring(L, -1), codeLabel.c_str());
 		LUA_CLOSE(&L);
@@ -643,7 +645,9 @@ int LuaParser::Include(lua_State* L)
  		lua_error(L);
 	}
 
+#ifndef TRACY_ENABLE
 	tracy::LuaRemove(code.data());
+#endif
 	int error = luaL_loadbuffer(L, code.c_str(), code.size(), filename.c_str());
 	if (error != 0) {
 		char buf[1024];


### PR DESCRIPTION
We avoid calling tracy::LuaRemove which removes tracy instrumentation in Lua scripts when TRACY_ENABLE is set.

Does not affect release builds, see rts/lib/CMakeLists.txt:76.