### PR TITLE
UpdateWeaponVectors MT

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -665,12 +665,24 @@ void CUnit::Update()
 	outOfMapTime *= (!pos.IsInBounds());
 }
 
-void CUnit::UpdateWeapons()
+void CUnit::UpdateWeaponVectors()
 {
 	ZoneScoped;
 	if (!CanUpdateWeapons())
 		return;
+	for (CWeapon* w : weapons) {
+		w->UpdateWeaponVectors();
+	}
+}
 
+void CUnit::UpdateWeapons()
+{
+	ZoneScoped;
+	{
+		ZoneScopedN("CanUpdateWeapons");
+		if (!CanUpdateWeapons())
+			return;
+	}
 	for (CWeapon* w: weapons) {
 		w->Update();
 	}

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -673,6 +673,7 @@ void CUnit::UpdateWeaponVectors()
 		return;
 
 	for (CWeapon* w : weapons) {
+		w->UpdateWeaponErrorVector();
 		w->UpdateWeaponVectors();
 	}
 }

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -668,8 +668,10 @@ void CUnit::Update()
 void CUnit::UpdateWeaponVectors()
 {
 	ZoneScoped;
+
 	if (!CanUpdateWeapons())
 		return;
+
 	for (CWeapon* w : weapons) {
 		w->UpdateWeaponVectors();
 	}
@@ -678,11 +680,10 @@ void CUnit::UpdateWeaponVectors()
 void CUnit::UpdateWeapons()
 {
 	ZoneScoped;
-	{
-		ZoneScopedN("CanUpdateWeapons");
-		if (!CanUpdateWeapons())
+
+	if (!CanUpdateWeapons())
 			return;
-	}
+
 	for (CWeapon* w: weapons) {
 		w->Update();
 	}

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -195,6 +195,7 @@ public:
 	void UpdateLosStatus(int allyTeam);
 
 	void UpdateWeapons();
+	void UpdateWeaponVectors();
 
 	void SlowUpdateWeapons();
 	void SlowUpdateKamikaze(bool scanForTargets);

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -28,6 +28,7 @@
 #include "System/TimeProfiler.h"
 #include "System/creg/STL_Deque.h"
 #include "System/creg/STL_Set.h"
+#include "System/Threading/ThreadPool.h"
 
 #include "Sim/Path/HAPFS/PathGlobal.h"
 
@@ -401,9 +402,18 @@ void CUnitHandler::UpdateUnits()
 
 void CUnitHandler::UpdateUnitWeapons()
 {
-	SCOPED_TIMER("Sim::Unit::Weapon");
-	for (activeUpdateUnit = 0; activeUpdateUnit < activeUnits.size(); ++activeUpdateUnit) {
-		activeUnits[activeUpdateUnit]->UpdateWeapons();
+	{
+		SCOPED_TIMER("Sim::Unit::UpdateWeaponVectors");
+		for_mt(0, activeUnits.size(), [&](const int idx) {
+			auto unit = activeUnits[idx];
+			unit->UpdateWeaponVectors();
+		});
+	}
+	{
+		SCOPED_TIMER("Sim::Unit::Weapon");
+		for (activeUpdateUnit = 0; activeUpdateUnit < activeUnits.size(); ++activeUpdateUnit) {
+			activeUnits[activeUpdateUnit]->UpdateWeapons();
+		}
 	}
 }
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -256,6 +256,13 @@ void CWeapon::UpdateWeaponPieces(const bool updateAimFrom)
 
 void CWeapon::UpdateWeaponVectors()
 {
+	ZoneScoped;
+
+	float3 newErrorVector = (errorVector + errorVectorAdd);
+	if (newErrorVector.SqLength() <= 1.0f)
+		errorVector = newErrorVector;
+
+
 	relAimFromPos = owner->script->GetPiecePos(aimFromPiece);
 	owner->script->GetEmitDirPos(muzzlePiece, relWeaponMuzzlePos, weaponDir);
 
@@ -291,9 +298,9 @@ void CWeapon::Update()
 	ZoneScoped;
 	// update conditional cause last SlowUpdate maybe longer away than UNIT_SLOWUPDATE_RATE
 	// i.e. when the unit got stunned (neither is SlowUpdate exactly called at UNIT_SLOWUPDATE_RATE, it's only called `close` to that)
-	float3 newErrorVector = (errorVector + errorVectorAdd);
-	if (newErrorVector.SqLength() <= 1.0f)
-		errorVector = newErrorVector;
+	//float3 newErrorVector = (errorVector + errorVectorAdd);
+	//if (newErrorVector.SqLength() <= 1.0f)
+	//	errorVector = newErrorVector;
 
 	// Fast auto targeting needs to trigger an immediate retarget once the target is dead.
 	bool fastAutoRetargetRequired = fastAutoRetargeting && HaveTarget()
@@ -314,7 +321,7 @@ void CWeapon::Update()
 	if (!HaveTarget() && owner->curTarget.type != Target_None)
 		Attack(owner->curTarget);
 
-	UpdateWeaponVectors();
+	//UpdateWeaponVectors();
 	currentTargetPos = GetLeadTargetPos(currentTarget);
 
 	if (!UpdateStockpile())

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -298,9 +298,6 @@ void CWeapon::Update()
 	ZoneScoped;
 	// update conditional cause last SlowUpdate maybe longer away than UNIT_SLOWUPDATE_RATE
 	// i.e. when the unit got stunned (neither is SlowUpdate exactly called at UNIT_SLOWUPDATE_RATE, it's only called `close` to that)
-	//float3 newErrorVector = (errorVector + errorVectorAdd);
-	//if (newErrorVector.SqLength() <= 1.0f)
-	//	errorVector = newErrorVector;
 
 	// Fast auto targeting needs to trigger an immediate retarget once the target is dead.
 	bool fastAutoRetargetRequired = fastAutoRetargeting && HaveTarget()
@@ -321,7 +318,6 @@ void CWeapon::Update()
 	if (!HaveTarget() && owner->curTarget.type != Target_None)
 		Attack(owner->curTarget);
 
-	//UpdateWeaponVectors();
 	currentTargetPos = GetLeadTargetPos(currentTarget);
 
 	if (!UpdateStockpile())

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -254,14 +254,18 @@ void CWeapon::UpdateWeaponPieces(const bool updateAimFrom)
 }
 
 
-void CWeapon::UpdateWeaponVectors()
+void CWeapon::UpdateWeaponErrorVector()
 {
-	ZoneScoped;
-
+	// update conditional cause last SlowUpdate maybe longer away than UNIT_SLOWUPDATE_RATE
+	// i.e. when the unit got stunned (neither is SlowUpdate exactly called at UNIT_SLOWUPDATE_RATE, it's only called `close` to that)
 	float3 newErrorVector = (errorVector + errorVectorAdd);
 	if (newErrorVector.SqLength() <= 1.0f)
 		errorVector = newErrorVector;
+}
 
+void CWeapon::UpdateWeaponVectors()
+{
+	ZoneScoped;
 
 	relAimFromPos = owner->script->GetPiecePos(aimFromPiece);
 	owner->script->GetEmitDirPos(muzzlePiece, relWeaponMuzzlePos, weaponDir);
@@ -296,8 +300,6 @@ float CWeapon::GetPredictedImpactTime(float3 p) const
 void CWeapon::Update()
 {
 	ZoneScoped;
-	// update conditional cause last SlowUpdate maybe longer away than UNIT_SLOWUPDATE_RATE
-	// i.e. when the unit got stunned (neither is SlowUpdate exactly called at UNIT_SLOWUPDATE_RATE, it's only called `close` to that)
 
 	// Fast auto targeting needs to trigger an immediate retarget once the target is dead.
 	bool fastAutoRetargetRequired = fastAutoRetargeting && HaveTarget()

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -96,6 +96,7 @@ public:
 	bool StopAttackingAllyTeam(const int ally);
 
 	bool IsFastAutoRetargetingEnabled() const { return fastAutoRetargeting; }
+	void UpdateWeaponVectors();
 
 protected:
 	virtual void FireImpl(const bool scriptCall) {}
@@ -107,7 +108,6 @@ protected:
 	static bool TargetInWater(const float3 tgtPos, const SWeaponTarget&);
 
 	void UpdateWeaponPieces(const bool updateAimFrom = true);
-	void UpdateWeaponVectors();
 	float3 GetLeadVec(const CUnit* unit) const;
 
 private:

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -96,6 +96,7 @@ public:
 	bool StopAttackingAllyTeam(const int ally);
 
 	bool IsFastAutoRetargetingEnabled() const { return fastAutoRetargeting; }
+	void UpdateWeaponErrorVector();
 	void UpdateWeaponVectors();
 
 protected:


### PR DESCRIPTION
This PR multithreads one of the most expensive parts of UpdateUnitWeapons, namely updating the weapon vectors. 
All units who have weapons perform this task every frame. The UpdateWeaponVectors function is self-contained, and does not call into lua or bos.

However, in order to make this optimization possible, the UpdateWeaponVectors function has to be called before fastautoretargeting and attacking existing targets. 
This is mostly due to the fact that Weapon::Update is virtual function, which would otherwise make any preMT/MT/postMT split near impossible. Also, most Weapon::Update overrides also do their own UpdateWeaponVectors, as does, for example Weapon::Attack. 

I have tested this change on the behaviour of a lot of units shooting, and found no unwanted side effects. 

Performance testing on two cases:
1. `/give 2000 armflash` These units are left idle. 

Old ST, 880 us per frame
![image](https://github.com/beyond-all-reason/spring/assets/109391/7d1bbee8-efe5-4c41-b7e7-8715beb4a532)

New MT, a total of 500 us per frame:
![image](https://github.com/beyond-all-reason/spring/assets/109391/d7a79937-8143-4c01-a3e1-1cb0a2325184)

2. `/luarules fightertest corak armpw` In this test, where almost all units are aiming and firing, 

Old ST: 1200 us per frame
New MT: 1050 us per frame. 

