### PR TITLE
Use axis separated blur algoritm

### DIFF
--- a/rts/Rendering/Textures/Bitmap.cpp
+++ b/rts/Rendering/Textures/Bitmap.cpp
@@ -630,74 +630,95 @@ void TBitmapAction<T, ch>::Renormalize(const float3& newCol)
 template<typename T, uint32_t ch>
 void TBitmapAction<T, ch>::Blur(int iterations, float weight)
 {
-	static constexpr float blurkernel[9] = {
-		1.0f / 16.0f, 2.0f / 16.0f, 1.0f / 16.0f,
-		2.0f / 16.0f, 4.0f / 16.0f, 2.0f / 16.0f,
-		1.0f / 16.0f, 2.0f / 16.0f, 1.0f / 16.0f
+	SCOPED_TIMER("Bitmap::Blur");
+
+	// We use an axis-separated blur algorithm. Applies blurkernel in both the x
+	// and y dimensions. This 3x1 blur kernel is equivalent to a 3x3 kernel in
+	// both the x and y dimensions.
+	// See more info
+	// https://www.rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
+	static constexpr float blurkernel[3] = {
+		1.0f / 4.0f, 2.0f / 4.0f, 1.0f / 4.0f
 	};
 
+	// Two temporaries are required in order to perform axis separated gaussian
+	// blur with additional weighting from the source pixel. See the comment block
+	// below.
 	CBitmap tmp(nullptr, bmp->xsize, bmp->ysize, bmp->channels, bmp->dataType);
+	CBitmap tmp2(nullptr, bmp->xsize, bmp->ysize, bmp->channels, bmp->dataType);
 
-	CBitmap* src =  bmp;
-	CBitmap* dst = &tmp;
-
-	//don't use "this" here
-	auto srcAction = BitmapAction::GetBitmapAction(src);
-	auto dstAction = BitmapAction::GetBitmapAction(dst);
+	std::array<CBitmap*, 3> bitmaps = {bmp, &tmp, &tmp2};
+	std::array<std::unique_ptr<BitmapAction>, 3> actions = {
+		BitmapAction::GetBitmapAction(bitmaps[0]),
+		BitmapAction::GetBitmapAction(bitmaps[1]),
+		BitmapAction::GetBitmapAction(bitmaps[2])
+	};
 
 	using ThisType = decltype(this);
 
 	for (int iter = 0; iter < iterations; ++iter) {
-		for_mt(0, src->ysize, [&](const int y) {
-			for (int x = 0; x < src->xsize; x++) {
-				int yBaseOffset = (y * src->xsize);
-				for (int a = 0; a < src->channels; a++) {
+		for(int dimension = 0; dimension < 2; ++dimension) {
 
-					///////////////////////////////////////
-					float fragment = 0.0f;
+			CBitmap* src = bitmaps[dimension];
+			CBitmap* dst = bitmaps[dimension + 1];
 
-					for (int i = 0; i < 9; ++i) {
-						int yoffset = (i / 3) - 1;
-						int xoffset = (i - (yoffset + 1) * 3) - 1;
+			auto& srcAction = actions[dimension];
+			auto& dstAction = actions[dimension + 1];
 
-						const int tx = x + xoffset;
-						const int ty = y + yoffset;
+			for_mt(0, src->ysize, [&](const int y) {
+				for (int x = 0; x < src->xsize; x++) {
+					int yBaseOffset = (y * src->xsize);
+					for (int a = 0; a < src->channels; a++) {
+						float fragment = 0.0f;
 
-						xoffset *= ((tx >= 0) && (tx < src->xsize));
-						yoffset *= ((ty >= 0) && (ty < src->ysize));
+						for (int i = 0; i < 3; ++i) {
+							int yoffset = dimension == 1 ? (i - 1) : 0;
+							int xoffset = dimension == 0 ? (i - 1) : 0;
 
-						const int offset = (yoffset * src->xsize + xoffset);
+							const int tx = x + xoffset;
+							const int ty = y + yoffset;
 
-						auto& srcChannel = static_cast<ThisType>(srcAction.get())->GetRef(yBaseOffset + x + offset, a);
+							xoffset *= ((tx >= 0) && (tx < src->xsize));
+							yoffset *= ((ty >= 0) && (ty < src->ysize));
 
-						const float thisWeight = mix(1.0f, weight, i == 4);
-						fragment += (thisWeight * blurkernel[i] * srcChannel);
+							const int offset = (yoffset * src->xsize + xoffset);
+
+							auto& srcChannel = static_cast<ThisType>(srcAction.get())->GetRef(yBaseOffset + x + offset, a);
+
+							fragment += (blurkernel[i] * srcChannel);
+						}
+
+						// The original blur algorithm is not a gaussian blur, as it weights
+						// the source pixel more heavily by `weight`. To replicate the
+						// same effect with axis-separated gaussian blur, we use two
+						// temporaries for each complete blur pass. bitmaps[1] stores the
+						// result of blurring bitmaps[0] in the x-axis and bitmap[2] the
+						// result of blurring bitmaps[1] in the y-axis. Finally, at the end
+						// of the blur pass we add the additional weight from the source
+						// pixel in bitmap[0] to the final result in bitmap[2].
+						if (dimension == 1) {
+							auto& srcChannel = static_cast<ThisType>(actions[0].get())->GetRef(yBaseOffset + x, a);
+
+							fragment += (blurkernel[1] * blurkernel[1]) * (weight - 1.0f) * srcChannel;
+						}
+
+						auto& dstChannel = static_cast<ThisType>(dstAction.get())->GetRef(yBaseOffset + x, a);
+
+						if constexpr (std::is_same_v<ChanType, float>) {
+							dstChannel = static_cast<ChanType>(std::max(fragment, 0.0f));
+						}
+						else {
+							dstChannel = static_cast<ChanType>(std::clamp(fragment, 0.0f, static_cast<float>(GetMaxNormValue())));
+						}
 					}
-
-					auto& dstChannel = static_cast<ThisType>(dstAction.get())->GetRef(yBaseOffset + x, a);
-
-					if constexpr (std::is_same_v<ChanType, float>) {
-						dstChannel = static_cast<ChanType>(std::max(fragment, 0.0f));
-					}
-					else {
-						dstChannel = static_cast<ChanType>(std::clamp(fragment, 0.0f, static_cast<float>(GetMaxNormValue())));
-					}
-					///////////////////////////////////////
 				}
-			}
-		});
+			});
+		}
 
-		std::swap(srcAction, dstAction);
-		std::swap(src, dst);
+		std::swap(actions[0], actions[2]);
+		std::swap(bitmaps[0], bitmaps[2]);
 	}
 
-	// if dst points to temporary, we are done
-	// otherwise need to perform one more swap
-	// (e.g. if iterations=1)
-	if (dst != bmp)
-		return;
-
-	std::swap(src, dst);
 }
 
 template<typename T, uint32_t ch>


### PR DESCRIPTION
Gaussian blur can be axis separated to decrease the number of computation needed per blur pass. A significant portion of game load time is used blurring font shadow textures. Using the cheaper blur algorithm saves a minor amount of time in every load screen.

Note that performance is not significantly improved as the original blur kernel is a small 3x3 kernel - axis separation sees more significant performance improvements the larger the original kernel.

See https://github.com/beyond-all-reason/spring/issues/1126 for more details.

Saves about ~0.3s / 2.6s on the main thread in loading screens.

Original Blur
![Screenshot from 2023-12-15 06-25-40](https://github.com/beyond-all-reason/spring/assets/2730943/9504a6c3-2bff-4f56-918a-bfbb4e6ead72)

Axis Separated
![Screenshot from 2023-12-15 06-26-35](https://github.com/beyond-all-reason/spring/assets/2730943/618ec077-3609-4656-8618-4b0685820d90)

Note that the blur algorithm is also run on other threads during loads. Non-main thread blurs are also sped up, decreasing CPU usage (but not overall load times).

There is no visual difference

Original Blur
![Screenshot from 2023-12-15 06-24-38](https://github.com/beyond-all-reason/spring/assets/2730943/8f3d5a5f-25b9-4d21-8ab2-a39449065173)

Axis Separated
![Screenshot from 2023-12-15 06-19-29](https://github.com/beyond-all-reason/spring/assets/2730943/87ce482d-7a0a-4eff-ac20-a828e77ec761)
