### PR TITLE
Make Memory Pools memory alignment aware

### DIFF
--- a/rts/Rendering/Env/Decals/GroundDecalHandler.cpp
+++ b/rts/Rendering/Env/Decals/GroundDecalHandler.cpp
@@ -45,7 +45,6 @@
 #include "System/EventHandler.h"
 #include "System/Exceptions.h"
 #include "System/Log/ILog.h"
-#include "System/MemPoolTypes.h"
 #include "System/SpringMath.h"
 #include "System/StringUtil.h"
 #include "System/FileSystem/FileHandler.h"
@@ -822,7 +821,7 @@ void CGroundDecalHandler::GhostDestroyed(const GhostSolidObject* gb) {
 	// just in case
 	if (decal.info.type != GroundDecal::Type::DECAL_PLATE)
 		return;
-	
+
 	decal.alpha = 0.0f;
 	decalsUpdateList.SetUpdate(doIt->second);
 	decalOwners.erase(doIt);

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -28,7 +28,7 @@
 #include "Map/Ground.h"
 #include "Map/ReadMap.h"
 
-static FixedDynMemPool<sizeof(GhostSolidObject), MAX_UNITS / 1000, MAX_UNITS / 32> ghostMemPool;
+static FixedDynMemPoolT<MAX_UNITS / 1000, MAX_UNITS / 32, GhostSolidObject> ghostMemPool;
 
 ///////////////////////////
 

--- a/rts/Sim/Features/FeatureMemPool.h
+++ b/rts/Sim/Features/FeatureMemPool.h
@@ -10,7 +10,7 @@
 #if (defined(__x86_64) || defined(__x86_64__) || defined(_M_X64))
 typedef StaticMemPoolT<MAX_FEATURES, CFeature> FeatureMemPool;
 #else
-typedef FixedDynMemPool<sizeof(CFeature), MAX_FEATURES / 1000, MAX_FEATURES / 32> FeatureMemPool;
+typedef FixedDynMemPoolT<MAX_FEATURES / 1000, MAX_FEATURES / 32, CFeature> FeatureMemPool;
 #endif
 
 extern FeatureMemPool featureMemPool;

--- a/rts/Sim/Features/FeatureMemPool.h
+++ b/rts/Sim/Features/FeatureMemPool.h
@@ -8,7 +8,7 @@
 #include "System/MemPoolTypes.h"
 
 #if (defined(__x86_64) || defined(__x86_64__) || defined(_M_X64))
-typedef StaticMemPool<MAX_FEATURES, sizeof(CFeature)> FeatureMemPool;
+typedef StaticMemPoolT<MAX_FEATURES, CFeature> FeatureMemPool;
 #else
 typedef FixedDynMemPool<sizeof(CFeature), MAX_FEATURES / 1000, MAX_FEATURES / 32> FeatureMemPool;
 #endif

--- a/rts/Sim/Path/HAPFS/PathMemPool.h
+++ b/rts/Sim/Path/HAPFS/PathMemPool.h
@@ -10,9 +10,9 @@
 
 namespace HAPFS {
 
-typedef DynMemPool<sizeof(CPathCache    )> PCMemPool;
+typedef DynMemPoolT<CPathCache> PCMemPool;
 //typedef DynMemPool<sizeof(CPathEstimator)> PEMemPool;
-typedef DynMemPool<sizeof(CPathFinder   )> PFMemPool;
+typedef DynMemPoolT<CPathFinder> PFMemPool;
 
 extern PCMemPool pcMemPool;
 //extern PEMemPool peMemPool;

--- a/rts/Sim/Projectiles/ExplosionGenerator.cpp
+++ b/rts/Sim/Projectiles/ExplosionGenerator.cpp
@@ -39,7 +39,7 @@
 #include "System/SafeUtil.h"
 #include "System/StringHash.h"
 
-static DynMemPool<sizeof(CCustomExplosionGenerator)> egMemPool;
+static DynMemPoolT<CCustomExplosionGenerator, CStdExplosionGenerator, IExplosionGenerator> egMemPool;
 
 alignas(LuaParser) static std::byte exploParserMem[sizeof(LuaParser)];
 alignas(LuaParser) static std::byte aliasParserMem[sizeof(LuaParser)];

--- a/rts/Sim/Projectiles/ProjectileMemPool.h
+++ b/rts/Sim/Projectiles/ProjectileMemPool.h
@@ -15,7 +15,7 @@ static constexpr size_t PMP_S = AlignUp(sizeof(CStarburstProjectile), PMP_ALIGN)
 #if (defined(__x86_64) || defined(__x86_64__) || defined(_M_X64))
 typedef StaticMemPool<MAX_PROJECTILES, PMP_S, PMP_ALIGN> ProjMemPool;
 #else
-typedef FixedDynMemPool<PMP_S, MAX_PROJECTILES / 2000, MAX_PROJECTILES / 64> ProjMemPool;
+typedef FixedDynMemPool<PMP_S, MAX_PROJECTILES / 2000, MAX_PROJECTILES / 64, PMP_ALIGN> ProjMemPool;
 #endif
 
 extern ProjMemPool projMemPool;

--- a/rts/Sim/Projectiles/ProjectileMemPool.h
+++ b/rts/Sim/Projectiles/ProjectileMemPool.h
@@ -9,7 +9,7 @@
 
 #include "Sim/Projectiles/WeaponProjectiles/StarburstProjectile.h"
 
-static constexpr size_t PMP_ALIGN = 8;
+static constexpr size_t PMP_ALIGN = 8; // smallest that fits the needs of all the various projectile types
 static constexpr size_t PMP_S = AlignUp(sizeof(CStarburstProjectile), PMP_ALIGN); //biggest in size
 
 #if (defined(__x86_64) || defined(__x86_64__) || defined(_M_X64))

--- a/rts/Sim/Projectiles/ProjectileMemPool.h
+++ b/rts/Sim/Projectiles/ProjectileMemPool.h
@@ -9,10 +9,11 @@
 
 #include "Sim/Projectiles/WeaponProjectiles/StarburstProjectile.h"
 
-static constexpr size_t PMP_S = AlignUp(sizeof(CStarburstProjectile), 4); //biggest in size
+static constexpr size_t PMP_ALIGN = 8;
+static constexpr size_t PMP_S = AlignUp(sizeof(CStarburstProjectile), PMP_ALIGN); //biggest in size
 
 #if (defined(__x86_64) || defined(__x86_64__) || defined(_M_X64))
-typedef StaticMemPool<MAX_PROJECTILES, PMP_S> ProjMemPool;
+typedef StaticMemPool<MAX_PROJECTILES, PMP_S, PMP_ALIGN> ProjMemPool;
 #else
 typedef FixedDynMemPool<PMP_S, MAX_PROJECTILES / 2000, MAX_PROJECTILES / 64> ProjMemPool;
 #endif

--- a/rts/Sim/Units/UnitMemPool.h
+++ b/rts/Sim/Units/UnitMemPool.h
@@ -9,7 +9,7 @@
 
 #if (defined(__x86_64) || defined(__x86_64__) || defined(_M_X64))
 // CBuilder is (currently) the largest derived unit-type
-typedef StaticMemPool<MAX_UNITS, sizeof(CBuilder)> UnitMemPool;
+typedef StaticMemPoolT<MAX_UNITS, CBuilder> UnitMemPool;
 #else
 typedef FixedDynMemPool<sizeof(CBuilder), MAX_UNITS / 1000, MAX_UNITS / 32> UnitMemPool;
 #endif

--- a/rts/Sim/Units/UnitMemPool.h
+++ b/rts/Sim/Units/UnitMemPool.h
@@ -11,7 +11,7 @@
 // CBuilder is (currently) the largest derived unit-type
 typedef StaticMemPoolT<MAX_UNITS, CBuilder> UnitMemPool;
 #else
-typedef FixedDynMemPool<sizeof(CBuilder), MAX_UNITS / 1000, MAX_UNITS / 32> UnitMemPool;
+typedef FixedDynMemPoolT<MAX_UNITS / 1000, MAX_UNITS / 32, CBuilder> UnitMemPool;
 #endif
 
 extern UnitMemPool unitMemPool;

--- a/rts/Sim/Weapons/WeaponMemPool.h
+++ b/rts/Sim/Weapons/WeaponMemPool.h
@@ -9,13 +9,14 @@
 
 #include "Sim/Weapons/PlasmaRepulser.h"
 
-static constexpr size_t WMP_S = AlignUp(sizeof(CPlasmaRepulser), 4); //biggest in size
+static constexpr size_t WMP_S = AlignUp(sizeof(CPlasmaRepulser), 8); //biggest in size
+static constexpr size_t WMP_A = 8;
 
 #if (defined(__x86_64) || defined(__x86_64__) || defined(_M_X64))
 // NOTE: ~742MB, way too big for 32-bit builds
-typedef StaticMemPool<MAX_UNITS * MAX_WEAPONS_PER_UNIT, WMP_S> WeaponMemPool;
+typedef StaticMemPool<MAX_UNITS * MAX_WEAPONS_PER_UNIT, WMP_S, WMP_A> WeaponMemPool;
 #else
-typedef FixedDynMemPool<WMP_S, (MAX_UNITS * MAX_WEAPONS_PER_UNIT) / 4000, (MAX_UNITS * MAX_WEAPONS_PER_UNIT) / 256> WeaponMemPool;
+typedef FixedDynMemPool<WMP_S, (MAX_UNITS * MAX_WEAPONS_PER_UNIT) / 4000, (MAX_UNITS * MAX_WEAPONS_PER_UNIT) / 256, WMP_A> WeaponMemPool;
 #endif
 
 extern WeaponMemPool weaponMemPool;

--- a/rts/System/MemPoolTypes.h
+++ b/rts/System/MemPoolTypes.h
@@ -32,6 +32,7 @@ public:
 	}
 
 	template<typename T, typename... A> T* alloc(A&&... a) {
+		static_assert(BUCKET_STEP >= alignof(T), "Can't allocate memory with alignment greater than BUCKET_STEP");
 		return new (allocMem(sizeof(T))) T(std::forward<A>(a)...);
 	}
 	void* allocMem(size_t size) {
@@ -100,7 +101,7 @@ public:
 		const auto iter = table.find(m);
 		const auto pair = std::pair<void*, size_t>{iter->first, iter->second};
 
-		std::memset(pages[pair.second].data(), 0, PAGE_SIZE());
+		std::memset(pages[pair.second].data, 0, PAGE_SIZE());
 
 		indcs.push_back(pair.second);
 		table.erase(pair.first);
@@ -124,7 +125,7 @@ public:
 	size_t freed_size() const { return (indcs.size() * PAGE_SIZE()); } // size of number of pages that were freed and are awaiting reuse
 
 	bool mapped(void* p) const { return (table.find(p) != table.end()); }
-	bool alloced(void* p) const { return ((curr_page_index < pages.size()) && (pages[curr_page_index].data() == p)); }
+	bool alloced(void* p) const { return ((curr_page_index < pages.size()) && (pages[curr_page_index].data == p)); }
 	bool can_alloc() const { return true; }
 	bool can_free() const { return indcs.size() < pages.size(); }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,7 @@ set(test_Log_sources
 
 set(test_common_libraries
 	cpuid
+	Tracy::TracyClient
 )
 
 add_custom_target(tests)
@@ -477,6 +478,9 @@ endif()
 			"${CMAKE_CURRENT_SOURCE_DIR}/other/testMemPoolTypes.cpp"
 			${test_Log_sources}
 		)
+	set(test_libs
+		""
+	)
 	add_spring_test(${test_name} "${test_src}" "${test_libs}" "${test_flags}")
 	target_include_directories(test_${test_name} PRIVATE ${ENGINE_SOURCE_DIR}/lib/)
 

--- a/test/other/testMemPoolTypes.cpp
+++ b/test/other/testMemPoolTypes.cpp
@@ -82,7 +82,7 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test bounded allocator base functionali
 }
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test unbounded allocator base functionality", "[class][template]",
-		(DynMemPool<sizeof(TestData)>))
+		(DynMemPoolT<TestData>))
 {
 	AllocFixture<TestType> inst;
 	auto& mempool = *inst.mempool;
@@ -113,7 +113,7 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test unbounded allocator base functiona
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class][template]",
 		(StaticMemPoolT<TEST_ALLOCATOR_SIZE, TestData>),
 		(FixedDynMemPoolT<1, TEST_ALLOCATOR_SIZE, TestData>),
-		(DynMemPool<sizeof(TestData)>))
+		(DynMemPoolT<TestData>))
 {
 	AllocFixture<TestType> inst;
 	auto& mempool = *inst.mempool;
@@ -144,7 +144,7 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory in LIFO order", "[class][template]",
 		(StaticMemPoolT<TEST_ALLOCATOR_SIZE, TestData>),
 		(FixedDynMemPoolT<1, TEST_ALLOCATOR_SIZE, TestData>),
-		(DynMemPool<sizeof(TestData)>))
+		(DynMemPoolT<TestData>))
 {
 	AllocFixture<TestType> inst;
 	auto& mempool = *inst.mempool;

--- a/test/other/testMemPoolTypes.cpp
+++ b/test/other/testMemPoolTypes.cpp
@@ -37,8 +37,8 @@ template <typename T>
 	};
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator when full", "[class][template]",
-		(StaticMemPool<1,sizeof(TestData)>),
-		(FixedDynMemPool<sizeof(TestData), 1, 1>))
+		(StaticMemPoolT<1,TestData>),
+		(FixedDynMemPoolT<1, 1, TestData>))
 {
 	AllocFixture<TestType> inst;
 	auto& mempool = *inst.mempool;
@@ -52,8 +52,8 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator when full", "[class][tem
 }
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test bounded allocator base functionality", "[class][template]",
-		(StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
-		(FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>))
+		(StaticMemPoolT<TEST_ALLOCATOR_SIZE, TestData>),
+		(FixedDynMemPoolT<1, TEST_ALLOCATOR_SIZE, TestData>))
 {
 	AllocFixture<TestType> inst;
 	auto& mempool = *inst.mempool;
@@ -111,8 +111,8 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test unbounded allocator base functiona
 }
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class][template]",
-		(StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
-		(FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>),
+		(StaticMemPoolT<TEST_ALLOCATOR_SIZE, TestData>),
+		(FixedDynMemPoolT<1, TEST_ALLOCATOR_SIZE, TestData>),
 		(DynMemPool<sizeof(TestData)>))
 {
 	AllocFixture<TestType> inst;
@@ -142,8 +142,8 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory", "[class
 
 // obeying the order is not a functional requirement of allocator
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory in LIFO order", "[class][template]",
-		(StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
-		(FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>),
+		(StaticMemPoolT<TEST_ALLOCATOR_SIZE, TestData>),
+		(FixedDynMemPoolT<1, TEST_ALLOCATOR_SIZE, TestData>),
 		(DynMemPool<sizeof(TestData)>))
 {
 	AllocFixture<TestType> inst;
@@ -172,8 +172,8 @@ TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test reuse allocator's memory in LIFO o
 }
 
 TEMPLATE_TEST_CASE_METHOD(AllocFixture, "test allocator's clear method", "[class][template]",
-		(StaticMemPool<TEST_ALLOCATOR_SIZE,sizeof(TestData)>),
-		(FixedDynMemPool<sizeof(TestData), 1, TEST_ALLOCATOR_SIZE>))
+		(StaticMemPoolT<TEST_ALLOCATOR_SIZE, TestData>),
+		(FixedDynMemPoolT<1, TEST_ALLOCATOR_SIZE, TestData>))
 {
 	AllocFixture<TestType> inst;
 	auto& mempool = *inst.mempool;


### PR DESCRIPTION
Memory pools not being aligned allows compilers to generate code that depends on that alignment. This caused spurious crashes when code was compiled under clang, but could happen in any other compiler.

In addition to making the pool alignment aware
- I added helpers that automatically infer the required size and alignment straight from the set of types that can be stored in the given memory pool instance
- and compile time checks that verify that memory alignment of the pool is suitable for the allocated object