### PR TITLE
fix(SpringMem): UB in fallback case

### DIFF
--- a/rts/System/SpringMem.cpp
+++ b/rts/System/SpringMem.cpp
@@ -33,7 +33,7 @@ void* spring::ReallocateAlignedMemory(void* ptr, size_t size, size_t alignment)
 
     // bad luck
     void* newPtr = nullptr;
-    if (posix_memalign(&ptr, alignment, size) != 0)
+    if (posix_memalign(&newPtr, alignment, size) != 0)
         throw std::bad_alloc();
     std::memcpy(ptr, newPtr, size);
     return newPtr;


### PR DESCRIPTION
Passing `nullptr` to `std::memcpy` triggers UB, see https://en.cppreference.com/w/cpp/string/byte/memcpy.

On Fedora 39 it segfaults (GCC 13, `-O3` build):
```
#0  __memcpy_avx_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:265
#1  0x0000000000ccfc9f in spring::ReallocateAlignedMemory
    (ptr=<optimized out>, size=size@entry=536870912, alignment=alignment@entry=64)
    at /spring/rts/System/SpringMem.cpp:38
#2  0x0000000000b18ad8 in TexMemPool::Resize (this=0x488a15f0, size=536870912) at /usr/include/c++/13/span:287
#3  0x0000000000b0e461 in ITexMemPool::Init (size=size@entry=536870912) at /usr/include/c++/13/bits/unique_ptr.h:199
#4  0x0000000000b0ea70 in CBitmap::InitPool (size=536870912, size@entry=512)
    at /spring/rts/Rendering/Textures/Bitmap.cpp:1040
#5  0x0000000000c94795 in SpringApp::Init (this=this@entry=0x7ffef74a5830)
    at /spring/rts/System/SpringApp.cpp:258
#6  0x0000000000c94f77 in SpringApp::Run (this=this@entry=0x7ffef74a5830)
    at /spring/rts/System/SpringApp.cpp:876
#7  0x0000000000c6ceb9 in Run (argc=2, argv=0x7ffef74a5998) at /spring/rts/System/Main.cpp:48
#8  0x00007f89e8a4614a in __libc_start_call_main
    (main=main@entry=0xc6cf00 <main(int, char**)>, argc=argc@entry=2, argv=argv@entry=0x7ffef74a5998)
    at ../sysdeps/nptl/libc_start_call_main.h:58
#9  0x00007f89e8a4620b in __libc_start_main_impl
    (main=0xc6cf00 <main(int, char**)>, argc=2, argv=0x7ffef74a5998, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7ffef74a5988) at ../csu/libc-start.c:360
#10 0x00000000004dc975 in _start ()
```

Even if some systems do not segfault, `spring::ReallocateAlignedMemory` would then return `nullptr` which is clearly not the intented behaviour.

`clang-tidy` is also flagging the UB:
```
/spring/rts/System/SpringMem.cpp:38:5: warning: Null pointer passed to 2nd parameter expecting 'nonnull' [clang-analyzer-core.NonNullParamChecker]
   38 |     std::memcpy(ptr, newPtr, size);
      |     ^                ~~~~~~
/spring/rts/System/SpringMem.cpp:31:9: note: Assuming the condition is false
   31 |     if (reinterpret_cast<std::uintptr_t>(ptr) % alignment == 0)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/spring/rts/System/SpringMem.cpp:31:5: note: Taking false branch
   31 |     if (reinterpret_cast<std::uintptr_t>(ptr) % alignment == 0)
      |     ^
/spring/rts/System/SpringMem.cpp:35:5: note: 'newPtr' initialized to a null pointer value
   35 |     void* newPtr = nullptr;
      |     ^~~~~~~~~~~~
/spring/rts/System/SpringMem.cpp:36:9: note: Assuming the condition is false
   36 |     if (posix_memalign(&ptr, alignment, size) != 0)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/spring/rts/System/SpringMem.cpp:36:5: note: Taking false branch
   36 |     if (posix_memalign(&ptr, alignment, size) != 0)
      |     ^
/spring/rts/System/SpringMem.cpp:38:5: note: Null pointer passed to 2nd parameter expecting 'nonnull'
   38 |     std::memcpy(ptr, newPtr, size);
      |     ^                ~~~~~~
```