### PR TITLE
Fac insert obeys mults

### DIFF
--- a/rts/Sim/Units/CommandAI/FactoryCAI.cpp
+++ b/rts/Sim/Units/CommandAI/FactoryCAI.cpp
@@ -141,6 +141,14 @@ CFactoryCAI::CFactoryCAI(CUnit* owner): CCommandAI(owner)
 }
 
 
+static constexpr int GetCountMultiplierFromOptions(int opts)
+{
+	// The choice of keys and their associated multipliers are from OTA.
+	int ret = 1;
+	if (opts &   SHIFT_KEY) ret *=  5;
+	if (opts & CONTROL_KEY) ret *= 20;
+	return ret;
+}
 
 void CFactoryCAI::GiveCommandReal(const Command& c, bool fromSynced)
 {
@@ -224,10 +232,7 @@ void CFactoryCAI::GiveCommandReal(const Command& c, bool fromSynced)
 	}
 
 	int& numQueued = boi->second;
-	int numItems = 1;
-
-	if (c.GetOpts() & SHIFT_KEY)   { numItems *= 5; }
-	if (c.GetOpts() & CONTROL_KEY) { numItems *= 20; }
+	int numItems = GetCountMultiplierFromOptions(c.GetOpts());
 
 	if (c.GetOpts() & RIGHT_MOUSE_KEY) {
 		numQueued -= numItems;

--- a/rts/Sim/Units/CommandAI/FactoryCAI.cpp
+++ b/rts/Sim/Units/CommandAI/FactoryCAI.cpp
@@ -292,8 +292,9 @@ void CFactoryCAI::InsertBuildCommand(CCommandQueue::iterator& it,
                                      const Command& newCmd)
 {
 	const auto boi = buildOptions.find(newCmd.GetID());
+	auto buildCount = GetCountMultiplierFromOptions(newCmd.GetOpts());
 	if (boi != buildOptions.end()) {
-		boi->second++;
+		boi->second += buildCount;
 		UpdateIconName(newCmd.GetID(), boi->second);
 	}
 	if (!commandQue.empty() && (it == commandQue.begin())) {
@@ -301,7 +302,8 @@ void CFactoryCAI::InsertBuildCommand(CCommandQueue::iterator& it,
 		CFactory* fac = static_cast<CFactory*>(owner);
 		fac->StopBuild();
 	}
-	commandQue.insert(it, newCmd);
+	while (buildCount--)
+		it = commandQue.insert(it, newCmd);
 }
 
 


### PR DESCRIPTION
Issue: if you tell the factory to build something with CTRL and/or SHIFT modifiers it gets multiplied by x20 and/or x5 respectively. But this doesn't work if you do it via the insert command, the modifiers are then ignored (and you have to work around it by sending a bunch of x1 commands in a loop).

This patch fixes this behaviour. See https://github.com/ZeroK-RTS/Zero-K/tree/fac-insert for a test case (build a fac, queue a unit, alt+shift queue a different one)