### PR TITLE
Use lua_createtable when size of table is known.

### DIFF
--- a/rts/Lua/LuaFeatureDefs.cpp
+++ b/rts/Lua/LuaFeatureDefs.cpp
@@ -269,7 +269,7 @@ static int Pairs(lua_State* L)
 static int CustomParamsTable(lua_State* L, const void* data)
 {
 	const spring::unordered_map<std::string, std::string>& params = *((const spring::unordered_map<std::string, std::string>*)data);
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/params.size());
 
 	for (const auto& param: params) {
 		lua_pushsstring(L, param.first);

--- a/rts/Lua/LuaFeatureDefs.cpp
+++ b/rts/Lua/LuaFeatureDefs.cpp
@@ -269,7 +269,7 @@ static int Pairs(lua_State* L)
 static int CustomParamsTable(lua_State* L, const void* data)
 {
 	const spring::unordered_map<std::string, std::string>& params = *((const spring::unordered_map<std::string, std::string>*)data);
-	lua_createtable(L, /*narr=*/0, /*nrec=*/params.size());
+	lua_createtable(L, 0, params.size());
 
 	for (const auto& param: params) {
 		lua_pushsstring(L, param.first);

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2275,7 +2275,7 @@ void CLuaHandle::ViewResize()
 
 	const int winPosY_bl = globalRendering->screenSizeY - globalRendering->winSizeY - globalRendering->winPosY; //! origin BOTTOMLEFT
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/16);
 	LuaPushNamedNumber(L, "screenSizeX", globalRendering->screenSizeX);
 	LuaPushNamedNumber(L, "screenSizeY", globalRendering->screenSizeY);
 	LuaPushNamedNumber(L, "screenPosX", globalRendering->screenPosX);
@@ -3355,7 +3355,7 @@ bool CLuaHandle::GameSetup(const string& state, bool& ready,
 	lua_pushsstring(L, state);
 	lua_pushboolean(L, ready);
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/playerStates.size(), /*nrec=*/0);
 
 	for (const auto& playerState: playerStates) {
 		lua_pushsstring(L, playerState.second);
@@ -3624,7 +3624,7 @@ void CLuaHandle::CollectGarbage(bool forced)
 bool CLuaHandle::AddBasicCalls(lua_State* L)
 {
 	HSTR_PUSH(L, "Script");
-	lua_newtable(L); {
+	lua_createtable(L, /*narr=*/0, /*nrec=*/17); {
 		HSTR_PUSH_CFUNC(L, "Kill",            KillActiveHandle);
 		HSTR_PUSH_CFUNC(L, "UpdateCallIn",    CallOutUpdateCallIn);
 		HSTR_PUSH_CFUNC(L, "GetName",         CallOutGetName);
@@ -3768,7 +3768,7 @@ int CLuaHandle::CallOutGetCallInList(lua_State* L)
 	lua_createtable(L, 0, eventList.size());
 	for (const auto& event : eventList) {
 		lua_pushsstring(L, event);
-		lua_newtable(L); {
+		lua_createtable(L, /*narr=*/0, /*nrec=*/2); {
 			lua_pushliteral(L, "unsynced");
 			lua_pushboolean(L, eventHandler.IsUnsynced(event));
 			lua_rawset(L, -3);

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2275,7 +2275,7 @@ void CLuaHandle::ViewResize()
 
 	const int winPosY_bl = globalRendering->screenSizeY - globalRendering->winSizeY - globalRendering->winPosY; //! origin BOTTOMLEFT
 
-	lua_createtable(L, /*narr=*/0, /*nrec=*/16);
+	lua_createtable(L, 0, 16);
 	LuaPushNamedNumber(L, "screenSizeX", globalRendering->screenSizeX);
 	LuaPushNamedNumber(L, "screenSizeY", globalRendering->screenSizeY);
 	LuaPushNamedNumber(L, "screenPosX", globalRendering->screenPosX);
@@ -3355,7 +3355,7 @@ bool CLuaHandle::GameSetup(const string& state, bool& ready,
 	lua_pushsstring(L, state);
 	lua_pushboolean(L, ready);
 
-	lua_createtable(L, /*narr=*/playerStates.size(), /*nrec=*/0);
+	lua_createtable(L, playerStates.size(), 0);
 
 	for (const auto& playerState: playerStates) {
 		lua_pushsstring(L, playerState.second);
@@ -3624,7 +3624,7 @@ void CLuaHandle::CollectGarbage(bool forced)
 bool CLuaHandle::AddBasicCalls(lua_State* L)
 {
 	HSTR_PUSH(L, "Script");
-	lua_createtable(L, /*narr=*/0, /*nrec=*/17); {
+	lua_createtable(L, 0, 17); {
 		HSTR_PUSH_CFUNC(L, "Kill",            KillActiveHandle);
 		HSTR_PUSH_CFUNC(L, "UpdateCallIn",    CallOutUpdateCallIn);
 		HSTR_PUSH_CFUNC(L, "GetName",         CallOutGetName);
@@ -3768,7 +3768,7 @@ int CLuaHandle::CallOutGetCallInList(lua_State* L)
 	lua_createtable(L, 0, eventList.size());
 	for (const auto& event : eventList) {
 		lua_pushsstring(L, event);
-		lua_createtable(L, /*narr=*/0, /*nrec=*/2); {
+		lua_createtable(L, 0, 2); {
 			lua_pushliteral(L, "unsynced");
 			lua_pushboolean(L, eventHandler.IsUnsynced(event));
 			lua_rawset(L, -3);

--- a/rts/Lua/LuaInterCall.cpp
+++ b/rts/Lua/LuaInterCall.cpp
@@ -108,7 +108,7 @@ static int PushCallHandler(lua_State* L, int luaInstance, const string& name)
 	int* ptr = (int*) lua_newuserdata(L, sizeof(int));
 	*ptr = luaInstance;
 	{ // create metatable of the userdata
-		lua_createtable(L, /*narr=*/0, /*nrec=*/3); {
+		lua_createtable(L, 0, 3); {
 			lua_pushliteral(L, "__index");
 			lua_pushvalue(L, -3); //userdata
 			lua_pushcclosure(L,  IndexHook, 1);

--- a/rts/Lua/LuaInterCall.cpp
+++ b/rts/Lua/LuaInterCall.cpp
@@ -108,7 +108,7 @@ static int PushCallHandler(lua_State* L, int luaInstance, const string& name)
 	int* ptr = (int*) lua_newuserdata(L, sizeof(int));
 	*ptr = luaInstance;
 	{ // create metatable of the userdata
-		lua_newtable(L); {
+		lua_createtable(L, /*narr=*/0, /*nrec=*/3); {
 			lua_pushliteral(L, "__index");
 			lua_pushvalue(L, -3); //userdata
 			lua_pushcclosure(L,  IndexHook, 1);

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -5029,11 +5029,10 @@ static void PushPixelData(lua_State* L, int fSize, const float*& data)
 		lua_pushnumber(L, *data);
 		data++;
 	} else {
-		lua_newtable(L);
+		lua_createtable(L, /*narr=*/fSize, /*nrec=*/0);
 		for (int e = 1; e <= fSize; e++) {
-			lua_pushnumber(L, e);
 			lua_pushnumber(L, *data);
-			lua_rawset(L, -3);
+			lua_rawseti(L, -2, e);
 			data++;
 		}
 	}

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -5029,7 +5029,7 @@ static void PushPixelData(lua_State* L, int fSize, const float*& data)
 		lua_pushnumber(L, *data);
 		data++;
 	} else {
-		lua_createtable(L, /*narr=*/fSize, /*nrec=*/0);
+		lua_createtable(L, fSize, 0);
 		for (int e = 1; e <= fSize; e++) {
 			lua_pushnumber(L, *data);
 			lua_rawseti(L, -2, e);

--- a/rts/Lua/LuaPathFinder.cpp
+++ b/rts/Lua/LuaPathFinder.cpp
@@ -87,10 +87,10 @@ int LuaPathFinder::PushPathNodes(lua_State* L, const int pathID)
 	const int startCount = starts.size();
 
 	{
-		lua_newtable(L);
+		lua_createtable(L, /*narr=*/pointCount, /*nrec=*/0);
 
 		for (int i = 0; i < pointCount; i++) {
-			lua_newtable(L); {
+			lua_createtable(L, /*narr=*/3, /*nrec=*/0); {
 				const float3& p = points[i];
 				lua_pushnumber(L, p.x); lua_rawseti(L, -2, 1);
 				lua_pushnumber(L, p.y); lua_rawseti(L, -2, 2);
@@ -101,7 +101,7 @@ int LuaPathFinder::PushPathNodes(lua_State* L, const int pathID)
 	}
 
 	{
-		lua_newtable(L);
+		lua_createtable(L, /*narr=*/startCount, /*nrec=*/0);
 
 		for (int i = 0; i < startCount; i++) {
 			lua_pushnumber(L, starts[i] + 1);

--- a/rts/Lua/LuaPathFinder.cpp
+++ b/rts/Lua/LuaPathFinder.cpp
@@ -87,10 +87,10 @@ int LuaPathFinder::PushPathNodes(lua_State* L, const int pathID)
 	const int startCount = starts.size();
 
 	{
-		lua_createtable(L, /*narr=*/pointCount, /*nrec=*/0);
+		lua_createtable(L, pointCount, 0);
 
 		for (int i = 0; i < pointCount; i++) {
-			lua_createtable(L, /*narr=*/3, /*nrec=*/0); {
+			lua_createtable(L, 3, 0); {
 				const float3& p = points[i];
 				lua_pushnumber(L, p.x); lua_rawseti(L, -2, 1);
 				lua_pushnumber(L, p.y); lua_rawseti(L, -2, 2);
@@ -101,7 +101,7 @@ int LuaPathFinder::PushPathNodes(lua_State* L, const int pathID)
 	}
 
 	{
-		lua_createtable(L, /*narr=*/startCount, /*nrec=*/0);
+		lua_createtable(L, startCount, 0);
 
 		for (int i = 0; i < startCount; i++) {
 			lua_pushnumber(L, starts[i] + 1);

--- a/rts/Lua/LuaRules.cpp
+++ b/rts/Lua/LuaRules.cpp
@@ -99,12 +99,12 @@ bool CLuaRules::AddUnsyncedCode(lua_State* L)
 	lua_getglobal(L, "Spring");
 
 	lua_pushliteral(L, "UnitRendering");
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/17);
 	LuaObjectRendering<LUAOBJ_UNIT>::PushEntries(L);
 	lua_rawset(L, -3);
 
 	lua_pushliteral(L, "FeatureRendering");
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/17);
 	LuaObjectRendering<LUAOBJ_FEATURE>::PushEntries(L);
 	lua_rawset(L, -3);
 

--- a/rts/Lua/LuaRules.cpp
+++ b/rts/Lua/LuaRules.cpp
@@ -99,12 +99,12 @@ bool CLuaRules::AddUnsyncedCode(lua_State* L)
 	lua_getglobal(L, "Spring");
 
 	lua_pushliteral(L, "UnitRendering");
-	lua_createtable(L, /*narr=*/0, /*nrec=*/17);
+	lua_createtable(L, 0, 17);
 	LuaObjectRendering<LUAOBJ_UNIT>::PushEntries(L);
 	lua_rawset(L, -3);
 
 	lua_pushliteral(L, "FeatureRendering");
-	lua_createtable(L, /*narr=*/0, /*nrec=*/17);
+	lua_createtable(L, 0, 17);
 	LuaObjectRendering<LUAOBJ_FEATURE>::PushEntries(L);
 	lua_rawset(L, -3);
 

--- a/rts/Lua/LuaShaders.cpp
+++ b/rts/Lua/LuaShaders.cpp
@@ -892,11 +892,11 @@ int LuaShaders::GetActiveUniforms(lua_State* L)
 	if (prog == nullptr)
 		return 0;
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/prog->activeUniforms.size(), /*nrec=*/0);
 
 	GLint i = 0;
 	for (const auto& [name, au] : prog->activeUniforms) {
-		lua_newtable(L); {
+		lua_createtable(L, /*narr=*/0, /*nrec=*/5); {
 			HSTR_PUSH_STRING(L, "name"    , name);
 			HSTR_PUSH_STRING(L, "type"    , UniformTypeString(au.type));
 			HSTR_PUSH_NUMBER(L, "length"  , name.size());

--- a/rts/Lua/LuaShaders.cpp
+++ b/rts/Lua/LuaShaders.cpp
@@ -892,11 +892,11 @@ int LuaShaders::GetActiveUniforms(lua_State* L)
 	if (prog == nullptr)
 		return 0;
 
-	lua_createtable(L, /*narr=*/prog->activeUniforms.size(), /*nrec=*/0);
+	lua_createtable(L, prog->activeUniforms.size(), 0);
 
 	GLint i = 0;
 	for (const auto& [name, au] : prog->activeUniforms) {
-		lua_createtable(L, /*narr=*/0, /*nrec=*/5); {
+		lua_createtable(L, 0, 5); {
 			HSTR_PUSH_STRING(L, "name"    , name);
 			HSTR_PUSH_STRING(L, "type"    , UniformTypeString(au.type));
 			HSTR_PUSH_NUMBER(L, "length"  , name.size());

--- a/rts/Lua/LuaSyncedMoveCtrl.cpp
+++ b/rts/Lua/LuaSyncedMoveCtrl.cpp
@@ -34,7 +34,7 @@
 bool LuaSyncedMoveCtrl::PushMoveCtrl(lua_State* L)
 {
 	lua_pushliteral(L, "MoveCtrl");
-	lua_createtable(L, /*narr=*/0, /*nrec=*/32);
+	lua_createtable(L, 0, 32);
 
 	REGISTER_LUA_CFUNC(IsEnabled);
 

--- a/rts/Lua/LuaSyncedMoveCtrl.cpp
+++ b/rts/Lua/LuaSyncedMoveCtrl.cpp
@@ -34,7 +34,7 @@
 bool LuaSyncedMoveCtrl::PushMoveCtrl(lua_State* L)
 {
 	lua_pushliteral(L, "MoveCtrl");
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/32);
 
 	REGISTER_LUA_CFUNC(IsEnabled);
 

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -1440,9 +1440,9 @@ int LuaSyncedRead::GetSideData(lua_State* L)
 	}
 	{
 		const unsigned int sideCount = sideParser.GetCount();
-		lua_createtable(L, /*narr=*/sideCount, /*nrec=*/0);
+		lua_createtable(L, sideCount, 0);
 		for (unsigned int i = 0; i < sideCount; i++) {
-			lua_createtable(L, /*narr=*/0, /*nrec=*/3); {
+			lua_createtable(L, 0, 3); {
 				LuaPushNamedString(L, "sideName",  sideParser.GetSideName(i));
 				LuaPushNamedString(L, "caseName",  sideParser.GetCaseName(i));
 				LuaPushNamedString(L, "startUnit", sideParser.GetStartUnit(i));
@@ -1970,12 +1970,12 @@ int LuaSyncedRead::GetTeamStatsHistory(lua_State* L)
 
 	std::advance(it, start);
 
-	lua_createtable(L, /*narr=*/max(0, end - start), /*nrec=*/0);
+	lua_createtable(L, max(0, end - start), 0);
 	if (statCount > 0) {
 		int count = 1;
 		for (int i = start; i <= end; ++i, ++it) {
 			const TeamStatistics& stats = *it;
-			lua_createtable(L, /*narr=*/0, /*nrec=*/21); {
+			lua_createtable(L, 0, 21); {
 				if (i+1 == teamStats.size()) {
 					// the `stats.frame` var indicates the frame when a new entry needs to get added,
 					// for the most recent stats entry this lies obviously in the future,
@@ -2193,7 +2193,7 @@ int LuaSyncedRead::GetAIInfo(lua_State* L)
 		lua_pushsstring(L, aiData->shortName);
 		lua_pushsstring(L, aiData->version);
 
-		lua_createtable(L, /*narr=*/0, /*nrec=*/aiData->options.size());
+		lua_createtable(L, 0, aiData->options.size());
 
 		for (const auto& option: aiData->options) {
 			lua_pushsstring(L, option.first);
@@ -5399,7 +5399,7 @@ int LuaSyncedRead::GetUnitDefDimensions(lua_State* L)
 
 	const S3DModel& m = *model;
 	const float3& mid = model->relMidPos;
-	lua_createtable(L, /*narr=*/0, /*nrec=*/11);
+	lua_createtable(L, 0, 11);
 	HSTR_PUSH_NUMBER(L, "height", m.height);
 	HSTR_PUSH_NUMBER(L, "radius", m.radius);
 	HSTR_PUSH_NUMBER(L, "midx",   mid.x);
@@ -5457,7 +5457,7 @@ int LuaSyncedRead::GetUnitMoveTypeData(lua_State* L)
 
 	AMoveType* amt = unit->moveType;
 
-	lua_createtable(L, /*narr=*/0, /*nrec=*/26);
+	lua_createtable(L, 0, 26);
 	HSTR_PUSH_NUMBER(L, "maxSpeed", amt->GetMaxSpeed() * GAME_SPEED);
 	HSTR_PUSH_NUMBER(L, "maxWantedSpeed", amt->GetMaxWantedSpeed() * GAME_SPEED);
 	HSTR_PUSH_NUMBER(L, "goalx", amt->goalPos.x);
@@ -5828,7 +5828,7 @@ int LuaSyncedRead::GetFactoryBuggerOff(lua_State* L)
 static void PackFactoryCounts(lua_State* L,
                               const CCommandQueue& q, int count, bool noCmds)
 {
-	lua_createtable(L, /*narr=*/count + 1, /*nrec=*/0);
+	lua_createtable(L, count + 1, 0);
 
 	int entry = 0;
 	int currentCmd = 0;
@@ -5857,7 +5857,7 @@ static void PackFactoryCounts(lua_State* L,
 			// Here and below, negative integer keys in lua tables are stored in the
 			// hash part of the table, hence we set nrec to 1 instead of narr.
 			// Lua Gems Chapter 2: About tables.
-			lua_createtable(L, /*narr=*/0, /*nrec=*/1); {
+			lua_createtable(L, 0, 1); {
 				lua_pushnumber(L, currentCount);
 				lua_rawseti(L, -2, -currentCmd);
 			}
@@ -5868,7 +5868,7 @@ static void PackFactoryCounts(lua_State* L,
 	}
 	if (currentCount > 0) {
 		entry++;
-		lua_createtable(L, /*narr=*/0, /*nrec=*/1); {
+		lua_createtable(L, 0, 1); {
 			lua_pushnumber(L, currentCount);
 			lua_rawseti(L, -2, -currentCmd);
 		}
@@ -7820,12 +7820,12 @@ static int GetSolidObjectPieceList(lua_State* L, const CSolidObject* o)
 
 static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 {
-	lua_createtable(L, /*narr=*/0, /*nrec=*/7);
+	lua_createtable(L, 0, 7);
 	HSTR_PUSH_STRING(L, "name", op.name);
 	HSTR_PUSH_STRING(L, "parent", ((op.parent != nullptr) ? op.parent->name : "[null]"));
 
 	HSTR_PUSH(L, "children");
-	lua_createtable(L, /*narr=*/op.children.size(), /*nrec=*/0);
+	lua_createtable(L, op.children.size(), 0);
 	for (size_t c = 0; c < op.children.size(); c++) {
 		lua_pushsstring(L, op.children[c]->name);
 		lua_rawseti(L, -2, c + 1);
@@ -7837,7 +7837,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	lua_rawset(L, -3);
 
 	HSTR_PUSH(L, "min");
-	lua_createtable(L, /*narr=*/3, /*nrec=*/0); {
+	lua_createtable(L, 3, 0); {
 		lua_pushnumber(L, op.mins.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.mins.y); lua_rawseti(L, -2, 2);
 		lua_pushnumber(L, op.mins.z); lua_rawseti(L, -2, 3);
@@ -7845,7 +7845,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	lua_rawset(L, -3);
 
 	HSTR_PUSH(L, "max");
-	lua_createtable(L, /*narr=*/3, /*nrec=*/0); {
+	lua_createtable(L, 3, 0); {
 		lua_pushnumber(L, op.maxs.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.maxs.y); lua_rawseti(L, -2, 2);
 		lua_pushnumber(L, op.maxs.z); lua_rawseti(L, -2, 3);
@@ -7853,7 +7853,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	lua_rawset(L, -3);
 
 	HSTR_PUSH(L, "offset");
-	lua_createtable(L, /*narr=*/3, /*nrec=*/0); {
+	lua_createtable(L, 3, 0); {
 		lua_pushnumber(L, op.offset.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.offset.y); lua_rawseti(L, -2, 2);
 		lua_pushnumber(L, op.offset.z); lua_rawseti(L, -2, 3);

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -1439,10 +1439,10 @@ int LuaSyncedRead::GetSideData(lua_State* L)
 		return 3;
 	}
 	{
-		lua_newtable(L);
 		const unsigned int sideCount = sideParser.GetCount();
+		lua_createtable(L, /*narr=*/sideCount, /*nrec=*/0);
 		for (unsigned int i = 0; i < sideCount; i++) {
-			lua_newtable(L); {
+			lua_createtable(L, /*narr=*/0, /*nrec=*/3); {
 				LuaPushNamedString(L, "sideName",  sideParser.GetSideName(i));
 				LuaPushNamedString(L, "caseName",  sideParser.GetCaseName(i));
 				LuaPushNamedString(L, "startUnit", sideParser.GetStartUnit(i));
@@ -1970,12 +1970,12 @@ int LuaSyncedRead::GetTeamStatsHistory(lua_State* L)
 
 	std::advance(it, start);
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/max(0, end - start), /*nrec=*/0);
 	if (statCount > 0) {
 		int count = 1;
 		for (int i = start; i <= end; ++i, ++it) {
 			const TeamStatistics& stats = *it;
-			lua_newtable(L); {
+			lua_createtable(L, /*narr=*/0, /*nrec=*/21); {
 				if (i+1 == teamStats.size()) {
 					// the `stats.frame` var indicates the frame when a new entry needs to get added,
 					// for the most recent stats entry this lies obviously in the future,
@@ -2193,7 +2193,7 @@ int LuaSyncedRead::GetAIInfo(lua_State* L)
 		lua_pushsstring(L, aiData->shortName);
 		lua_pushsstring(L, aiData->version);
 
-		lua_newtable(L);
+		lua_createtable(L, /*narr=*/0, /*nrec=*/aiData->options.size());
 
 		for (const auto& option: aiData->options) {
 			lua_pushsstring(L, option.first);
@@ -5399,7 +5399,7 @@ int LuaSyncedRead::GetUnitDefDimensions(lua_State* L)
 
 	const S3DModel& m = *model;
 	const float3& mid = model->relMidPos;
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/11);
 	HSTR_PUSH_NUMBER(L, "height", m.height);
 	HSTR_PUSH_NUMBER(L, "radius", m.radius);
 	HSTR_PUSH_NUMBER(L, "midx",   mid.x);
@@ -5457,7 +5457,7 @@ int LuaSyncedRead::GetUnitMoveTypeData(lua_State* L)
 
 	AMoveType* amt = unit->moveType;
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/26);
 	HSTR_PUSH_NUMBER(L, "maxSpeed", amt->GetMaxSpeed() * GAME_SPEED);
 	HSTR_PUSH_NUMBER(L, "maxWantedSpeed", amt->GetMaxWantedSpeed() * GAME_SPEED);
 	HSTR_PUSH_NUMBER(L, "goalx", amt->goalPos.x);
@@ -5828,7 +5828,7 @@ int LuaSyncedRead::GetFactoryBuggerOff(lua_State* L)
 static void PackFactoryCounts(lua_State* L,
                               const CCommandQueue& q, int count, bool noCmds)
 {
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/count + 1, /*nrec=*/0);
 
 	int entry = 0;
 	int currentCmd = 0;
@@ -5854,7 +5854,10 @@ static void PackFactoryCounts(lua_State* L,
 		}
 		else {
 			entry++;
-			lua_newtable(L); {
+			// Here and below, negative integer keys in lua tables are stored in the
+			// hash part of the table, hence we set nrec to 1 instead of narr.
+			// Lua Gems Chapter 2: About tables.
+			lua_createtable(L, /*narr=*/0, /*nrec=*/1); {
 				lua_pushnumber(L, currentCount);
 				lua_rawseti(L, -2, -currentCmd);
 			}
@@ -5865,7 +5868,7 @@ static void PackFactoryCounts(lua_State* L,
 	}
 	if (currentCount > 0) {
 		entry++;
-		lua_newtable(L); {
+		lua_createtable(L, /*narr=*/0, /*nrec=*/1); {
 			lua_pushnumber(L, currentCount);
 			lua_rawseti(L, -2, -currentCmd);
 		}
@@ -7817,12 +7820,12 @@ static int GetSolidObjectPieceList(lua_State* L, const CSolidObject* o)
 
 static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 {
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/7);
 	HSTR_PUSH_STRING(L, "name", op.name);
 	HSTR_PUSH_STRING(L, "parent", ((op.parent != nullptr) ? op.parent->name : "[null]"));
 
 	HSTR_PUSH(L, "children");
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/op.children.size(), /*nrec=*/0);
 	for (size_t c = 0; c < op.children.size(); c++) {
 		lua_pushsstring(L, op.children[c]->name);
 		lua_rawseti(L, -2, c + 1);
@@ -7834,7 +7837,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	lua_rawset(L, -3);
 
 	HSTR_PUSH(L, "min");
-	lua_newtable(L); {
+	lua_createtable(L, /*narr=*/3, /*nrec=*/0); {
 		lua_pushnumber(L, op.mins.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.mins.y); lua_rawseti(L, -2, 2);
 		lua_pushnumber(L, op.mins.z); lua_rawseti(L, -2, 3);
@@ -7842,7 +7845,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	lua_rawset(L, -3);
 
 	HSTR_PUSH(L, "max");
-	lua_newtable(L); {
+	lua_createtable(L, /*narr=*/3, /*nrec=*/0); {
 		lua_pushnumber(L, op.maxs.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.maxs.y); lua_rawseti(L, -2, 2);
 		lua_pushnumber(L, op.maxs.z); lua_rawseti(L, -2, 3);
@@ -7850,7 +7853,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	lua_rawset(L, -3);
 
 	HSTR_PUSH(L, "offset");
-	lua_newtable(L); {
+	lua_createtable(L, /*narr=*/3, /*nrec=*/0); {
 		lua_pushnumber(L, op.offset.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.offset.y); lua_rawseti(L, -2, 2);
 		lua_pushnumber(L, op.offset.z); lua_rawseti(L, -2, 3);

--- a/rts/Lua/LuaSyncedTable.cpp
+++ b/rts/Lua/LuaSyncedTable.cpp
@@ -38,7 +38,7 @@ static int SyncTableIndex(lua_State* dstL)
 	const int valueCopied = LuaUtils::CopyData(dstL, srcL, 1);
 	if (lua_istable(dstL, -1)) {
 		// disallow writing in SYNCED[...]
-		lua_createtable(dstL, /*narr=*/0, /*nrec=*/2); {
+		lua_createtable(dstL, 0, 2); {
 			LuaPushNamedCFunc(dstL, "__newindex",  SyncTableNewIndex);
 			LuaPushNamedCFunc(dstL, "__metatable", SyncTableMetatable);
 		}
@@ -75,7 +75,7 @@ bool LuaSyncedTable::PushEntries(lua_State* L)
 	HSTR_PUSH(L, "SYNCED");
 	lua_newtable(L); { // the proxy table
 
-		lua_createtable(L, /*narr=*/0, /*nrec=*/3); { // the metatable
+		lua_createtable(L, 0, 3); { // the metatable
 			LuaPushNamedCFunc(L, "__index",     SyncTableIndex);
 			LuaPushNamedCFunc(L, "__newindex",  SyncTableNewIndex);
 			LuaPushNamedCFunc(L, "__metatable", SyncTableMetatable);

--- a/rts/Lua/LuaSyncedTable.cpp
+++ b/rts/Lua/LuaSyncedTable.cpp
@@ -38,7 +38,7 @@ static int SyncTableIndex(lua_State* dstL)
 	const int valueCopied = LuaUtils::CopyData(dstL, srcL, 1);
 	if (lua_istable(dstL, -1)) {
 		// disallow writing in SYNCED[...]
-		lua_newtable(dstL); { // the metatable
+		lua_createtable(dstL, /*narr=*/0, /*nrec=*/2); {
 			LuaPushNamedCFunc(dstL, "__newindex",  SyncTableNewIndex);
 			LuaPushNamedCFunc(dstL, "__metatable", SyncTableMetatable);
 		}
@@ -75,7 +75,7 @@ bool LuaSyncedTable::PushEntries(lua_State* L)
 	HSTR_PUSH(L, "SYNCED");
 	lua_newtable(L); { // the proxy table
 
-		lua_newtable(L); { // the metatable
+		lua_createtable(L, /*narr=*/0, /*nrec=*/3); { // the metatable
 			LuaPushNamedCFunc(L, "__index",     SyncTableIndex);
 			LuaPushNamedCFunc(L, "__newindex",  SyncTableNewIndex);
 			LuaPushNamedCFunc(L, "__metatable", SyncTableMetatable);

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -259,7 +259,7 @@ void CLuaUI::UpdateTeams()
 
 bool CLuaUI::LoadCFunctions(lua_State* L)
 {
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/1);
 
 	REGISTER_LUA_CFUNC(SetShockFrontFactors);
 

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -259,7 +259,7 @@ void CLuaUI::UpdateTeams()
 
 bool CLuaUI::LoadCFunctions(lua_State* L)
 {
-	lua_createtable(L, /*narr=*/0, /*nrec=*/1);
+	lua_createtable(L, 0, 1);
 
 	REGISTER_LUA_CFUNC(SetShockFrontFactors);
 

--- a/rts/Lua/LuaUnitDefs.cpp
+++ b/rts/Lua/LuaUnitDefs.cpp
@@ -289,7 +289,7 @@ static int SafeIconType(lua_State* L, const void* data)
 static int CustomParamsTable(lua_State* L, const void* data)
 {
 	const spring::unordered_map<std::string, std::string>& params = *((const spring::unordered_map<std::string, std::string>*)data);
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/params.size());
 
 	for (const auto& param: params) {
 		lua_pushsstring(L, param.first);
@@ -305,7 +305,7 @@ static int BuildOptions(lua_State* L, const void* data)
 	const spring::unordered_map<int, std::string>& buildOptions = *((const spring::unordered_map<int, std::string>*)data);
 	const spring::unordered_map<std::string, int>& unitDefIDsMap = unitDefHandler->GetUnitDefIDs();
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/buildOptions.size(), /*nrec=*/0);
 	int count = 0;
 
 	for (const auto& buildOption: buildOptions) {
@@ -324,8 +324,8 @@ static int BuildOptions(lua_State* L, const void* data)
 
 static inline int BuildCategorySet(lua_State* L, const vector<string>& cats)
 {
-	lua_newtable(L);
 	const int count = (int)cats.size();
+	lua_createtable(L, /*narr*/0, /*nrec*/count);
 	for (int i = 0; i < count; i++) {
 		lua_pushsstring(L, cats[i]);
 		lua_pushboolean(L, true);
@@ -357,14 +357,15 @@ static int WeaponsTable(lua_State* L, const void* data)
 {
 	const auto& udWeapons = *reinterpret_cast<const decltype(UnitDef::weapons)*>(data);
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/udWeapons.size() + LUA_WEAPON_BASE_INDEX,
+			/*nrec=*/0);
 
 	for (size_t i = 0; i < udWeapons.size() && udWeapons[i].def != nullptr; i++) {
 		const UnitDefWeapon& udw = udWeapons[i];
 		const WeaponDef* wd = udw.def;
 
 		lua_pushnumber(L, i + LUA_WEAPON_BASE_INDEX);
-		lua_newtable(L); {
+		lua_createtable(L, /*narr=*/0, /*nrec=*/10); {
 			HSTR_PUSH_NUMBER(L, "weaponDef",   wd->id);
 			HSTR_PUSH_NUMBER(L, "slavedTo",    udw.slavedTo - 1 + LUA_WEAPON_BASE_INDEX);
 			HSTR_PUSH_NUMBER(L, "maxAngleDif", udw.maxMainDirAngleDif);
@@ -397,7 +398,8 @@ static void PushGuiSoundSet(lua_State* L, const string& name,
 
 	for (int i = 0; i < soundCount; i++) {
 		lua_pushnumber(L, i + 1);
-		lua_newtable(L);
+		lua_createtable(L, /*narr=*/0,
+				/*nrec=*/CLuaHandle::GetHandleSynced(L) ? 2 : 3);
 		const GuiSoundSetData& sound = soundSet.GetSoundData(i);
 		HSTR_PUSH_STRING(L, "name",   sound.name);
 		HSTR_PUSH_NUMBER(L, "volume", sound.volume);
@@ -413,7 +415,7 @@ static void PushGuiSoundSet(lua_State* L, const string& name,
 static int SoundsTable(lua_State* L, const void* data) {
 	const UnitDef::SoundStruct& sounds = *((const UnitDef::SoundStruct*) data);
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/10);
 	PushGuiSoundSet(L, "select",      sounds.select);
 	PushGuiSoundSet(L, "ok",          sounds.ok);
 	PushGuiSoundSet(L, "arrived",     sounds.arrived);

--- a/rts/Lua/LuaUnitDefs.cpp
+++ b/rts/Lua/LuaUnitDefs.cpp
@@ -289,7 +289,7 @@ static int SafeIconType(lua_State* L, const void* data)
 static int CustomParamsTable(lua_State* L, const void* data)
 {
 	const spring::unordered_map<std::string, std::string>& params = *((const spring::unordered_map<std::string, std::string>*)data);
-	lua_createtable(L, /*narr=*/0, /*nrec=*/params.size());
+	lua_createtable(L, 0, params.size());
 
 	for (const auto& param: params) {
 		lua_pushsstring(L, param.first);
@@ -305,7 +305,7 @@ static int BuildOptions(lua_State* L, const void* data)
 	const spring::unordered_map<int, std::string>& buildOptions = *((const spring::unordered_map<int, std::string>*)data);
 	const spring::unordered_map<std::string, int>& unitDefIDsMap = unitDefHandler->GetUnitDefIDs();
 
-	lua_createtable(L, /*narr=*/buildOptions.size(), /*nrec=*/0);
+	lua_createtable(L, buildOptions.size(), 0);
 	int count = 0;
 
 	for (const auto& buildOption: buildOptions) {
@@ -325,7 +325,7 @@ static int BuildOptions(lua_State* L, const void* data)
 static inline int BuildCategorySet(lua_State* L, const vector<string>& cats)
 {
 	const int count = (int)cats.size();
-	lua_createtable(L, /*narr*/0, /*nrec*/count);
+	lua_createtable(L, 0, count);
 	for (int i = 0; i < count; i++) {
 		lua_pushsstring(L, cats[i]);
 		lua_pushboolean(L, true);
@@ -357,15 +357,19 @@ static int WeaponsTable(lua_State* L, const void* data)
 {
 	const auto& udWeapons = *reinterpret_cast<const decltype(UnitDef::weapons)*>(data);
 
-	lua_createtable(L, /*narr=*/udWeapons.size() + LUA_WEAPON_BASE_INDEX,
-			/*nrec=*/0);
+	// When LUA_WEAPON_BASE_INDEX is not 1, lua will resort to using the hash
+	// part to index table keys as we're no longer adding keys to the table
+	// following the sequence 1 to N for any N.
+	lua_createtable(L, 
+			LUA_WEAPON_BASE_INDEX == 1 ? udWeapons.size() : 0,
+			LUA_WEAPON_BASE_INDEX == 1 ? 0 : udWeapons.size());
 
 	for (size_t i = 0; i < udWeapons.size() && udWeapons[i].def != nullptr; i++) {
 		const UnitDefWeapon& udw = udWeapons[i];
 		const WeaponDef* wd = udw.def;
 
 		lua_pushnumber(L, i + LUA_WEAPON_BASE_INDEX);
-		lua_createtable(L, /*narr=*/0, /*nrec=*/10); {
+		lua_createtable(L, 0, 10); {
 			HSTR_PUSH_NUMBER(L, "weaponDef",   wd->id);
 			HSTR_PUSH_NUMBER(L, "slavedTo",    udw.slavedTo - 1 + LUA_WEAPON_BASE_INDEX);
 			HSTR_PUSH_NUMBER(L, "maxAngleDif", udw.maxMainDirAngleDif);
@@ -398,8 +402,7 @@ static void PushGuiSoundSet(lua_State* L, const string& name,
 
 	for (int i = 0; i < soundCount; i++) {
 		lua_pushnumber(L, i + 1);
-		lua_createtable(L, /*narr=*/0,
-				/*nrec=*/CLuaHandle::GetHandleSynced(L) ? 2 : 3);
+		lua_createtable(L, 0, CLuaHandle::GetHandleSynced(L) ? 2 : 3);
 		const GuiSoundSetData& sound = soundSet.GetSoundData(i);
 		HSTR_PUSH_STRING(L, "name",   sound.name);
 		HSTR_PUSH_NUMBER(L, "volume", sound.volume);
@@ -415,7 +418,7 @@ static void PushGuiSoundSet(lua_State* L, const string& name,
 static int SoundsTable(lua_State* L, const void* data) {
 	const UnitDef::SoundStruct& sounds = *((const UnitDef::SoundStruct*) data);
 
-	lua_createtable(L, /*narr=*/0, /*nrec=*/10);
+	lua_createtable(L, 0, 10);
 	PushGuiSoundSet(L, "select",      sounds.select);
 	PushGuiSoundSet(L, "ok",          sounds.ok);
 	PushGuiSoundSet(L, "arrived",     sounds.arrived);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -2744,7 +2744,8 @@ int LuaUnsyncedRead::GetCameraState(lua_State* L)
 		}
 	}
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0,
+			/*nrec=*/std::tuple_size<CCameraController::StateMap::ArrayMap>{});
 
 	lua_pushliteral(L, "name");
 	lua_pushsstring(L, (camHandler->GetCurrentController()).GetName());
@@ -2842,7 +2843,7 @@ int LuaUnsyncedRead::GetCameraVectors(lua_State* L)
 	lua_pushnumber(L, camera-> n .z); lua_rawseti(L, -2, 3); \
 	lua_rawset(L, -3)
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/7);
 	PACK_CAMERA_VECTOR(forward, GetDir());
 	PACK_CAMERA_VECTOR(up, GetUp());
 	PACK_CAMERA_VECTOR(right, GetRight());
@@ -3039,7 +3040,7 @@ static bool AddPlayerToRoster(lua_State* L, int playerID, bool onlyActivePlayers
 		return false;
 
 	int index = 1;
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/7, /*nrec=*/0);
 	PUSH_ROSTER_ENTRY(string, p->name.c_str());
 	PUSH_ROSTER_ENTRY(number, playerID);
 	PUSH_ROSTER_ENTRY(number, p->team);
@@ -3386,7 +3387,7 @@ int LuaUnsyncedRead::GetActiveCmdDescs(lua_State* L)
 	const int cmdDescCount = (int)cmdDescs.size();
 
 	lua_checkstack(L, 1 + 2);
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/cmdDescCount + CMD_INDEX_OFFSET, /*nrec=*/0);
 
 	for (int i = 0; i < cmdDescCount; i++) {
 		LuaUtils::PushCommandDesc(L, cmdDescs[i]);
@@ -3955,9 +3956,9 @@ int LuaUnsyncedRead::GetKeyBindings(lua_State* L)
 	}
 
 	int i = 1;
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/actions.size(), /*nrec=*/0);
 	for (const Action& action: actions) {
-		lua_newtable(L);
+		lua_createtable(L, /*narr=*/0, /*nrec=*/4);
 			lua_pushsstring(L, action.command);
 			lua_pushsstring(L, action.extra);
 			lua_rawset(L, -3);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -2744,8 +2744,8 @@ int LuaUnsyncedRead::GetCameraState(lua_State* L)
 		}
 	}
 
-	lua_createtable(L, /*narr=*/0,
-			/*nrec=*/std::tuple_size<CCameraController::StateMap::ArrayMap>{});
+	lua_createtable(L, 0,
+			std::tuple_size<CCameraController::StateMap::ArrayMap>{});
 
 	lua_pushliteral(L, "name");
 	lua_pushsstring(L, (camHandler->GetCurrentController()).GetName());
@@ -2843,7 +2843,7 @@ int LuaUnsyncedRead::GetCameraVectors(lua_State* L)
 	lua_pushnumber(L, camera-> n .z); lua_rawseti(L, -2, 3); \
 	lua_rawset(L, -3)
 
-	lua_createtable(L, /*narr=*/0, /*nrec=*/7);
+	lua_createtable(L, 0, 7);
 	PACK_CAMERA_VECTOR(forward, GetDir());
 	PACK_CAMERA_VECTOR(up, GetUp());
 	PACK_CAMERA_VECTOR(right, GetRight());
@@ -3040,7 +3040,7 @@ static bool AddPlayerToRoster(lua_State* L, int playerID, bool onlyActivePlayers
 		return false;
 
 	int index = 1;
-	lua_createtable(L, /*narr=*/7, /*nrec=*/0);
+	lua_createtable(L, 7, 0);
 	PUSH_ROSTER_ENTRY(string, p->name.c_str());
 	PUSH_ROSTER_ENTRY(number, playerID);
 	PUSH_ROSTER_ENTRY(number, p->team);
@@ -3387,7 +3387,12 @@ int LuaUnsyncedRead::GetActiveCmdDescs(lua_State* L)
 	const int cmdDescCount = (int)cmdDescs.size();
 
 	lua_checkstack(L, 1 + 2);
-	lua_createtable(L, /*narr=*/cmdDescCount + CMD_INDEX_OFFSET, /*nrec=*/0);
+	// When CMD_INDEX_OFFSET is not 1, lua will resort to using the hash
+	// part to index table keys as we're no longer adding keys to the table
+	// following the sequence 1 to N for any N.
+	lua_createtable(L,
+			CMD_INDEX_OFFSET == 1 ? cmdDescCount : 0,
+			CMD_INDEX_OFFSET == 1 ? 0 : cmdDescCount);
 
 	for (int i = 0; i < cmdDescCount; i++) {
 		LuaUtils::PushCommandDesc(L, cmdDescs[i]);
@@ -3956,9 +3961,9 @@ int LuaUnsyncedRead::GetKeyBindings(lua_State* L)
 	}
 
 	int i = 1;
-	lua_createtable(L, /*narr=*/actions.size(), /*nrec=*/0);
+	lua_createtable(L, actions.size(), 0);
 	for (const Action& action: actions) {
-		lua_createtable(L, /*narr=*/0, /*nrec=*/4);
+		lua_createtable(L, 0, 4);
 			lua_pushsstring(L, action.command);
 			lua_pushsstring(L, action.extra);
 			lua_rawset(L, -3);

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -778,7 +778,7 @@ int LuaUtils::PushModelTable(lua_State* L, const SolidObjectDef* def) {
 
 	const S3DModel* model = def->LoadModel();
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/10);
 
 	if (model != nullptr) {
 		// unit, or non-tree feature
@@ -806,7 +806,8 @@ int LuaUtils::PushModelTable(lua_State* L, const SolidObjectDef* def) {
 	}
 
 	HSTR_PUSH(L, "textures");
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0,
+			/*nrec=*/model != nullptr ? 2 : 0);
 
 	if (model != nullptr) {
 		LuaPushNamedString(L, "tex1", model->texs[0]);
@@ -824,7 +825,7 @@ int LuaUtils::PushModelTable(lua_State* L, const SolidObjectDef* def) {
 int LuaUtils::PushColVolTable(lua_State* L, const CollisionVolume* vol) {
 	assert(vol != nullptr);
 
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/11);
 	switch (vol->GetVolumeType()) {
 		case CollisionVolume::COLVOL_TYPE_ELLIPSOID:
 			HSTR_PUSH_CSTRING(L, "type", "ellipsoid");

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -778,7 +778,7 @@ int LuaUtils::PushModelTable(lua_State* L, const SolidObjectDef* def) {
 
 	const S3DModel* model = def->LoadModel();
 
-	lua_createtable(L, /*narr=*/0, /*nrec=*/10);
+	lua_createtable(L, 0, 10);
 
 	if (model != nullptr) {
 		// unit, or non-tree feature
@@ -806,8 +806,7 @@ int LuaUtils::PushModelTable(lua_State* L, const SolidObjectDef* def) {
 	}
 
 	HSTR_PUSH(L, "textures");
-	lua_createtable(L, /*narr=*/0,
-			/*nrec=*/model != nullptr ? 2 : 0);
+	lua_createtable(L, 0, model != nullptr ? 2 : 0);
 
 	if (model != nullptr) {
 		LuaPushNamedString(L, "tex1", model->texs[0]);
@@ -825,7 +824,7 @@ int LuaUtils::PushModelTable(lua_State* L, const SolidObjectDef* def) {
 int LuaUtils::PushColVolTable(lua_State* L, const CollisionVolume* vol) {
 	assert(vol != nullptr);
 
-	lua_createtable(L, /*narr=*/0, /*nrec=*/11);
+	lua_createtable(L, 0, 11);
 	switch (vol->GetVolumeType()) {
 		case CollisionVolume::COLVOL_TYPE_ELLIPSOID:
 			HSTR_PUSH_CSTRING(L, "type", "ellipsoid");

--- a/rts/Lua/LuaUtils.h
+++ b/rts/Lua/LuaUtils.h
@@ -216,8 +216,7 @@ static void PushObjectDefProxyTable(
 	const ObjectDefType* def
 ) {
 	lua_pushnumber(L, def->id);
-	// the proxy table
-	lua_createtable(L, 0, iterFuncsSize); {
+	lua_createtable(L, 0, iterFuncsSize); { // the proxy table
 
 		lua_createtable(L, 0, indxFuncsSize); // the metatable
 

--- a/rts/Lua/LuaUtils.h
+++ b/rts/Lua/LuaUtils.h
@@ -216,9 +216,10 @@ static void PushObjectDefProxyTable(
 	const ObjectDefType* def
 ) {
 	lua_pushnumber(L, def->id);
-	lua_newtable(L); { // the proxy table
+	// the proxy table
+	lua_createtable(L, /*narr=*/0, /*nrec=*/iterFuncsSize); {
 
-		lua_newtable(L); // the metatable
+		lua_createtable(L, /*narr=*/0, /*nrec=*/indxFuncsSize); // the metatable
 
 		for (size_t n = 0; n < indxFuncsSize; n++) {
 			indxOpers[n].Push(L);

--- a/rts/Lua/LuaUtils.h
+++ b/rts/Lua/LuaUtils.h
@@ -217,9 +217,9 @@ static void PushObjectDefProxyTable(
 ) {
 	lua_pushnumber(L, def->id);
 	// the proxy table
-	lua_createtable(L, /*narr=*/0, /*nrec=*/iterFuncsSize); {
+	lua_createtable(L, 0, iterFuncsSize); {
 
-		lua_createtable(L, /*narr=*/0, /*nrec=*/indxFuncsSize); // the metatable
+		lua_createtable(L, 0, indxFuncsSize); // the metatable
 
 		for (size_t n = 0; n < indxFuncsSize; n++) {
 			indxOpers[n].Push(L);

--- a/rts/Sim/Units/Scripts/LuaUnitScript.cpp
+++ b/rts/Sim/Units/Scripts/LuaUnitScript.cpp
@@ -978,7 +978,7 @@ bool CLuaUnitScript::PushEntries(lua_State* L)
 	}
 
 	lua_pushstring(L, "UnitScript");
-	lua_newtable(L);
+	lua_createtable(L, /*narr=*/0, /*nrec=*/25);
 
 	REGISTER_LUA_CFUNC(CreateScript);
 	REGISTER_LUA_CFUNC(UpdateCallIn);

--- a/rts/Sim/Units/Scripts/LuaUnitScript.cpp
+++ b/rts/Sim/Units/Scripts/LuaUnitScript.cpp
@@ -978,7 +978,7 @@ bool CLuaUnitScript::PushEntries(lua_State* L)
 	}
 
 	lua_pushstring(L, "UnitScript");
-	lua_createtable(L, /*narr=*/0, /*nrec=*/25);
+	lua_createtable(L, 0, 25);
 
 	REGISTER_LUA_CFUNC(CreateScript);
 	REGISTER_LUA_CFUNC(UpdateCallIn);


### PR DESCRIPTION
Using lua_createtable instead of lua_newtable reduces the number of rehashes needed when populating lua tables with sizes known at table creation time.

This change is a strict improvement over using lua_newtable: tables that get larger than the initial size will get rehashed as normal. Tables that fit into the specified size will avoid the need to rehash after creation.

Additionally, in `rts/Lua/LuaOpenGL.cpp` we use `lua_rawseti` to populate the array table instead of manually specifying integer keys.

See 'Lua Gems, Chapter 2, About tables' on details on table keys are hashed.