### PR TITLE
Unit def build speed now defined per second

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2800,7 +2800,7 @@ int LuaSyncedCtrl::SetUnitBuildSpeed(lua_State* L)
 	if (unit == nullptr)
 		return 0;
 
-	const float buildScale = (1.0f / TEAM_SLOWUPDATE_RATE);
+	constexpr float buildScale = (1.0f / GAME_SPEED);
 	const float buildSpeed = buildScale * max(0.0f, luaL_checkfloat(L, 2));
 
 	CFactory* factory = dynamic_cast<CFactory*>(unit);

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -101,7 +101,7 @@ void CBuilder::PreInit(const UnitLoadParams& params)
 	range3D = unitDef->buildRange3D;
 	buildDistance = (params.unitDef)->buildDistance;
 
-	const float scale = (1.0f / TEAM_SLOWUPDATE_RATE);
+	constexpr float scale = (1.0f / GAME_SPEED);
 
 	buildSpeed     = scale * unitDef->buildSpeed;
 	repairSpeed    = scale * unitDef->repairSpeed;

--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -76,7 +76,7 @@ void CFactory::KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed)
 void CFactory::PreInit(const UnitLoadParams& params)
 {
 	unitDef = params.unitDef;
-	buildSpeed = unitDef->buildSpeed / TEAM_SLOWUPDATE_RATE;
+	buildSpeed = unitDef->buildSpeed / GAME_SPEED;
 
 	CBuilding::PreInit(params);
 


### PR DESCRIPTION
Previously was defined per team slowupdate, which happens every second. This means there is no behaviour difference, but it now works correctly if somebody tweaks game speed or team slowupdate rate.