### PR TITLE
fix(widgets): only SafeWrapFunc Initialize() once

### DIFF
--- a/cont/LuaUI/widgets.lua
+++ b/cont/LuaUI/widgets.lua
@@ -721,9 +721,10 @@ local function SafeWrapWidget(widget)
     if (widget[ciName]) then
       widget[ciName] = SafeWrapFunc(widget[ciName], ciName)
     end
-    if (widget.Initialize) then
-      widget.Initialize = SafeWrapFunc(widget.Initialize, 'Initialize')
-    end
+  end
+
+  if (widget.Initialize) then
+    widget.Initialize = SafeWrapFunc(widget.Initialize, 'Initialize')
   end
 end
 


### PR DESCRIPTION
Previously, Initialize() was wrapped dozens of times for each widget.

---

Based on https://github.com/beyond-all-reason/Beyond-All-Reason/pull/2643

While I have tested the BAR PR, I have not tested this PR (I don't have enough experience with the base game or non-BAR games to be confident in testing it here). That said, it is not that complicated, so it at least seems fine to me.