### PR TITLE
UpdateBoundingVolume MT during Unit::SlowUpdate

### DIFF
--- a/rts/Rendering/Models/3DModel.cpp
+++ b/rts/Rendering/Models/3DModel.cpp
@@ -364,9 +364,6 @@ void LocalModel::UpdateBoundingVolume()
 {
 	ZoneScoped;
 
-	if (!needsBoundariesRecalc)
-		return;
-
 	// bounding-box extrema (local space)
 	float3 bbMins = DEF_MIN_SIZE;
 	float3 bbMaxs = DEF_MAX_SIZE;

--- a/rts/Rendering/Models/3DModel.h
+++ b/rts/Rendering/Models/3DModel.h
@@ -613,7 +613,8 @@ struct LocalModel
 		verts[9] = bbMaxs;
 	}
 
-	void SetBoundariesNeedsRecalc() { needsBoundariesRecalc = true; }
+	void SetBoundariesNeedsRecalc()       { needsBoundariesRecalc = true; }
+	bool GetBoundariesNeedsRecalc() const { return needsBoundariesRecalc; }
 private:
 	LocalModelPiece* CreateLocalModelPieces(const S3DModelPiece* mpParent);
 

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -31,9 +31,6 @@
 
 #include "Sim/Path/HAPFS/PathGlobal.h"
 
-#include "System/Config/ConfigHandler.h"
-// TODO: Remove this once its validated to not cause major issues downstream
-CONFIG(int, SlowUpdateBoundingVolumeMT).defaultValue(1).safemodeValue(0).minimumValue(0).description("MTs the UpdateBoundingVolume in SlowUpdate. WARNING: TOGGLING THIS INGAME MAY DESYNC! THIS IS FOR TESTING ONLY!");
 
 CR_BIND(CUnitHandler, )
 CR_REG_METADATA(CUnitHandler, (
@@ -357,40 +354,27 @@ void CUnitHandler::SlowUpdateUnits()
 	activeSlowUpdateUnit = idxEnd;
 	// stagger the SlowUpdate's
 
-	int slowUpdateBoundingVolumeMT = configHandler->GetInt("SlowUpdateBoundingVolumeMT");
-	if (slowUpdateBoundingVolumeMT == 0) {
+
+	{
+		ZoneScopedN("Sim::Unit::SlowUpdateST");
 		for (size_t i = idxBeg; i < idxEnd; ++i) {
 			CUnit* unit = activeUnits[i];
 
 			unit->SanityCheck();
 			unit->SlowUpdate();
-			unit->SlowUpdateWeapons();				
-			unit->localModel.UpdateBoundingVolume();
-			unit->SanityCheck();
+			unit->SlowUpdateWeapons();
 		}
 	}
-	else {
-		{
-			ZoneScopedN("Sim::Unit::SlowUpdateST");
-			for (size_t i = idxBeg; i < idxEnd; ++i) {
-				CUnit* unit = activeUnits[i];
-
-				unit->SanityCheck();
-				unit->SlowUpdate();
-				unit->SlowUpdateWeapons();
+	// Since the bounding volumes are calculated from the maximum piecematrix-offset piece vertices
+	// They dont have much of an effect if updated late-ish. 
+	{
+		ZoneScopedN("Sim::Unit::SlowUpdateMT");
+		for_mt(idxBeg, idxEnd, [&](const int i) {
+			CUnit* unit = activeUnits[i];
+			unit->localModel.UpdateBoundingVolume();
+			unit->SanityCheck();
 			}
-		}
-		// Since the bounding volumes are calculated from the maximum piecematrix-offset piece vertices
-		// They dont have much of an effect if updated late-ish. 
-		{
-			ZoneScopedN("Sim::Unit::SlowUpdateMT");
-			for_mt(idxBeg, idxEnd, [&](const int i) {
-				CUnit* unit = activeUnits[i];
-				unit->localModel.UpdateBoundingVolume();
-				unit->SanityCheck();
-				}
-			);
-		}
+		);
 	}
 }
 


### PR DESCRIPTION
Try to save half a millisec per frame lategame by performing  this MT'd.

Ive temporarily added a config int SlowUpdateBoundingVolumeMT to toggle this ingame for comparison only. Otherwise toggling this ingame may lead to a desync.