### PR TITLE
Buildpower cache robustness (no logic change)

### DIFF
--- a/rts/Sim/Misc/NanoPieceCache.cpp
+++ b/rts/Sim/Misc/NanoPieceCache.cpp
@@ -16,7 +16,7 @@ CR_REG_METADATA(NanoPieceCache, (
 
 int NanoPieceCache::GetNanoPiece(CUnitScript* ownerScript) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	curBuildPowerMask |= (1 << (UNIT_SLOWUPDATE_RATE - 1));
+	curBuildPowerMask |= (1 << (MASK_BITS - 1));
 
 	int nanoPiece = -1;
 

--- a/rts/Sim/Misc/NanoPieceCache.h
+++ b/rts/Sim/Misc/NanoPieceCache.h
@@ -4,6 +4,7 @@
 #define _NANO_PIECE_CACHE_H
 
 #include <bit>
+#include <limits>
 #include <vector>
 
 #include "Sim/Misc/GlobalConstants.h"
@@ -21,7 +22,7 @@ public:
 
 	void Update() { curBuildPowerMask >>= 1; }
 
-	float GetBuildPower() const { return std::popcount(curBuildPowerMask) / static_cast <float> (UNIT_SLOWUPDATE_RATE); }
+	float GetBuildPower() const { return std::popcount(curBuildPowerMask) / static_cast <float> (MASK_BITS); }
 
 	/// returns modelPiece (NOT scriptModelPiece)
 	int GetNanoPiece(CUnitScript* ownerScript);
@@ -39,6 +40,11 @@ private:
 
 	int lastNanoPieceCnt;
 	uint32_t curBuildPowerMask;
+
+	/* Mask length controls for how long each frame of pouring buildpower "saturates" the counter. In this case it takes
+	 * half a second of building to reach 100% buildpower after starting building, and to reach 0% after stopping.
+	 * The min() call is just for technical reasons. */
+	static constexpr int MASK_BITS = std::min(GAME_SPEED / 2, std::numeric_limits<decltype(curBuildPowerMask)>::digits);
 };
 
 #endif


### PR DESCRIPTION
* changed nominal buildpower expiration duration from 1 slowupdate to half a second. This will matter if somebody changes either of these values.

* is now capped at 32 frames, so it compiles even if the nominal duration is higher.