### PR TITLE
Index DefType tag keys to speed up GetMetadataBy*Key calls

### DIFF
--- a/rts/Sim/Misc/DefinitionTag.cpp
+++ b/rts/Sim/Misc/DefinitionTag.cpp
@@ -47,23 +47,20 @@ void DefType::AddTagMetaData(const DefTagMetaData* data)
 
 	tagMetaData[tagMetaDataCnt++] = data;
 
-	const std::string internalKey = StringToLower(data->GetInternalName());
-	if (auto it = tagMetaDataByInternalName.find(internalKey);
-			it == tagMetaDataByInternalName.end()) {
+	if (const std::string internalKey = StringToLower(data->GetInternalName());
+			!tagMetaDataByInternalName.contains(internalKey)) {
 		tagMetaDataByInternalName[internalKey] = data;
 	}
 
 	if (const auto& externalName = data->GetExternalName(); externalName.IsSet()) {
-		const std::string externalKey = StringToLower(externalName.Get());
-		if (auto it = tagMetaDataByExternalName.find(externalKey);
-				it == tagMetaDataByExternalName.end()) {
+		if (const std::string externalKey = StringToLower(externalName.Get());
+				!tagMetaDataByExternalName.contains(externalKey)) {
 			tagMetaDataByExternalName[externalKey] = data;
 		}
 	}
 	if (const auto& fallbackName = data->GetFallbackName(); fallbackName.IsSet()) {
-		const std::string fallbackKey = StringToLower(fallbackName.Get());
-		if (auto it = tagMetaDataByFallbackName.find(fallbackKey);
-				it == tagMetaDataByFallbackName.end()) {
+		if (const std::string fallbackKey = StringToLower(fallbackName.Get());
+				!tagMetaDataByFallbackName.contains(fallbackKey)) {
 			tagMetaDataByFallbackName[fallbackKey] = data;
 		}
 	}

--- a/rts/Sim/Misc/DefinitionTag.cpp
+++ b/rts/Sim/Misc/DefinitionTag.cpp
@@ -46,36 +46,53 @@ void DefType::AddTagMetaData(const DefTagMetaData* data)
 	}
 
 	tagMetaData[tagMetaDataCnt++] = data;
-}
 
+	const std::string internalKey = StringToLower(data->GetInternalName());
+	if (auto it = tagMetaDataByInternalName.find(internalKey);
+			it == tagMetaDataByInternalName.end()) {
+		tagMetaDataByInternalName[internalKey] = data;
+	}
 
-const DefTagMetaData* DefType::GetMetaDataByInternalKey(const string& key)
-{
-	const auto tend = tagMetaData.begin() + tagMetaDataCnt;
-	const auto pred = [&](const DefTagMetaData* md) { return (key == md->GetInternalName()); };
-	const auto iter = std::find_if(tagMetaData.begin(), tend, pred);
-
-	return ((iter == tend)? nullptr: *iter);
-}
-
-
-const DefTagMetaData* DefType::GetMetaDataByExternalKey(const string& key)
-{
-	const std::string lkey = StringToLower(key);
-
-	for (unsigned int i = 0; i < tagMetaDataCnt; i++) {
-		const DefTagMetaData* md = tagMetaData[i];
-
-		if (md->GetExternalName().IsSet()) {
-			if (lkey == StringToLower(md->GetExternalName().Get()))
-				return md;
-		} else {
-			if (lkey == StringToLower(md->GetInternalName()))
-				return md;
+	if (const auto& externalName = data->GetExternalName(); externalName.IsSet()) {
+		const std::string externalKey = StringToLower(externalName.Get());
+		if (auto it = tagMetaDataByExternalName.find(externalKey);
+				it == tagMetaDataByExternalName.end()) {
+			tagMetaDataByExternalName[externalKey] = data;
 		}
+	}
+	if (const auto& fallbackName = data->GetFallbackName(); fallbackName.IsSet()) {
+		const std::string fallbackKey = StringToLower(fallbackName.Get());
+		if (auto it = tagMetaDataByFallbackName.find(fallbackKey);
+				it == tagMetaDataByFallbackName.end()) {
+			tagMetaDataByFallbackName[fallbackKey] = data;
+		}
+	}
+}
 
-		if (lkey == StringToLower(md->GetFallbackName().Get()))
-			return md;
+
+const DefTagMetaData* DefType::GetMetaDataByInternalKey(const string& key) {
+	const std::string lkey = StringToLower(key);
+	if (auto it = tagMetaDataByInternalName.find(lkey);
+			it != tagMetaDataByInternalName.end()) {
+		return it->second;
+	}
+	return nullptr;
+}
+
+
+const DefTagMetaData* DefType::GetMetaDataByExternalKey(const string& key) {
+	const std::string lkey = StringToLower(key);
+	if (auto it = tagMetaDataByExternalName.find(lkey);
+			it != tagMetaDataByExternalName.end()) {
+		return it->second;
+	}
+	if (auto it = tagMetaDataByInternalName.find(lkey);
+			it != tagMetaDataByInternalName.end()) {
+		return it->second;
+	}
+	if (auto it = tagMetaDataByFallbackName.find(lkey);
+			it != tagMetaDataByFallbackName.end()) {
+		return it->second;
 	}
 
 	return nullptr;

--- a/rts/Sim/Misc/DefinitionTag.h
+++ b/rts/Sim/Misc/DefinitionTag.h
@@ -17,10 +17,14 @@
 #include "Lua/LuaParser.h"
 #include "System/float3.h"
 #include "System/SpringMath.h"
+#include "System/UnorderedMap.hpp"
 
 // table placeholder (used for LuaTables)
 // example usage: DUMMYTAG(Defs, DefClass, table, customParams)
 struct table {};
+
+// Forward declaration for DefTagBuilder.
+class DefType;
 
 namespace {
 	static inline std::ostream& operator<<(std::ostream& os, const float3& point)
@@ -157,7 +161,7 @@ protected:
 
 
 /**
- * @brief Fluent interface to declare meta data of deftag
+ * @brief Fluent interface to customize meta data of deftag
  *
  * Uses method chaining so that a definition tag can be declared like this:
  *
@@ -174,10 +178,23 @@ template<typename T>
 class DefTagBuilder
 {
 public:
-	DefTagBuilder(DefTagTypedMetaData<T>* d) : data(d) {}
+	DefTagBuilder(DefType* dt, DefTagTypedMetaData<T>* d) : def(dt), data(d) {}
 
 	const DefTagMetaData* GetData() const { return data; }
 	operator T() const { return data->GetData(); }
+
+	// Implementation note: although not strictly required, calling asReference at
+	// the beggining of the fluent chain means that BuiltDefTag only needs a
+	// single constructor which accepts DefTagBuilder by reference (as opposed to
+	// multiple constructors).
+	DefTagBuilder& asReference() { return *this; }
+
+	// Finalizes all the customizations of the metadata for this deftag.
+	// Equivalent to .build() calls in fluent builders.
+	//
+	// No further method calls to the DefTagBuilder object should be made after
+	// AddTag().
+	void AddTag();
 
 #define MAKE_CHAIN_METHOD(property, type) \
 	DefTagBuilder& property(type const& x) { \
@@ -188,7 +205,19 @@ public:
 	typedef T (*TagFunc)(T x);
 	MAKE_CHAIN_METHOD(declarationFile, const char*);
 	MAKE_CHAIN_METHOD(declarationLine, int);
+	// It is underdefined for multiple tags to have the same externalName.
+	// In general, it is OK for multiple tags to have the same externalName in the
+	// same .cpp file.
+	//
+	// Within the same translation unit (roughly, the same .cpp file), values for
+	// a given externalName will be assigned to the first tag with that
+	// externalName. The 'first tag' refers to the first tag as appears in the
+	// source.
+	// If the same externalName is specified for a given DefTag across multiple
+	// translation units, the behavior is undefined and will lead to sync errors.
 	MAKE_CHAIN_METHOD(externalName, std::string);
+	// It is underdefined for multiple tags to have the same fallbackName. See
+	// externalName above.
 	MAKE_CHAIN_METHOD(fallbackName, std::string);
 	MAKE_CHAIN_METHOD(description, std::string);
 	MAKE_CHAIN_METHOD(defaultValue, T);
@@ -202,7 +231,27 @@ public:
 #undef MAKE_CHAIN_METHOD
 
 private:
+	DefType* def;
 	DefTagTypedMetaData<T>* data;
+	bool addTagCalled = false;
+};
+
+
+/**
+ * @brief Storage object for DefTagBuilder after all cusomtizations.
+ *
+ * The constructor ensures that a DefTagBuilder::AddTag is called after all
+ * customizations done by fluent calls are complete. This call order allows
+ * DefType::AddTagMetaData to see all changes to DefTagTypedMetaData done by the
+ * DefTagBuilder.
+ */
+class BuiltDefTag
+{
+public:
+	template <typename T>
+	BuiltDefTag(DefTagBuilder<T>& builder) {
+		builder.AddTag();
+	}
 };
 
 
@@ -225,10 +274,9 @@ public:
 
 	const char* GetName() const { return name; }
 
-	template<typename T> DefTagBuilder<T> AddTag(const char* name) {
+	template<typename T> DefTagBuilder<T> AllocateTag(const char* name) {
 		DefTagTypedMetaData<T>* meta = AllocTagMetaData<T>(name);
-		AddTagMetaData(meta); //FIXME
-		return DefTagBuilder<T>(meta);
+		return DefTagBuilder<T>(this, meta);
 	}
 
 	template<typename T> T GetTag(const std::string& name) {
@@ -262,6 +310,11 @@ private:
 	std::array<const DefTagMetaData*, 1024> tagMetaData;
 	std::array<uint8_t, 1024 * 1024 * 4> metaDataMem;
 
+	// All keys are lower case.
+	spring::unordered_map<std::string, const DefTagMetaData*> tagMetaDataByInternalName;
+	spring::unordered_map<std::string, const DefTagMetaData*> tagMetaDataByExternalName;
+	spring::unordered_map<std::string, const DefTagMetaData*> tagMetaDataByFallbackName;
+
 	unsigned int defInitFuncCnt = 0;
 	unsigned int tagMetaDataCnt = 0;
 	unsigned int metaDataMemIdx = 0;
@@ -293,7 +346,19 @@ private:
 	const DefTagMetaData* GetMetaDataByExternalKey(const std::string& key);
 
 	static void CheckType(const DefTagMetaData* meta, const std::type_info& want);
+
+	template<typename F> friend class DefTagBuilder;
 };
+
+
+// N.B. Must be defined in the header in order to instantiate definition
+// templates.
+template <typename T>
+void DefTagBuilder<T>::AddTag() {
+	assert(!addTagCalled);
+	addTagCalled = true;
+	def->AddTagMetaData(data);
+}
 
 
 /**
@@ -315,7 +380,8 @@ private:
 			staticCheckType = Defs.GetTag<T>(#name); \
 		} \
 	} static MACRO_CONCAT(do_once_,name); \
-	static DefTagBuilder<T> deftag_##name = Defs.AddTag<T>(#name)
+	static BuiltDefTag deftag_##Defs##name = Defs. \
+			AllocateTag<T>(#name).asReference()
 
 #define tagFunction(fname) \
 	tagFunctionPtr(&tagFnc_##fname).tagFunctionStr(tagFncStr_##fname)
@@ -332,7 +398,8 @@ private:
 	DEFTAG_CNTER(Defs, DefClass, T, name, GETSECONDARG(unused ,##__VA_ARGS__, name))
 
 #define DUMMYTAG(Defs, T, name) \
-	static DefTagBuilder<T> MACRO_CONCAT(deftag_,__LINE__) = Defs.AddTag<T>(#name)
+	static BuiltDefTag MACRO_CONCAT(deftag_,__LINE__) = Defs. \
+			AllocateTag<T>(#name).asReference()
 
 #define TAGFUNCTION(name, T, function) \
 	static T tagFnc_##name(T x) { \


### PR DESCRIPTION
During game loading, WeaponDefHandler.cpp constructs all known WeaponDefs. Each WeaponDef object is constructed by finding the [lua table key <-> WeaponDef member variable mapping] in DefType::tagMetaData. This search is done by linearly scanning DefType::tagMetaData.

The construction process' exection time grows in proportion to (number of tags) * (number of weapons).

To cut down on loading times, we ensure that DefType::Load calls uses an index to look up tags.

Additionally, this change makes GetMetaDataByInternalKey look up keys case-insensitively.

- There is no change to the DEFTAG and DUMMYTAG API macros.
- Slightly reduces static storage required.
- Slightly increases the pre-main dynamic initialization time.
- Significantly speeds up DefType::Load and DefType::ReportUnknownTags calls.

Tested against BAR - there are no differences in `DefType::GetMetaDataByInternalKey` and `DefType::GetMetaDataByExternalKey` calls.

## Further Details

The fundamental source of the slowness lies in `DefType::GetMetaDataByExternalKey` and `DefType::GetMetaDataByInternalKey` which both linearly scans the `tagMetaData` array for a tag matching the specified key. Both of these GetMetaDataBy*Key calls are used repeatedly in `DefType::Load` calls through the chain `DefType::Load` -> `defInitFuncs`, defined in the `DEFTAG_CNTER` macro -> `DefType::GetTag` as well as in `DefType::ReportUnknownTags`.

The solution to this problem is to create an index from `tag name string` to `DefTagMetaData*`.

A first pass implementation of the solution puts the construction of the index in `DefType::AddTag`. However, the fluent interface exposed by `DefTagBuilder` allows for modification of member `DefTagBuilder::data` after the call to `DefType::AddTag` (see the FIXME in DefType::AddTag). Specifically, this means that properties such as `externalName` and `fallbackName` can be changed after the initial `DefType::AddTag` call. There are two potential solutions to this issue:

- [Chosen solution] Implicitly finalize the `DefTagBuilder` once the fluent chain is complete. In most fluent interface this would require a `.build()` call at the end of the chain, but that would require changes in WeaponDef.cpp. Here, we rely on the `BuiltDefTag` type's constructor to automatically finalize the `DefTagBuilder` by calling `DefTagBuilder::AddTag`.
- Alternatively, we could construct the index on demand. I.e. we could put a `std::call_once(.., /* construct tagMetaDataBy*Name indices */)` in DefTag::Load such that the first DefTag::Load call populates the map.


## Profiler Screenshots

### Before
~580ms to initialize all WeaponDefs (in `WeaponDefHandler::Init`)
~200us in pre-main dynamic initialization of the various WeaponDef tags.
![before_objdef](https://github.com/beyond-all-reason/spring/assets/2730943/6813f8ca-8289-494f-86c4-e7648de7ad7e)

### After
~100ms to initialize all WeaponDefs (in `WeaponDefHandler::Init`)
~250us in pre-main dynamic initialization of various WeaponDef tags. (Not included in the screenshot is about another ~10us in AllocateTag calls in pre-main initialization).
![after_objdef](https://github.com/beyond-all-reason/spring/assets/2730943/8c2f87ca-0928-49ac-930e-db99226bb4da)
