### PR TITLE
docs(LuaVAOImpl): remove extra parameter from DrawArrays doc comment

### DIFF
--- a/rts/Lua/LuaVAOImpl.cpp
+++ b/rts/Lua/LuaVAOImpl.cpp
@@ -368,7 +368,6 @@ LuaVAOImpl::DrawCheckResult LuaVAOImpl::DrawCheck(GLenum mode, const DrawCheckIn
  *
  * @function VAO:DrawArrays
  * @number glEnum primitivesMode
- * @number[opt] numVertices
  * @number[opt] vertexCount
  * @number[opt] vertexFirst
  * @number[opt] instanceCount


### PR DESCRIPTION
Just makes the documentation match the function definition.