### PR TITLE
add OpenBSD into branching/building in several places

### DIFF
--- a/rts/CMakeLists.txt
+++ b/rts/CMakeLists.txt
@@ -77,9 +77,9 @@ if    (UNIX AND NOT MINGW)
 	list(APPEND engineCommonLibraries ${CMAKE_DL_LIBS})
 
 	# Needed for backtrace* on some systems
-	if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+	if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
 		list(APPEND engineCommonLibraries execinfo)
-	endif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+	endif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
 endif (UNIX AND NOT MINGW)
 
 find_package_static(ZLIB REQUIRED)
@@ -87,6 +87,9 @@ list(APPEND engineCommonLibraries ${IL_LIBRARIES} ${JPEG_LIBRARY} ${PNG_LIBRARY}
 list(APPEND engineCommonLibraries 7zip prd::jsoncpp ${SPRING_MINIZIP_LIBRARY} ${ZLIB_LIBRARY} Tracy::TracyClient)
 list(APPEND engineCommonLibraries lua luasocket archives assimp
 	gflags_nothreads_static)
+if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+	list(APPEND engineCommonLibraries execinfo)
+endif(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
 if (ENABLE_STREFLOP)
 	list(APPEND engineCommonLibraries streflop)
 endif ()
@@ -97,7 +100,7 @@ if (WIN32)
 	list(APPEND engineCommonLibraries ${WIN32_LIBRARIES})
 endif (WIN32)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
 	#tcmalloc on freebsd is broken, default disable it (#4754)
 	set(USE_TCMALLOC_DEFAULT FALSE)
 else()
@@ -112,7 +115,7 @@ if    (USE_TCMALLOC AND TCMALLOC_LIBRARY)
 endif (USE_TCMALLOC AND TCMALLOC_LIBRARY)
 
 
-if(UNIX)
+if(UNIX AND NOT (CMAKE_SYSTEM_NAME MATCHES "OpenBSD"))
 	find_package_static(Libunwind REQUIRED)
 	prefer_static_libs()
 	find_library(LZMA_LIBRARY lzma)

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -11,7 +11,7 @@
 #include "System/float3.h"
 #include "System/Misc/SpringTime.h"
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 // defined in X11/X.h
 #undef KeyPress
 #undef KeyRelease

--- a/rts/System/Platform/Linux/CrashHandler.cpp
+++ b/rts/System/Platform/Linux/CrashHandler.cpp
@@ -45,7 +45,7 @@
 #define ADDR2LINE "atos"
 #endif
 
-#if (defined(__FreeBSD__))
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 // show function names, demangle
 #define ADDR2LINE_ARGS " -f -C"
 #else

--- a/rts/System/Platform/Misc.cpp
+++ b/rts/System/Platform/Misc.cpp
@@ -247,7 +247,7 @@ namespace Platform
 		// this will only be used if moduleFilePath stays empty
 		const char* error = nullptr;
 
-	#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		#ifdef __APPLE__
 		#define SHARED_LIBRARY_EXTENSION "dylib"
 		#else
@@ -381,6 +381,8 @@ namespace Platform
 		return "Linux";
 		#elif defined(__FreeBSD__)
 		return "FreeBSD";
+		#elif defined(__OpenBSD__)
+		return "OpenBSD";
 		#elif defined(__APPLE__)
 		return "MacOS";
 		#else

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -12,7 +12,7 @@
 #include <functional>
 #include <memory>
 #include <cinttypes>
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #elif defined(_WIN32)
 	#include <windows.h>
 #else
@@ -37,7 +37,7 @@ namespace Threading {
 	static NativeThreadId nativeThreadIDs[THREAD_IDX_LAST] = {};
 	static Error threadError;
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #elif defined(_WIN32)
 	static DWORD_PTR cpusSystem = 0;
 #else
@@ -47,7 +47,7 @@ namespace Threading {
 
 	void DetectCores()
 	{
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		// no-op
 
 	#elif defined(_WIN32)
@@ -75,7 +75,7 @@ namespace Threading {
 
 
 
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 	#elif defined(_WIN32)
 	#else
 	static std::uint32_t CalcCoreAffinityMask(const cpu_set_t* cpuSet) {
@@ -110,7 +110,7 @@ namespace Threading {
 
 	std::uint32_t GetAffinity()
 	{
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		// no-op
 		return 0;
 
@@ -134,7 +134,7 @@ namespace Threading {
 		if (coreMask == 0)
 			return (~0);
 
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		// no-op
 		return 0;
 
@@ -190,7 +190,7 @@ namespace Threading {
 
 	std::uint32_t GetAvailableCoresMask()
 	{
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		// no-op
 		return (~0);
 	#elif defined(_WIN32)
@@ -219,7 +219,7 @@ namespace Threading {
 
 	void SetThreadScheduler()
 	{
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		// no-op
 
 	#elif defined(_WIN32)

--- a/rts/System/Platform/Threading.h
+++ b/rts/System/Platform/Threading.h
@@ -203,7 +203,7 @@ namespace Threading {
 namespace Threading {
 	bool NativeThreadIdsEqual(const NativeThreadId thID1, const NativeThreadId thID2)
 	{
-	#ifdef __APPLE__
+	#if defined(__APPLE__) || defined(__OpenBSD__)
 		// quote from the pthread_equal manpage:
 		// Implementations may choose to define a thread ID as a structure.
 		// This allows additional flexibility and robustness over using an int.

--- a/rts/System/Platform/byteorder.h
+++ b/rts/System/Platform/byteorder.h
@@ -59,7 +59,7 @@
 		// do not swab
 	#endif
 
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 
 	#include <sys/endian.h>
 

--- a/rts/System/Sound/OpenAL/SoundSource.cpp
+++ b/rts/System/Sound/OpenAL/SoundSource.cpp
@@ -215,7 +215,7 @@ void CSoundSource::Play(IAudioChannel* channel, SoundItem* item, float3 pos, flo
 		alSourcei(id, AL_SOURCE_RELATIVE, AL_TRUE);
 		alSourcef(id, AL_ROLLOFF_FACTOR, 0.f);
 		alSource3f(id, AL_POSITION, 0.0f, 0.0f, -1.0f * ELMOS_TO_METERS);
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 		alSourcef(id, AL_REFERENCE_DISTANCE, REFERENCE_DIST * ELMOS_TO_METERS);
 #endif
 	} else {
@@ -238,7 +238,7 @@ void CSoundSource::Play(IAudioChannel* channel, SoundItem* item, float3 pos, flo
 		alSourcef(id, AL_ROLLOFF_FACTOR, ROLLOFF_FACTOR * item->rolloff * heightRolloffModifier);
 
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 		alSourcef(id, AL_MAX_DISTANCE, 1000000.0f);
 		// Max distance is too small by default on my Mac...
 		ALfloat gain = channel->volume * item->GetGain() * volume;

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -301,7 +301,7 @@ bool SpringApp::Init()
 
 bool SpringApp::InitPlatformLibs()
 {
-#if !(defined(_WIN32) || defined(__APPLE__) || defined(HEADLESS))
+#if !(defined(_WIN32) || defined(__APPLE__) || defined(HEADLESS)) || defined(__OpenBSD__)
 	// MUST run before any other X11 call (including
 	// those by SDL) to make calls to X11 threadsafe
 	if (!XInitThreads()) {

--- a/rts/builds/dedicated/CMakeLists.txt
+++ b/rts/builds/dedicated/CMakeLists.txt
@@ -44,9 +44,9 @@ if    (UNIX AND NOT MINGW)
 	list(APPEND engineDedicatedLibraries ${CMAKE_DL_LIBS})
 
 	# Needed for backtrace* on some systems
-	if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+	if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
 		list(APPEND engineDedicatedLibraries execinfo)
-	endif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+	endif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
 endif (UNIX AND NOT MINGW)
 
 find_package(SDL2 REQUIRED)


### PR DESCRIPTION
In many places it's just accounting for OpenBSD like for FreeBSD. Also avoiding some non-existent libraries like libunwind, librt. zlib.h needs to be added in a few places on OpenBSD, and ucontext.h in one. Overall this is the more straightforward part of supporting the engine on OpenBSD.