### PR TITLE
Add the ability to use Tracy plots directly from Lua via UnsyncedCtrl Spring.LuaTracyPlotConfig and Spring.LuaTracyPlot 

### DIFF
--- a/rts/Lua/LuaIntro.cpp
+++ b/rts/Lua/LuaIntro.cpp
@@ -212,6 +212,9 @@ bool CLuaIntro::LoadUnsyncedCtrlFunctions(lua_State* L)
 
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, SetLogSectionFilterLevel);
 
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, LuaTracyPlotConfig);
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, LuaTracyPlot);
+
 	return true;
 }
 

--- a/rts/Lua/LuaMenu.cpp
+++ b/rts/Lua/LuaMenu.cpp
@@ -252,6 +252,10 @@ bool CLuaMenu::LoadUnsyncedCtrlFunctions(lua_State* L)
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, SDLSetTextInputRect);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, SDLStartTextInput);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, SDLStopTextInput);
+
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, LuaTracyPlotConfig);
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, LuaTracyPlot);
+
 	return true;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4870,7 +4870,7 @@ int LuaUnsyncedCtrl::Yield(lua_State* L)
 
 /* NB: strings here are never cleaned up, but the use case assumes
  * that they live a long time and there's just a handful of them */
-std::set <std::string> tracyLuaPlots;
+std::set <std::string, std::less<>> tracyLuaPlots;
 
 /*** Configure custom appearence for a Tracy plot for use in debugging or profiling
  *
@@ -4898,8 +4898,11 @@ int LuaUnsyncedCtrl::LuaTracyPlotConfig(lua_State* L)
 		default:            plotFormatType = tracy::PlotFormatType::Number;     break;
 	}
 
-	const auto [iterator, inserted] = tracyLuaPlots.emplace(plotName);
-	TracyPlotConfig(iterator->c_str(), plotFormatType, step, fill, color);
+	auto plot = tracyLuaPlots.find(plotName);
+	if (plot == tracyLuaPlots.end())
+		plot = tracyLuaPlots.emplace(plotName).first;
+
+	TracyPlotConfig(plot->c_str(), plotFormatType, step, fill, color);
 	return 0;
 }
 
@@ -4916,8 +4919,11 @@ int LuaUnsyncedCtrl::LuaTracyPlot(lua_State* L)
 	const auto plotName  = luaL_checkstring(L, 1);
 	const auto plotValue = luaL_checkfloat(L, 2);
 
-	const auto [iterator, inserted] = tracyLuaPlots.emplace(plotName);
-	TracyPlot(iterator->c_str(), plotValue);
+	auto plot = tracyLuaPlots.find(plotName);
+	if (plot == tracyLuaPlots.end())
+		plot = tracyLuaPlots.emplace(plotName).first;
+
+	TracyPlot(plot->c_str(), plotValue);
 	return 0;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4872,13 +4872,13 @@ int LuaUnsyncedCtrl::Yield(lua_State* L)
  * that they live a long time and there's just a handful of them */
 std::set <std::string> tracyLuaPlots;
 
-/*** Initialize a plot in Tracy for use in debugging, up to 9 plots [1-9] may be used
+/*** Initialize a plot in Tracy for use in debugging or profiling
  *
  * @function Spring.LuaTracyPlotConfig
  * @string plotName which should be initialized
  * @string[opt] plotFormatType "Number"|"Percentage"|"Memory", default "Number"
- * @bool[opt] step stepwise chart, default stepwise
- * @bool[opt] fill color fill, default no fill
+ * @bool[opt] step stepwise chart, default true is stepwise
+ * @bool[opt] fill color fill, default false is no fill
  * @number[opt] color unit32 number as BGR color, default white
  * @treturn nil
  */
@@ -4907,7 +4907,7 @@ int LuaUnsyncedCtrl::LuaTracyPlotConfig(lua_State* L)
 /*** Update a Tracy Plot with a value
  *
  * @function Spring.LuaTracyPlot
- * @string plotName which LuaPlot should be updated (must have been initialized as per above!)
+ * @string plotName which LuaPlot should be updated (must have been initialized via LuaTracyPlotConfig)
  * @number plotvalue the number to show on the Tracy plot
  * @treturn nil
  */

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -111,6 +111,8 @@
 #undef CreateDirectory
 #undef Yield
 
+#include <tracy/Tracy.hpp>
+#include <common/TracyQueue.hpp>
 
 /******************************************************************************
  * Callouts to set state

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4868,74 +4868,54 @@ int LuaUnsyncedCtrl::Yield(lua_State* L)
 	return 1;
 }
 
-const char * tracyLuaPlot1 = "LuaPlot1";
-const char * tracyLuaPlot2 = "LuaPlot2";
-const char * tracyLuaPlot3 = "LuaPlot3";
-const char * tracyLuaPlot4 = "LuaPlot4";
-const char * tracyLuaPlot5 = "LuaPlot5";
-const char * tracyLuaPlot6 = "LuaPlot6";
-const char * tracyLuaPlot7 = "LuaPlot7";
-const char * tracyLuaPlot8 = "LuaPlot8";
-const char * tracyLuaPlot9 = "LuaPlot9";
+std::set <std::string> tracyLuaPlots;
 
 /*** Initialize a plot in Tracy for use in debugging, up to 9 plots [1-9] may be used
  *
  * @function Spring.LuaTracyPlotConfig
- * @number plotIndex which LuaPlot[1-9] should be initialized
+ * @string plotName which should be initialized
  * @string[opt] plotFormatType "Number"|"Percentage"|"Memory", default "Number"
  * @bool[opt] step stepwise chart, default stepwise
  * @bool[opt] fill color fill, default no fill
- * @number[opt] color unit32 number as RGB color, default white
+ * @number[opt] color unit32 number as BGR color, default white
  * @treturn nil
  */
+
 int LuaUnsyncedCtrl::LuaTracyPlotConfig(lua_State* L)
 {
-	const int plotIndex = std::clamp(luaL_checkint(L, 1), 1, 9);
-	const char* plotFormatTypeString = luaL_optstring(L, 2, "");
-	tracy::PlotFormatType plotFormatType = tracy::PlotFormatType::Number;
+    const auto plotName 			= luaL_checkstring(L, 1);
+    const auto plotFormatTypeString = luaL_optstring(L, 2, "");
+    const auto step 				= luaL_optboolean(L, 3, true); // stepwise default
+    const auto fill 				= luaL_optboolean(L, 4, false); // no fill default
+    const uint32_t color 			= luaL_optint(L, 5, 0xFFFFFF); // white default
 
-	if (plotFormatTypeString[0] != 0 ){
-		if (plotFormatTypeString[0] == 'P') plotFormatType = tracy::PlotFormatType::Percentage; // for Perce
-		if (plotFormatTypeString[0] == 'M') plotFormatType = tracy::PlotFormatType::Memory; // for Perce
-	}
-	const bool step = luaL_optboolean(L, 3, true); // stepwise default
-	const bool fill = luaL_optboolean(L, 4, false); // no fill default
-	const uint32_t color = luaL_optint(L, 5, 0xffffff); // white default
-	switch(plotIndex){
-		case 1: TracyPlotConfig(tracyLuaPlot1, plotFormatType, step, fill, color); break;
-		case 2: TracyPlotConfig(tracyLuaPlot2, plotFormatType, step, fill, color); break;
-		case 3: TracyPlotConfig(tracyLuaPlot3, plotFormatType, step, fill, color); break;
-		case 4: TracyPlotConfig(tracyLuaPlot4, plotFormatType, step, fill, color); break;
-		case 5: TracyPlotConfig(tracyLuaPlot5, plotFormatType, step, fill, color); break;
-		case 6: TracyPlotConfig(tracyLuaPlot6, plotFormatType, step, fill, color); break;
-		case 7: TracyPlotConfig(tracyLuaPlot7, plotFormatType, step, fill, color); break;
-		case 8: TracyPlotConfig(tracyLuaPlot8, plotFormatType, step, fill, color); break;
-		case 9: TracyPlotConfig(tracyLuaPlot9, plotFormatType, step, fill, color); break;
-	}
-	return 0;
+    tracy::PlotFormatType plotFormatType;
+    switch (plotFormatTypeString[0]) {
+        case 'p': case 'P': plotFormatType = tracy::PlotFormatType::Percentage; break;
+        case 'm': case 'M': plotFormatType = tracy::PlotFormatType::Memory;     break;
+        default:            plotFormatType = tracy::PlotFormatType::Number;     break;
+    }
+
+    const auto [iterator, inserted] = tracyLuaPlots.emplace(plotName);
+    TracyPlotConfig(iterator->c_str(), plotFormatType, step, fill, color);
+    return 0;
 }
+
 
 /*** Update a Tracy Plot with a value
  *
  * @function Spring.LuaTracyPlot
- * @number plotIndex which LuaPlot[1-9] should be updated
+ * @string plotName which LuaPlot should be updated (must have been initialized as per above!)
  * @number plotvalue the number to show on the Tracy plot
  * @treturn nil
  */
 int LuaUnsyncedCtrl::LuaTracyPlot(lua_State* L)
 {
-	const int plotIndex = std::clamp(luaL_checkint(L, 1), 1, 9) ;
-	const float plotValue = luaL_checkfloat(L, 2);	
-	switch(plotIndex){
-		case 1: TracyPlot(tracyLuaPlot1, plotValue); break;
-		case 2: TracyPlot(tracyLuaPlot2, plotValue); break;
-		case 3: TracyPlot(tracyLuaPlot3, plotValue); break;
-		case 4: TracyPlot(tracyLuaPlot4, plotValue); break;
-		case 5: TracyPlot(tracyLuaPlot5, plotValue); break;
-		case 6: TracyPlot(tracyLuaPlot6, plotValue); break;
-		case 7: TracyPlot(tracyLuaPlot7, plotValue); break;
-		case 8: TracyPlot(tracyLuaPlot8, plotValue); break;
-		case 9: TracyPlot(tracyLuaPlot9, plotValue); break;
-	}
-	return 0;
+    const auto plotName  = luaL_checkstring(L, 1);
+    const auto plotValue = luaL_checkfloat(L, 2);
+
+    const auto [iterator, inserted] = tracyLuaPlots.emplace(plotName);
+    TracyPlot(iterator->c_str(), plotValue);
+    return 0;
 }
+

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -325,6 +325,9 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(Yield);
 
+	REGISTER_LUA_CFUNC(LuaTracyPlotConfig);
+	REGISTER_LUA_CFUNC(LuaTracyPlot);
+
 	return true;
 }
 
@@ -4863,4 +4866,59 @@ int LuaUnsyncedCtrl::Yield(lua_State* L)
 
 	lua_pushboolean(L, true); //hint Lua should keep calling Yield
 	return 1;
+}
+
+const char * tracyLuaPlot1 = "LuaPlot1";
+const char * tracyLuaPlot2 = "LuaPlot2";
+const char * tracyLuaPlot3 = "LuaPlot3";
+const char * tracyLuaPlot4 = "LuaPlot4";
+const char * tracyLuaPlot5 = "LuaPlot5";
+const char * tracyLuaPlot6 = "LuaPlot6";
+const char * tracyLuaPlot7 = "LuaPlot7";
+const char * tracyLuaPlot8 = "LuaPlot8";
+const char * tracyLuaPlot9 = "LuaPlot9";
+
+int LuaUnsyncedCtrl::LuaTracyPlotConfig(lua_State* L)
+{
+	const int plotIndex = std::clamp(luaL_checkint(L, 1), 1, 9);
+	const char* plotFormatTypeString = luaL_optstring(L, 2, "");
+	tracy::PlotFormatType plotFormatType = tracy::PlotFormatType::Number;
+
+	if (plotFormatTypeString[0] != 0 ){
+		if (plotFormatTypeString[0] == 'P') plotFormatType = tracy::PlotFormatType::Percentage; // for Perce
+		if (plotFormatTypeString[0] == 'M') plotFormatType = tracy::PlotFormatType::Memory; // for Perce
+	}
+	const bool step = luaL_optboolean(L, 3, true); // stepwise default
+	const bool fill = luaL_optboolean(L, 4, false); // no fill default
+	const uint32_t color = luaL_optint(L, 5, 0xffffff); // white default
+	switch(plotIndex){
+		case 1: TracyPlotConfig(tracyLuaPlot1, plotFormatType, step, fill, color); break;
+		case 2: TracyPlotConfig(tracyLuaPlot2, plotFormatType, step, fill, color); break;
+		case 3: TracyPlotConfig(tracyLuaPlot3, plotFormatType, step, fill, color); break;
+		case 4: TracyPlotConfig(tracyLuaPlot4, plotFormatType, step, fill, color); break;
+		case 5: TracyPlotConfig(tracyLuaPlot5, plotFormatType, step, fill, color); break;
+		case 6: TracyPlotConfig(tracyLuaPlot6, plotFormatType, step, fill, color); break;
+		case 7: TracyPlotConfig(tracyLuaPlot7, plotFormatType, step, fill, color); break;
+		case 8: TracyPlotConfig(tracyLuaPlot8, plotFormatType, step, fill, color); break;
+		case 9: TracyPlotConfig(tracyLuaPlot9, plotFormatType, step, fill, color); break;
+	}
+	return 0;
+}
+
+int LuaUnsyncedCtrl::LuaTracyPlot(lua_State* L)
+{
+	const int plotIndex = std::clamp(luaL_checkint(L, 1), 1, 9) ;
+	const float plotValue = luaL_checkfloat(L, 2);	
+	switch(plotIndex){
+		case 1: TracyPlot(tracyLuaPlot1, plotValue); break;
+		case 2: TracyPlot(tracyLuaPlot2, plotValue); break;
+		case 3: TracyPlot(tracyLuaPlot3, plotValue); break;
+		case 4: TracyPlot(tracyLuaPlot4, plotValue); break;
+		case 5: TracyPlot(tracyLuaPlot5, plotValue); break;
+		case 6: TracyPlot(tracyLuaPlot6, plotValue); break;
+		case 7: TracyPlot(tracyLuaPlot7, plotValue); break;
+		case 8: TracyPlot(tracyLuaPlot8, plotValue); break;
+		case 9: TracyPlot(tracyLuaPlot9, plotValue); break;
+	}
+	return 0;
 }

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4870,8 +4870,12 @@ int LuaUnsyncedCtrl::Yield(lua_State* L)
 	return 1;
 }
 
-/* NB: strings here are never cleaned up, but the use case assumes
- * that they live a long time and there's just a handful of them */
+/* Tracy seems to want unique, unchanging strings to be passed to
+ * its API, so we need to immanentize the ephemeral Lua strings
+ * and store them.
+ *
+ * NB: strings here are never cleaned up, but the use case assumes
+ * that they live a long time and there's just a handful of them. */
 std::set <std::string, std::less<>> tracyLuaPlots;
 
 /*** Configure custom appearence for a Tracy plot for use in debugging or profiling

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4868,6 +4868,8 @@ int LuaUnsyncedCtrl::Yield(lua_State* L)
 	return 1;
 }
 
+/* NB: strings here are never cleaned up, but the use case assumes
+ * that they live a long time and there's just a handful of them */
 std::set <std::string> tracyLuaPlots;
 
 /*** Initialize a plot in Tracy for use in debugging, up to 9 plots [1-9] may be used

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4878,6 +4878,16 @@ const char * tracyLuaPlot7 = "LuaPlot7";
 const char * tracyLuaPlot8 = "LuaPlot8";
 const char * tracyLuaPlot9 = "LuaPlot9";
 
+/***
+ *
+ * @function Spring.LuaTracyPlotConfig
+ * @number plotIndex which LuaPlot[1-9] should be initialized
+ * @string[opt] plotFormatType "Number"|"Percentage"|"Memory", default "Number"
+ * @bool[opt] step stepwise chart, default stepwise
+ * @bool[opt] fill color fill, default no fill
+ * @number[opt] color unit32 number as RGB color, default white
+ * @treturn nil
+ */
 int LuaUnsyncedCtrl::LuaTracyPlotConfig(lua_State* L)
 {
 	const int plotIndex = std::clamp(luaL_checkint(L, 1), 1, 9);
@@ -4905,6 +4915,13 @@ int LuaUnsyncedCtrl::LuaTracyPlotConfig(lua_State* L)
 	return 0;
 }
 
+/***
+ *
+ * @function Spring.LuaTracyPlot
+ * @number plotIndex which LuaPlot[1-9] should be updated
+ * @number plotvalue the number to show on the Tracy plot
+ * @treturn nil
+ */
 int LuaUnsyncedCtrl::LuaTracyPlot(lua_State* L)
 {
 	const int plotIndex = std::clamp(luaL_checkint(L, 1), 1, 9) ;

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4872,10 +4872,10 @@ int LuaUnsyncedCtrl::Yield(lua_State* L)
  * that they live a long time and there's just a handful of them */
 std::set <std::string> tracyLuaPlots;
 
-/*** Initialize a plot in Tracy for use in debugging or profiling
+/*** Configure custom appearence for a Tracy plot for use in debugging or profiling
  *
  * @function Spring.LuaTracyPlotConfig
- * @string plotName which should be initialized
+ * @string plotName which should be customized 
  * @string[opt] plotFormatType "Number"|"Percentage"|"Memory", default "Number"
  * @bool[opt] step stepwise chart, default true is stepwise
  * @bool[opt] fill color fill, default false is no fill
@@ -4885,39 +4885,39 @@ std::set <std::string> tracyLuaPlots;
 
 int LuaUnsyncedCtrl::LuaTracyPlotConfig(lua_State* L)
 {
-    const auto plotName 			= luaL_checkstring(L, 1);
-    const auto plotFormatTypeString = luaL_optstring(L, 2, "");
-    const auto step 				= luaL_optboolean(L, 3, true); // stepwise default
-    const auto fill 				= luaL_optboolean(L, 4, false); // no fill default
-    const uint32_t color 			= luaL_optint(L, 5, 0xFFFFFF); // white default
+	const auto plotName             = luaL_checkstring(L, 1);
+	const auto plotFormatTypeString = luaL_optstring(L, 2, "");
+	const auto step                 = luaL_optboolean(L, 3, true); // stepwise default
+	const auto fill                 = luaL_optboolean(L, 4, false); // no fill default
+	const uint32_t color            = luaL_optint(L, 5, 0xFFFFFF); // white default
 
-    tracy::PlotFormatType plotFormatType;
-    switch (plotFormatTypeString[0]) {
-        case 'p': case 'P': plotFormatType = tracy::PlotFormatType::Percentage; break;
-        case 'm': case 'M': plotFormatType = tracy::PlotFormatType::Memory;     break;
-        default:            plotFormatType = tracy::PlotFormatType::Number;     break;
-    }
+	tracy::PlotFormatType plotFormatType;
+	switch (plotFormatTypeString[0]) {
+		case 'p': case 'P': plotFormatType = tracy::PlotFormatType::Percentage; break;
+		case 'm': case 'M': plotFormatType = tracy::PlotFormatType::Memory;     break;
+		default:            plotFormatType = tracy::PlotFormatType::Number;     break;
+	}
 
-    const auto [iterator, inserted] = tracyLuaPlots.emplace(plotName);
-    TracyPlotConfig(iterator->c_str(), plotFormatType, step, fill, color);
-    return 0;
+	const auto [iterator, inserted] = tracyLuaPlots.emplace(plotName);
+	TracyPlotConfig(iterator->c_str(), plotFormatType, step, fill, color);
+	return 0;
 }
 
 
 /*** Update a Tracy Plot with a value
  *
  * @function Spring.LuaTracyPlot
- * @string plotName which LuaPlot should be updated (must have been initialized via LuaTracyPlotConfig)
+ * @string plotName which LuaPlot should be updated
  * @number plotvalue the number to show on the Tracy plot
  * @treturn nil
  */
 int LuaUnsyncedCtrl::LuaTracyPlot(lua_State* L)
 {
-    const auto plotName  = luaL_checkstring(L, 1);
-    const auto plotValue = luaL_checkfloat(L, 2);
+	const auto plotName  = luaL_checkstring(L, 1);
+	const auto plotValue = luaL_checkfloat(L, 2);
 
-    const auto [iterator, inserted] = tracyLuaPlots.emplace(plotName);
-    TracyPlot(iterator->c_str(), plotValue);
-    return 0;
+	const auto [iterator, inserted] = tracyLuaPlots.emplace(plotName);
+	TracyPlot(iterator->c_str(), plotValue);
+	return 0;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4878,7 +4878,7 @@ const char * tracyLuaPlot7 = "LuaPlot7";
 const char * tracyLuaPlot8 = "LuaPlot8";
 const char * tracyLuaPlot9 = "LuaPlot9";
 
-/***
+/*** Initialize a plot in Tracy for use in debugging, up to 9 plots [1-9] may be used
  *
  * @function Spring.LuaTracyPlotConfig
  * @number plotIndex which LuaPlot[1-9] should be initialized
@@ -4915,7 +4915,7 @@ int LuaUnsyncedCtrl::LuaTracyPlotConfig(lua_State* L)
 	return 0;
 }
 
-/***
+/*** Update a Tracy Plot with a value
  *
  * @function Spring.LuaTracyPlot
  * @number plotIndex which LuaPlot[1-9] should be updated

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -203,6 +203,9 @@ class LuaUnsyncedCtrl {
 		static int SetWindowMaximized(lua_State* L);
 
 		static int Yield(lua_State* L);
+
+		static int LuaTracyPlotConfig(lua_State* L);
+		static int LuaTracyPlot(lua_State* L);
 };
 
 #endif /* LUA_UNSYNCED_CTRL_H */


### PR DESCRIPTION
```
/*** Initialize a plot in Tracy for use in debugging or profiling
 *
 * @function Spring.LuaTracyPlotConfig
 * @string plotName which should be initialized
 * @string[opt] plotFormatType "Number"|"Percentage"|"Memory", default "Number"
 * @bool[opt] step stepwise chart, default true is stepwise
 * @bool[opt] fill color fill, default false is no fill
 * @number[opt] color unit32 number as BGR color, default white
 * @treturn nil
 */
```

```
/*** Update a Tracy Plot with a value
 *
 * @function Spring.LuaTracyPlot
 * @string plotName which LuaPlot should be updated (must have been initialized via LuaTracyPlotConfig)
 * @number plotvalue the number to show on the Tracy plot
 * @treturn nil
 */
```

I was now quickly able to plot chobby memory usage in a very fine grained way by wrapping a function via debug.sethook(), example below:

```
local function plotMem()
	if tracy then
		local ramuse = gcinfo()
		Spring.LuaTracyPlot("ChobbyMem",  ramuse)
	end
end
local function GetUserControls(userName,opts)
	debug.sethook(plotMem, 'c r')
	GetUserControlsWrapped(userName, opts)
	debug.sethook()
end
```
Result:
![image](https://github.com/beyond-all-reason/spring/assets/109391/24a4287f-8436-4344-836a-d96217ab777a)

Million thanks to @sprunk !