### PR TITLE
Decal API: bool main -> bool normal

### DIFF
--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4584,7 +4584,7 @@ int LuaUnsyncedCtrl::SetGroundDecalRotation(lua_State* L)
  * @function Spring.SetGroundDecalTexture
  * @number decalID
  * @string textureName
- * @bool[opt=true] isMainTex
+ * @bool[opt=false] isNormalsTex
  * @treturn nil|bool decalSet
  */
 int LuaUnsyncedCtrl::SetGroundDecalTexture(lua_State* L)

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -4590,12 +4590,12 @@ int LuaUnsyncedRead::GetGroundDecalRotation(lua_State* L)
  *
  * @function Spring.GetGroundDecalTexture
  * @number decalID
- * @bool[opt=true] isMainTex
+ * @bool[opt=false] isNormalsTex
  * @treturn nil|string texture
  */
 int LuaUnsyncedRead::GetGroundDecalTexture(lua_State* L)
 {
-	const auto& texName = groundDecals->GetDecalTexture(luaL_checkint(L, 1), luaL_optboolean(L, 2, true));
+	const auto& texName = groundDecals->GetDecalTexture(luaL_checkint(L, 1), luaL_optboolean(L, 2, false));
 	lua_pushsstring(L, texName);
 
 	return 1;
@@ -4604,12 +4604,12 @@ int LuaUnsyncedRead::GetGroundDecalTexture(lua_State* L)
 /***
  *
  * @function Spring.GetDecalTextures
- * @bool[opt=true] isMainTex
+ * @bool[opt=false] isNormalsTex
  * @treturn {[string],...} textureNames
  */
 int LuaUnsyncedRead::GetGroundDecalTextures(lua_State* L)
 {
-	const auto& texNames = groundDecals->GetDecalTextures(luaL_optboolean(L, 2, true));
+	const auto& texNames = groundDecals->GetDecalTextures(luaL_optboolean(L, 2, false));
 	LuaUtils::PushStringVector(L, texNames);
 
 	return 1;

--- a/rts/Rendering/Env/Decals/GroundDecalHandler.h
+++ b/rts/Rendering/Env/Decals/GroundDecalHandler.h
@@ -127,9 +127,9 @@ public:
 	bool DeleteLuaDecal(uint32_t id) override;
 	      GroundDecal* GetDecalById(uint32_t id)       override;
 	const GroundDecal* GetDecalById(uint32_t id) const override;
-	bool SetDecalTexture(uint32_t id, const std::string& texName, bool mainTex) override;
-	std::string GetDecalTexture(uint32_t id, bool mainTex) const override;
-	const std::vector<std::string> GetDecalTextures(bool mainTex) const override;
+	bool SetDecalTexture(uint32_t id, const std::string& texName, bool normalsTex) override;
+	std::string GetDecalTexture(uint32_t id, bool normalsTex) const override;
+	const std::vector<std::string> GetDecalTextures(bool normalsTex) const override;
 	const CSolidObject* GetDecalSolidObjectOwner(uint32_t id) const override;
 private:
 	static void BindVertexAtrribs();
@@ -140,7 +140,7 @@ private:
 	void GenerateAtlasTextures();
 	void ReloadDecalShaders();
 
-	void AddTexToAtlas(const std::string& name, const std::string& filename, bool mainTex, bool convertOldBMP);
+	void AddTexToAtlas(const std::string& name, const std::string& filename, bool normalsTex, bool convertOldBMP);
 
 	void AddTrack(const CUnit* unit, const float3& newPos, bool forceEval = false);
 


### PR DESCRIPTION
Self-documents what the "non main" texture represents and is future-proof in case there's ever more "meta" textures.