### PR TITLE
Add `Spring.GetGameTimeDraw() -> number`

### DIFF
--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -111,6 +111,7 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(GetDrawFrame);
 	REGISTER_LUA_CFUNC(GetFrameTimeOffset);
+	REGISTER_LUA_CFUNC(GetGameSecondsInterpolated);
 	REGISTER_LUA_CFUNC(GetLastUpdateSeconds);
 	REGISTER_LUA_CFUNC(GetVideoCapturingMode);
 
@@ -1072,6 +1073,17 @@ int LuaUnsyncedRead::GetFrameTimeOffset(lua_State* L)
 	return 1;
 }
 
+/*** Gets game time for drawing purposes
+ *
+ * Returns the game time, taking the interpolated draw frame into account.
+ *
+ * @treturn number game time in seconds
+ */
+int LuaUnsyncedRead::GetGameSecondsInterpolated(lua_State* L)
+{
+	lua_pushnumber(L, (gs->GetLuaSimFrame() + globalRendering->timeOffset) / GAME_SPEED);
+	return 1;
+}
 
 /***
  *

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -27,6 +27,7 @@ class LuaUnsyncedRead {
 
 		static int GetDrawFrame(lua_State* L);
 		static int GetFrameTimeOffset(lua_State* L);
+		static int GetGameSecondsInterpolated(lua_State* L);
 		static int GetLastUpdateSeconds(lua_State* L);
 		static int GetVideoCapturingMode(lua_State* L);
 


### PR DESCRIPTION
Check out the patterns of use for `Spring.GetFrameTimeOffset()` across a wide array of games including multiple examples in large ones:

https://github.com/search?q=getframetimeoffset+lang%3Alua+-is%3Afork&type=code

https://github.com/spring1944/spring1944/blob/master/ModelMaterials/0_flags.lua#L71

https://github.com/SplinterFaction/SplinterFaction/blob/c15fa5edb30f28386a31fea7706dc3a8bb8a868a/LuaUI/Widgets/cmd_mex_placement.lua#L753

https://github.com/techannihilation/TA/blob/master/lups/particleclasses/nanolasersnoshader.lua#L156

https://github.com/Arch-Shaman/ZK-Futurewars-Mod/blob/Stable/LuaRules/Gadgets/unit_cloak_shield.lua#L837

https://github.com/azaremoth/cursed/blob/2944b8f08ee294d18610c5750f61b7df058f0df7/LuaUI/Widgets/minimap_events.lua#L158
https://github.com/SpringCabal/Hunted-Map/blob/2b3bee4d0e9ce3a35b324edbb887885c3479f644/LuaGaia/Gadgets/precipitation.lua#L358-L359

https://github.com/SpringCabal/Flove/blob/0e6e70566dc32452f73ebc318583bed7859cdcb8/LuaRules/Gadgets/wisp_animation.lua#L371-L372

https://github.com/beyond-all-reason/Beyond-All-Reason/blob/e18f89d9c5fefe3ee8edae11e3972ba43d2f3b6f/luaui/Widgets/dbg_jitter_timer.lua#L140

https://github.com/ZeroK-RTS/Zero-K/blob/006f7ab8cdfe749dc232c76e373ee59e33512f2a/lups/ParticleClasses/NanoLasers.lua#L140

https://github.com/beyond-all-reason/Beyond-All-Reason/blob/e18f89d9c5fefe3ee8edae11e3972ba43d2f3b6f/lups/particleclasses/unitjitter.lua#L66

https://github.com/beyond-all-reason/Beyond-All-Reason/blob/e18f89d9c5fefe3ee8edae11e3972ba43d2f3b6f/lups/particleclasses/jitterparticles2.lua#L173

https://github.com/beyond-all-reason/Beyond-All-Reason/blob/e18f89d9c5fefe3ee8edae11e3972ba43d2f3b6f/lups/particleclasses/shieldjitter.lua#L57

https://github.com/beyond-all-reason/Beyond-All-Reason/blob/e18f89d9c5fefe3ee8edae11e3972ba43d2f3b6f/lups/particleclasses/ShieldSphereColor.lua#L130

https://github.com/beyond-all-reason/Beyond-All-Reason/blob/e18f89d9c5fefe3ee8edae11e3972ba43d2f3b6f/lups/particleclasses/shieldsphere.lua#L95

Almost everywhere it's `(Spring.GetFrameTimeOffset() + currentFrame) / 30` one way or another. This suggests a need to have a function which does this natively, which is this PR.