### PR TITLE
Use std lib lexical_normal to normalize paths.

### DIFF
--- a/rts/System/FileSystem/FileSystem.cpp
+++ b/rts/System/FileSystem/FileSystem.cpp
@@ -5,6 +5,8 @@
  */
 #include "FileSystem.h"
 
+#include <filesystem>
+
 #include "Game/GameVersion.h"
 #include "System/Log/ILog.h"
 #include "System/Platform/Win/win32.h"
@@ -215,32 +217,8 @@ std::string FileSystem::GetExtension(const std::string& path)
 	return "";
 }
 
-
 std::string FileSystem::GetNormalizedPath(const std::string& path) {
-
-	std::string normalizedPath = StringReplace(path, "\\", "/"); // convert to POSIX path separators
-
-	normalizedPath = StringReplace(normalizedPath, "/./", "/");
-
-	try {
-		normalizedPath = spring::regex_replace(normalizedPath, spring::regex("[/]{2,}"), {"/"});
-	} catch (const spring::regex_error& e) {
-		LOG_L(L_WARNING, "[%s][1] regex exception \"%s\" (code=%d)", __func__, e.what(), int(e.code()));
-	}
-
-	try {
-		normalizedPath = spring::regex_replace(normalizedPath, spring::regex("[^/]+[/][.]{2}"), {""});
-	} catch (const spring::regex_error& e) {
-		LOG_L(L_WARNING, "[%s][2] regex exception \"%s\" (code=%d)", __func__, e.what(), int(e.code()));
-	}
-
-	try {
-		normalizedPath = spring::regex_replace(normalizedPath, spring::regex("[/]{2,}"), {"/"});
-	} catch (const spring::regex_error& e) {
-		LOG_L(L_WARNING, "[%s][3] regex exception \"%s\" (code=%d)", __func__, e.what(), int(e.code()));
-	}
-
-	return normalizedPath; // maybe use FixSlashes here
+	return std::filesystem::path(path).lexically_normal().generic_string();
 }
 
 std::string& FileSystem::FixSlashes(std::string& path)


### PR DESCRIPTION
GetNormalizedPath uses a series of regular expressions to normalize a path, which can be quite slow.

This change uses C++17's <filesystem> library to normalize path names. Performance profiling the Spring load sequence shows the following:

Before:
  - 1,779 GetNormalizedPath calls, total time: ~170ms.

After:
  - 1,779 GetNormalizedPath call, total time: ~1.5ms.

Tested (not too thoroughly) by diffing GetNormalizedPath outputs between the original and new implementation on both Linux and Windows builds.

Below is a description of how the original behavior is replicated, see https://en.cppreference.com/w/cpp/filesystem/path for reference.

- https://github.com/beyond-all-reason/spring/blob/63a18aae7241943f77ff507983dd78325ce28514/rts/System/FileSystem/FileSystem.cpp#L221 `generic_string()` uses '/' as path separators.
- https://github.com/beyond-all-reason/spring/blob/df4bb2601a9a3359d3a9f932dfcc12a1c204b168/rts/System/FileSystem/FileSystem.cpp#L223 normalized algorithm point 4.
- https://github.com/beyond-all-reason/spring/blob/df4bb2601a9a3359d3a9f932dfcc12a1c204b168/rts/System/FileSystem/FileSystem.cpp#L226 normalized algorithm point 2.
- https://github.com/beyond-all-reason/spring/blob/df4bb2601a9a3359d3a9f932dfcc12a1c204b168/rts/System/FileSystem/FileSystem.cpp#L232 normalized algorithm point 5.
- https://github.com/beyond-all-reason/spring/blob/df4bb2601a9a3359d3a9f932dfcc12a1c204b168/rts/System/FileSystem/FileSystem.cpp#L238 normalized algorithm point 2.