### PR TITLE
Fix #1225: Add Spring.GetModOption(string) -> string

### DIFF
--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -123,7 +123,8 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(GetPlayerRulesParam);
 	REGISTER_LUA_CFUNC(GetPlayerRulesParams);
-
+	
+	REGISTER_LUA_CFUNC(GetMapOption);
 	REGISTER_LUA_CFUNC(GetMapOptions);
 	REGISTER_LUA_CFUNC(GetModOption);
 	REGISTER_LUA_CFUNC(GetModOptions);
@@ -1258,7 +1259,26 @@ int LuaSyncedRead::GetFeatureRulesParam(lua_State* L)
  *     if (Spring.GetModOptions.exampleOption) then...end
 ******************************************************************************/
 
+/***
+ *
+ * @function Spring.GetMapOption
+ *
+ * @string mapOption
+ *
+ * @treturn string value of mapOption  
+ * */
+int LuaSyncedRead::GetMapOption(lua_State* L)
+{
+	const auto& mapOpts = CGameSetup::GetMapOptions();
+	
+	const std::string& opt = luaL_checkstring(L, 1);
 
+	const std::string* optValue = mapOpts.try_get(opt);
+	if (optValue == nullptr)
+		return 0;
+	lua_pushsstring(L, *optValue);
+	return 1;
+}
 /***
  *
  * @function Spring.GetMapOptions
@@ -1295,14 +1315,11 @@ int LuaSyncedRead::GetModOption(lua_State* L)
 	
 	const std::string& opt = luaL_checkstring(L, 1);
 
-	if (modOpts.find(opt) == modOpts.end()) {
+	const std::string* optValue = modOpts.try_get(opt);
+	if (optValue == nullptr)
 		return 0;
-	}
-	else {
-		const std::string* optValue = modOpts.try_get(opt);
-		lua_pushsstring(L, *optValue);
-		return 1;
-	}
+	lua_pushsstring(L, *optValue);
+	return 1;	
 }
 
 

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -1295,8 +1295,6 @@ int LuaSyncedRead::GetModOption(lua_State* L)
 	
 	const std::string& opt = luaL_checkstring(L, 1);
 
-	const std::string* debuggingStr = modOpts.try_get(opt);
-
 	if (modOpts.find(opt) == modOpts.end()) {
 		return 0;
 	}

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -125,6 +125,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetPlayerRulesParams);
 
 	REGISTER_LUA_CFUNC(GetMapOptions);
+	REGISTER_LUA_CFUNC(GetModOption);
 	REGISTER_LUA_CFUNC(GetModOptions);
 
 	REGISTER_LUA_CFUNC(GetTidal);
@@ -1277,6 +1278,33 @@ int LuaSyncedRead::GetMapOptions(lua_State* L)
 	}
 
 	return 1;
+}
+
+
+/***
+ *
+ * @function Spring.GetModOption
+ *
+ * @string modOption 
+ *
+ * @treturn string value of modOption in option map
+ */
+int LuaSyncedRead::GetModOption(lua_State* L)
+{
+	const auto& modOpts = CGameSetup::GetModOptions();
+	
+	const std::string& opt = luaL_checkstring(L, 1);
+
+	const std::string* debuggingStr = modOpts.try_get(opt);
+
+	if (modOpts.find(opt) == modOpts.end()) {
+		return 0;
+	}
+	else {
+		const std::string* optValue = modOpts.try_get(opt);
+		lua_pushsstring(L, *optValue);
+		return 1;
+	}
 }
 
 

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -16,6 +16,7 @@ class LuaSyncedRead {
 
 	public: // also used with LuaParser clients
 		static int GetMapOptions(lua_State* L);
+		static int GetModOption(lua_State* L);
 		static int GetModOptions(lua_State* L);
 
 	private:

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -15,6 +15,7 @@ class LuaSyncedRead {
 		static void AllowGameChanges(bool value);
 
 	public: // also used with LuaParser clients
+		static int GetMapOption(lua_State* L);
 		static int GetMapOptions(lua_State* L);
 		static int GetModOption(lua_State* L);
 		static int GetModOptions(lua_State* L);


### PR DESCRIPTION
Fix of #1225: Add "Spring.GetModOption(string) -> string"

This PR varies slightly from the request in #1225, as it adds a new function GetModOption() instead of overloading GetModOptions(). This choice was made to be consistent with existing LuaSyncedRead functions (same pattern as GetGameRulesParam vs. GetGameRulesParams, GetPlayerRulesParam vs. GetPlayerRulesParams, etc.).

Limited testing validated that this is working as expected, but I would appreciate additional testing because I'm relatively new to this project and may have overlooked something.

Note the discussion on the [issue page](https://github.com/beyond-all-reason/spring/issues/1225): Spring.GetModOption("foo") may not return the same value as Spring.GetModOptions().foo if a game has overridden Spring.GetModOptions().