### PR TITLE
Add reclaim to TeamStatistics

### DIFF
--- a/rts/Game/UI/EndGameBox.cpp
+++ b/rts/Game/UI/EndGameBox.cpp
@@ -527,6 +527,9 @@ void CEndGameBox::FillTeamStats()
 	stats.emplace_back("Metal stored");
 	stats.emplace_back("Energy stored");
 
+	stats.emplace_back("Metal reclaimed");
+	stats.emplace_back("Energy reclaimed");
+
 	stats.emplace_back("Active Units");
 	stats.emplace_back("Units killed");
 
@@ -567,19 +570,22 @@ void CEndGameBox::FillTeamStats()
 			stats[11].AddStat(team, si.metalProduced + si.metalReceived - (si.metalUsed + si.metalSent+si.metalExcess) );
 			stats[12].AddStat(team, si.energyProduced + si.energyReceived - (si.energyUsed + si.energySent+si.energyExcess) );
 
-			stats[13].AddStat(team, si.unitsProduced + si.unitsReceived + si.unitsCaptured - (si.unitsDied + si.unitsSent + si.unitsOutCaptured));
-			stats[14].AddStat(team, si.unitsKilled);
+			stats[13].AddStat(team, si.metalReclaimed);
+			stats[14].AddStat(team, si.energyReclaimed);
 
-			stats[15].AddStat(team, si.unitsProduced);
-			stats[16].AddStat(team, si.unitsDied);
+			stats[15].AddStat(team, si.unitsProduced + si.unitsReceived + si.unitsCaptured - (si.unitsDied + si.unitsSent + si.unitsOutCaptured));
+			stats[16].AddStat(team, si.unitsKilled);
 
-			stats[17].AddStat(team, si.unitsReceived);
-			stats[18].AddStat(team, si.unitsSent);
-			stats[19].AddStat(team, si.unitsCaptured);
-			stats[20].AddStat(team, si.unitsOutCaptured);
+			stats[17].AddStat(team, si.unitsProduced);
+			stats[18].AddStat(team, si.unitsDied);
 
-			stats[21].AddStat(team, si.damageDealt);
-			stats[22].AddStat(team, si.damageReceived);
+			stats[19].AddStat(team, si.unitsReceived);
+			stats[20].AddStat(team, si.unitsSent);
+			stats[21].AddStat(team, si.unitsCaptured);
+			stats[22].AddStat(team, si.unitsOutCaptured);
+
+			stats[23].AddStat(team, si.damageDealt);
+			stats[24].AddStat(team, si.damageReceived);
 		}
 	}
 }

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -1919,7 +1919,8 @@ int LuaSyncedRead::GetTeamResourceStats(lua_State* L)
 			lua_pushnumber(L, stats.metalExcess);
 			lua_pushnumber(L, stats.metalReceived);
 			lua_pushnumber(L, stats.metalSent);
-			return 5;
+			lua_pushnumber(L, stats.metalReclaimed);
+			return 6;
 		} break;
 		case 'e': {
 			lua_pushnumber(L, stats.energyUsed);
@@ -1927,7 +1928,8 @@ int LuaSyncedRead::GetTeamResourceStats(lua_State* L)
 			lua_pushnumber(L, stats.energyExcess);
 			lua_pushnumber(L, stats.energyReceived);
 			lua_pushnumber(L, stats.energySent);
-			return 5;
+			lua_pushnumber(L, stats.energyReclaimed);
+			return 6;
 		} break;
 		default: {
 		} break;
@@ -2045,6 +2047,9 @@ int LuaSyncedRead::GetTeamStatsHistory(lua_State* L)
 				HSTR_PUSH_NUMBER(L, "unitsCaptured",    stats.unitsCaptured);
 				HSTR_PUSH_NUMBER(L, "unitsOutCaptured", stats.unitsOutCaptured);
 				HSTR_PUSH_NUMBER(L, "unitsKilled",      stats.unitsKilled);
+
+				HSTR_PUSH_NUMBER(L, "metalReclaimed",   stats.metalReclaimed);
+				HSTR_PUSH_NUMBER(L, "energyReclaimed",  stats.energyReclaimed);
 			}
 			lua_rawseti(L, -2, count++);
 		}

--- a/rts/Sim/Features/Feature.cpp
+++ b/rts/Sim/Features/Feature.cpp
@@ -341,15 +341,26 @@ bool CFeature::AddBuildPower(CUnit* builder, float amount)
 	order.separate   = true;
 	order.use.energy = energyUseScaled;
 
+	CTeam* team = teamHandler.Team(builder->team);
+	TeamStatistics& stats = team->GetCurrentStats();
+
 	if (reclaimLeftTemp == 0.0f) {
 		// always give remaining resources at the end
 		order.add.metal  = resources.metal;
 		order.add.energy = resources.energy;
+
+		//update team statistics
+		stats.metalReclaimed += resources.metal;
+		stats.energyReclaimed += resources.energy;
 	}
 	else if (modInfo.reclaimMethod == 0) {
 		// Gradual reclaim
 		order.add.metal  = metalFraction;
 		order.add.energy = energyFraction;
+
+		//update team statistics
+		stats.metalReclaimed  += metalFraction;
+		stats.energyReclaimed += energyFraction;
 	}
 	else if (modInfo.reclaimMethod == 1) {
 		// All-at-end method
@@ -364,8 +375,14 @@ bool CFeature::AddBuildPower(CUnit* builder, float amount)
 		const int numChunks = oldChunk - newChunk;
 
 		if (numChunks != 0) {
-			order.add.metal  = std::min(numChunks * defResources.metal  * chunkSize, resources.metal);
-			order.add.energy = std::min(numChunks * defResources.energy * chunkSize, resources.energy);
+			float metalIncr  = std::min(numChunks * defResources.metal * chunkSize, resources.metal);
+			float energyIncr = std::min(numChunks * defResources.energy * chunkSize, resources.energy);
+			order.add.metal  = metalIncr;
+			order.add.energy = energyIncr;
+
+			//update team statistics
+			stats.metalReclaimed  += metalIncr;
+			stats.energyReclaimed += energyIncr;
 		}
 	}
 

--- a/rts/Sim/Misc/TeamStatistics.cpp
+++ b/rts/Sim/Misc/TeamStatistics.cpp
@@ -26,7 +26,9 @@ CR_REG_METADATA(TeamStatistics, (
 	CR_MEMBER(unitsSent),
 	CR_MEMBER(unitsCaptured),
 	CR_MEMBER(unitsOutCaptured),
-	CR_MEMBER(unitsKilled)
+	CR_MEMBER(unitsKilled),
+	CR_MEMBER(metalReclaimed),
+	CR_MEMBER(energyReclaimed)
 ))
 
 TeamStatistics::TeamStatistics()
@@ -53,6 +55,8 @@ TeamStatistics::TeamStatistics()
 	, unitsCaptured(0)
 	, unitsOutCaptured(0)
 	, unitsKilled(0)
+	, metalReclaimed(0.0f)
+	, energyReclaimed(0.0f)
 {
 }
 
@@ -79,5 +83,7 @@ void TeamStatistics::swab()
 	swabDWordInPlace(unitsCaptured);
 	swabDWordInPlace(unitsOutCaptured);
 	swabDWordInPlace(unitsKilled);
+	swabDWordInPlace(metalReclaimed);
+	swabDWordInPlace(energyReclaimed);
 }
 

--- a/rts/Sim/Misc/TeamStatistics.h
+++ b/rts/Sim/Misc/TeamStatistics.h
@@ -36,6 +36,9 @@ struct TeamStatistics
 	int unitsOutCaptured;
 	/* how many enemy units have been killed by this teams units */
 	int unitsKilled;
+	/* how much reclaim */
+	float metalReclaimed;
+	float energyReclaimed;
 
 	/// Change structure from host endian to little endian or vice versa.
 	void swab();

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -1995,14 +1995,28 @@ bool CUnit::AddBuildPower(CUnit* builder, float amount)
 		order.quantum    = false;
 		order.overflow   = true;
 		order.use.energy = -energyRefundStepScaled;
+
+		CTeam* team = teamHandler.Team(builder->team);
+		TeamStatistics& stats = team->GetCurrentStats();
+
+		//update team statistics: energyReclaimed
+		stats.energyReclaimed += -energyRefundStepScaled;
+
 		if (modInfo.reclaimUnitMethod == 0) {
 			// gradual reclamation of invested metal
 			order.add.metal = -metalRefundStepScaled;
+
+			//update team statistics: metal reclaimed
+			stats.metalReclaimed += -metalRefundStepScaled;
 		} else {
 			// lump reclamation of invested metal
 			if (postHealth <= 0.0f || postBuildProgress <= 0.0f) {
-				order.add.metal = (cost.metal * buildProgress) * modInfo.reclaimUnitEfficiency;
+				float metalReclIncr = (cost.metal * buildProgress) * modInfo.reclaimUnitEfficiency;
+				order.add.metal = metalReclIncr;
 				killMe = true; // to make 100% sure the unit gets killed, and so no resources are reclaimed twice!
+				
+				//update team statistics: metalReclaimed
+				stats.metalReclaimed += metalReclIncr;
 			}
 		}
 

--- a/tools/DemoTool/DemoTool.cpp
+++ b/tools/DemoTool/DemoTool.cpp
@@ -470,8 +470,8 @@ void WriteTeamstatHistory(CDemoReader& reader, unsigned team, const std::string&
 		out << "Team Statistics for " << team << std::endl;
 		out << "Time[sec];MetalUsed;EnergyUsed;MetalProduced;EnergyProduced;MetalExcess;EnergyExcess;"
 		    << "EnergyReceived;MetalSent;EnergySent;DamageDealt;DamageReceived;"
-		    << "UnitsProduced;UnitsDied;UnitsReceived;UnitsSent;nitsCaptured;"
-		    << "UnitsOutCaptured;UnitsKilled" << std::endl;
+		    << "UnitsProduced;UnitsDied;UnitsReceived;UnitsSent;UnitsCaptured;"
+		    << "UnitsOutCaptured;UnitsKilled;MetalReclaimed;EnergyReclaimed" << std::endl;
 		for (unsigned i = 0; i < statvec[team].size(); ++i)
 		{
 			PrintSep(out, time);
@@ -494,6 +494,8 @@ void WriteTeamstatHistory(CDemoReader& reader, unsigned team, const std::string&
 			PrintSep(out, statvec[team][i].unitsCaptured);
 			PrintSep(out, statvec[team][i].unitsOutCaptured);
 			PrintSep(out, statvec[team][i].unitsKilled);
+			PrintSep(out, statvec[team][i].metalReclaimed);
+			PrintSep(out, statvec[team][i].energyReclaimed);
 			out << std::endl;
 			time += header.teamStatPeriod;
 		}

--- a/tools/DemoTool/StringSerializer.h
+++ b/tools/DemoTool/StringSerializer.h
@@ -77,6 +77,8 @@ wstringstream& operator<<(wstringstream& str, const TeamStatistics& header)
 	str<<L"UnitsCaptured: " <<header.unitsCaptured<<endl;
 	str<<L"UnitsOutCaptured: " <<header.unitsOutCaptured<<endl;
 	str<<L"UnitsKilled: " <<header.unitsKilled<<endl;
+	str<<L"MetalReclaimed: " << header.metalReclaimed << endl;
+	str<<L"EnergyReclaimed: " << header.energyReclaimed << endl;
 	return str;
 }
 


### PR DESCRIPTION
This PR adds the ability to track the amount of resources reclaimed by a team through two new statistics in TeamStatistics: metalReclaimed and energyReclaimed.

Despite the importance of reclaim for games built on this engine, it is currently not tracked in TeamStatistics. This makes it challenging to compare how different players utilize reclaim. Adding this feature allows for both metal and energy reclaim to be tracked internally, displayed on the end game graph, and accessed by in-game widgets via Lua calls (e.g. BAR's TeamStats GUI element).

This PR makes the following changes:

- Both metal and energy reclaim are added to TeamStatistics.

- Both are appropriately updated when a feature or unit is reclaimed (code changes within Feature and Unit).

- LuaSyncedRead now includes these statistics in Spring.GetTeamResourceStats() and Spring.GetTeamStatsHistory().

- The EndGameBox now includes these statistics in the graph.

- The DemoTool was also updated to include these in the statistics that are serialized.

Limited testing showed no problems, but additional testing would be appreciated.