### PR TITLE
Execute animations in a multithreaded way.

### DIFF
--- a/rts/Sim/Units/Scripts/UnitScript.cpp
+++ b/rts/Sim/Units/Scripts/UnitScript.cpp
@@ -234,10 +234,9 @@ void CUnitScript::TickAllAnims(int deltaTime)
 
 	// tick-functions; these never change address
 	static constexpr TickAnimFunc tickAnimFuncs[AMove + 1] = { &CUnitScript::TickTurnAnim, &CUnitScript::TickSpinAnim, &CUnitScript::TickMoveAnim };
-	{
-		for (int animType = ATurn; animType <= AMove; animType++) {
-			TickAnims(1000 / deltaTime, tickAnimFuncs[animType], anims[animType], doneAnimsMT[animType]);
-		}
+
+	for (int animType = ATurn; animType <= AMove; animType++) {
+		TickAnims(1000 / deltaTime, tickAnimFuncs[animType], anims[animType], doneAnimsMT[animType]);
 	}
 }
 

--- a/rts/Sim/Units/Scripts/UnitScript.cpp
+++ b/rts/Sim/Units/Scripts/UnitScript.cpp
@@ -257,14 +257,12 @@ bool CUnitScript::TickAnimFinished(int deltaTime)
 	// AnimContainerType doneAnimsMT[AMove + 1];
 
 	// Tell listeners to unblock, and remove finished animations from the unit/script.
-	{
-		for (int animType = ATurn; animType <= AMove; animType++) {
-			for (AnimInfo& ai : doneAnimsMT[animType]) {
-				AnimFinished(static_cast<AnimType>(animType), ai.piece, ai.axis);
-			}
-
-			doneAnimsMT[animType].clear();
+	for (int animType = ATurn; animType <= AMove; animType++) {
+		for (AnimInfo& ai : doneAnimsMT[animType]) {
+			AnimFinished(static_cast<AnimType>(animType), ai.piece, ai.axis);
 		}
+
+		doneAnimsMT[animType].clear();
 	}
 	return (HaveAnimations());
 }

--- a/rts/Sim/Units/Scripts/UnitScript.cpp
+++ b/rts/Sim/Units/Scripts/UnitScript.cpp
@@ -201,8 +201,9 @@ bool CUnitScript::Tick(int deltaTime)
 	// vector of indexes of finished animations,
 	// so we can get rid of them in constant time
 	static AnimContainerType doneAnims[AMove + 1];
+
 	// tick-functions; these never change address
-	static constexpr TickAnimFunc tickAnimFuncs[AMove + 1] = {&CUnitScript::TickTurnAnim, &CUnitScript::TickSpinAnim, &CUnitScript::TickMoveAnim};
+	static constexpr TickAnimFunc tickAnimFuncs[AMove + 1] = { &CUnitScript::TickTurnAnim, &CUnitScript::TickSpinAnim, &CUnitScript::TickMoveAnim };
 
 	for (int animType = ATurn; animType <= AMove; animType++) {
 		TickAnims(1000 / deltaTime, tickAnimFuncs[animType], anims[animType], doneAnims[animType]);
@@ -211,7 +212,7 @@ bool CUnitScript::Tick(int deltaTime)
 	// Tell listeners to unblock, and remove finished animations from the unit/script.
 	for (int animType = ATurn; animType <= AMove; animType++) {
 		for (AnimInfo& ai: doneAnims[animType]) {
-			AnimFinished((AnimType) animType, ai.piece, ai.axis);
+			AnimFinished(static_cast<AnimType>(animType), ai.piece, ai.axis);
 		}
 
 		doneAnims[animType].clear();
@@ -224,31 +225,32 @@ bool CUnitScript::Tick(int deltaTime)
  * @brief The multithreaded first half of the original CUnitScript::Tick function first does the heavy lifting of calculating all
 			  new piece positions according to the animations
 */
-bool CUnitScript::Tick_mt(int deltaTime)
+void CUnitScript::TickAllAnims(int deltaTime)
 {
 	ZoneScoped;
 	// vector of indexes of finished animations,
 	// so we can get rid of them in constant time is stored in each units CUnitScript class at doneAnimsMT
 	// AnimContainerType doneAnimsMT[AMove + 1];
-	constexpr TickAnimFunc tickAnimFuncs[AMove + 1] = { &CUnitScript::TickTurnAnim, &CUnitScript::TickSpinAnim, &CUnitScript::TickMoveAnim };
+
+	// tick-functions; these never change address
+	static constexpr TickAnimFunc tickAnimFuncs[AMove + 1] = { &CUnitScript::TickTurnAnim, &CUnitScript::TickSpinAnim, &CUnitScript::TickMoveAnim };
 	{
 		for (int animType = ATurn; animType <= AMove; animType++) {
 			TickAnims(1000 / deltaTime, tickAnimFuncs[animType], anims[animType], doneAnimsMT[animType]);
 		}
 	}
-	return true;
 }
-/**
-	 * @brief The single threaded second half of this function does the removal of finished animations,
-			  and it also is responsible for unblocking the listeners and returning wether we have animations or not.
-			  This is not multi threaded as it guarantees that AnimFinished will be called in consistent order for
-			  all anims for all participants of the simulation, and guarantees that the order of the animating
-			  vector in CUnitScriptEngine::Tick is preserved.
-	 * @param deltaTime int delta time to update
-	 * @return true if there are still active animations
-	 */
 
-bool CUnitScript::Tick_st(int deltaTime)
+/**
+* @brief The single threaded second half of this function does the removal of finished animations,
+		and it also is responsible for unblocking the listeners and returning wether we have animations or not.
+		This is not multi threaded as it guarantees that AnimFinished will be called in consistent order for
+		all anims for all participants of the simulation, and guarantees that the order of the animating
+		vector in CUnitScriptEngine::Tick is preserved.
+* @param deltaTime int delta time to update
+* @return true if there are still active animations
+*/
+bool CUnitScript::TickAnimFinished(int deltaTime)
 {
 	ZoneScoped;
 	// vector of indexes of finished animations,
@@ -259,7 +261,7 @@ bool CUnitScript::Tick_st(int deltaTime)
 	{
 		for (int animType = ATurn; animType <= AMove; animType++) {
 			for (AnimInfo& ai : doneAnimsMT[animType]) {
-				AnimFinished((AnimType)animType, ai.piece, ai.axis);
+				AnimFinished(static_cast<AnimType>(animType), ai.piece, ai.axis);
 			}
 
 			doneAnimsMT[animType].clear();

--- a/rts/Sim/Units/Scripts/UnitScript.h
+++ b/rts/Sim/Units/Scripts/UnitScript.h
@@ -113,8 +113,8 @@ public:
 	const CUnit* GetUnit() const { return unit; }
 
 	bool Tick(int tickRate);
-	bool Tick_mt(int tickRate);
-	bool Tick_st(int tickRate);
+	void TickAllAnims(int tickRate);
+	bool TickAnimFinished(int tickRate);
 	// note: must copy-and-set here (LMP dirty flag, etc)
 	bool TickMoveAnim(int tickRate, LocalModelPiece& lmp, AnimInfo& ai) { float3 pos = lmp.GetPosition(); const bool ret = MoveToward(pos[ai.axis], ai.dest, ai.speed / tickRate); lmp.SetPosition(pos); return ret; }
 	bool TickTurnAnim(int tickRate, LocalModelPiece& lmp, AnimInfo& ai) { float3 rot = lmp.GetRotation(); rot[ai.axis] = ClampRad(rot[ai.axis]); const bool ret = TurnToward(rot[ai.axis], ai.dest, ai.speed / tickRate         ); lmp.SetRotation(rot); return ret; }

--- a/rts/Sim/Units/Scripts/UnitScript.h
+++ b/rts/Sim/Units/Scripts/UnitScript.h
@@ -44,6 +44,12 @@ protected:
 
 	AnimContainerType anims[AMove + 1];
 
+	//This vector is used to finished animations can be removed in linear time. 
+	// A single static allocation of this in CUnitScript::Tick is enough when only doing single threaded animations, 
+	// however multi threaded animation calculation cannot share this static vector across multiple threads, 
+	// so we need to allocate one of these for each CUnitScript instance. 
+	AnimContainerType doneAnimsMT[AMove + 1];
+
 
 	bool hasSetSFXOccupy;
 	bool hasRockUnit;
@@ -107,6 +113,8 @@ public:
 	const CUnit* GetUnit() const { return unit; }
 
 	bool Tick(int tickRate);
+	bool Tick_mt(int tickRate);
+	bool Tick_st(int tickRate);
 	// note: must copy-and-set here (LMP dirty flag, etc)
 	bool TickMoveAnim(int tickRate, LocalModelPiece& lmp, AnimInfo& ai) { float3 pos = lmp.GetPosition(); const bool ret = MoveToward(pos[ai.axis], ai.dest, ai.speed / tickRate); lmp.SetPosition(pos); return ret; }
 	bool TickTurnAnim(int tickRate, LocalModelPiece& lmp, AnimInfo& ai) { float3 rot = lmp.GetRotation(); rot[ai.axis] = ClampRad(rot[ai.axis]); const bool ret = TurnToward(rot[ai.axis], ai.dest, ai.speed / tickRate         ); lmp.SetRotation(rot); return ret; }

--- a/rts/Sim/Units/Scripts/UnitScriptEngine.cpp
+++ b/rts/Sim/Units/Scripts/UnitScriptEngine.cpp
@@ -16,7 +16,7 @@
 #include "System/Config/ConfigHandler.h"
 
 
-CONFIG(int, AnimationMT).defaultValue(1).safemodeValue(0).minimumValue(0).description("Enable multithreaded execution of animation ticks");
+CONFIG(bool, AnimationMT).defaultValue(true).safemodeValue(false).minimumValue(false).description("Enable multithreaded execution of animation ticks");
 
 static CCobEngine gCobEngine;
 static CCobFileHandler gCobFileHandler;
@@ -103,6 +103,7 @@ void CUnitScriptEngine::ReloadScripts(const UnitDef* udef)
 
 void CUnitScriptEngine::AddInstance(CUnitScript* instance)
 {
+	assert(currentScript == nullptr);
 	if (instance == currentScript)
 		return;
 
@@ -111,67 +112,63 @@ void CUnitScriptEngine::AddInstance(CUnitScript* instance)
 
 void CUnitScriptEngine::RemoveInstance(CUnitScript* instance)
 {
+	assert(currentScript == nullptr);
 	if (instance == currentScript)
 		return;
 
 	spring::VectorErase(animating, instance);
 }
 
-
 void CUnitScriptEngine::Tick(int deltaTime)
 {
-	int animation_mt = configHandler->GetInt("AnimationMT");
-	if (animation_mt == 1) {
-		Tick_mt(deltaTime);
-		return;
-	}
-	{
-		cobEngine->Tick(deltaTime);
-		{
-			ZoneScoped;
-			// tick all (COB or LUS) script instances that have registered themselves as animating
-			for (size_t i = 0; i < animating.size(); ) {
-				currentScript = animating[i];
+	SCOPED_TIMER("CUnitScriptEngine::Tick");
 
-				if (!currentScript->Tick(deltaTime)) {
-					animating[i] = animating.back();
-					animating.pop_back();
-					continue;
-				}
+	cobEngine->Tick(deltaTime);
 
-				i++;
-			}
-		}
-		currentScript = nullptr;
-	}
+	using ImplFunctionT = decltype(&CUnitScriptEngine::ImplTickST);
+	static constexpr ImplFunctionT ImplFunctions[] = { &CUnitScriptEngine::ImplTickST, &CUnitScriptEngine::ImplTickMT };
+	// TODO: remove the conditional once it's proven to be sync safe
+	(this->*ImplFunctions[configHandler->GetInt("AnimationMT")])(deltaTime);
+
+	currentScript = nullptr;
 }
 
-void CUnitScriptEngine::Tick_mt(int deltaTime)
+void CUnitScriptEngine::ImplTickST(int deltaTime)
 {
-	cobEngine->Tick(deltaTime);
-	{
-		{
-			//ZoneScopedN("CUnitScriptEngine::Tick_st");
-			SCOPED_TIMER("Sim::Script::Tick_mt");
-			for_mt(0, animating.size(), [&](const int idx) {
-				auto mtCurrentScript = animating[idx];
-				mtCurrentScript->Tick_mt(deltaTime);
-				});
-		}
-		{
-			ZoneScopedN("CUnitScriptEngine::Tick_st");
-			// tick all (COB or LUS) script instances that have registered themselves as animating
-			for (size_t i = 0; i < animating.size(); ) {
-				currentScript = animating[i];
+	ZoneScopedN("CUnitScriptEngine::ImplTickST");
+	// tick all (COB or LUS) script instances that have registered themselves as animating
+	for (size_t i = 0; i < animating.size(); ) {
+		currentScript = animating[i];
 
-				//static AnimContainerType doneAnims[AMove + 1]; uh oh, here we are supposed to pre-alloc this one :/
-				if (!currentScript->Tick_st(deltaTime)) {
-					animating[i] = animating.back();
-					animating.pop_back();
-					continue;
-				}
-				i++;
+		if (!currentScript->Tick(deltaTime)) {
+			animating[i] = animating.back();
+			animating.pop_back();
+			continue;
+		}
+		i++;
+	}
+}
+void CUnitScriptEngine::ImplTickMT(int deltaTime)
+{
+	ZoneScopedN("CUnitScriptEngine::ImplTickMT");
+	// tick all (COB or LUS) script instances that have registered themselves as animating
+	{
+		ZoneScopedN("CUnitScriptEngine::ImplTickMT(MT)");
+		for_mt(0, animating.size(), [&](const int i) {
+			animating[i]->TickAllAnims(deltaTime);
+		});
+	}
+	{
+		ZoneScopedN("CUnitScriptEngine::ImplTickMT(ST)");
+		for (size_t i = 0; i < animating.size(); ) {
+			currentScript = animating[i];
+
+			if (!currentScript->TickAnimFinished(deltaTime)) {
+				animating[i] = animating.back();
+				animating.pop_back();
+				continue;
 			}
+			i++;
 		}
 	}
 }

--- a/rts/Sim/Units/Scripts/UnitScriptEngine.h
+++ b/rts/Sim/Units/Scripts/UnitScriptEngine.h
@@ -24,14 +24,15 @@ public:
 	void ReloadScripts(const UnitDef* udef);
 
 	void Tick(int deltaTime); 
-	void Tick_mt(int deltaTime);
 
 	void Init() { animating.reserve(256); }
 	void Kill() { animating.clear(); }
 
 	static void InitStatic();
 	static void KillStatic();
-
+private:
+	void ImplTickMT(int deltaTime);
+	void ImplTickST(int deltaTime);
 private:
 	CUnitScript* currentScript = nullptr;
 

--- a/rts/Sim/Units/Scripts/UnitScriptEngine.h
+++ b/rts/Sim/Units/Scripts/UnitScriptEngine.h
@@ -23,7 +23,7 @@ public:
 	void RemoveInstance(CUnitScript* instance);
 	void ReloadScripts(const UnitDef* udef);
 
-	void Tick(int deltaTime); 
+	void Tick(int deltaTime);
 
 	void Init() { animating.reserve(256); }
 	void Kill() { animating.clear(); }

--- a/rts/Sim/Units/Scripts/UnitScriptEngine.h
+++ b/rts/Sim/Units/Scripts/UnitScriptEngine.h
@@ -23,7 +23,8 @@ public:
 	void RemoveInstance(CUnitScript* instance);
 	void ReloadScripts(const UnitDef* udef);
 
-	void Tick(int deltaTime);
+	void Tick(int deltaTime); 
+	void Tick_mt(int deltaTime);
 
 	void Init() { animating.reserve(256); }
 	void Kill() { animating.clear(); }


### PR DESCRIPTION
The config int AnimationMT allows run-time configuration of this being on or off.

Tested for sync safety. in #1139

Clean implementation of:
https://github.com/beyond-all-reason/spring/pull/1139