### PR TITLE
Fix `Spring.GetGroupUnitsCount` crash + safety refactor

### DIFF
--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -4119,7 +4119,12 @@ int LuaUnsyncedRead::GetGroupUnitsCounts(lua_State* L)
  */
 int LuaUnsyncedRead::GetGroupUnitsCount(lua_State* L)
 {
-	const CGroup* group = uiGroupHandlers[gu->myTeam].GetGroup(luaL_checkint(L, 1));
+	const int groupID = luaL_checkint(L, 1);
+
+	if (!uiGroupHandlers[gu->myTeam].HasGroup(groupID))
+		return 0;
+
+	const CGroup* group = uiGroupHandlers[gu->myTeam].GetGroup(groupID);
 
 	lua_pushnumber(L, group->units.size());
 	return 1;

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -4050,6 +4050,16 @@ int LuaUnsyncedRead::GetUnitGroup(lua_State* L)
 	return 1;
 }
 
+static inline const CGroup* GetGroupFromArg(lua_State* L, int arg)
+{
+	const int groupID = luaL_checkint(L, arg);
+	const auto& groupHandler = uiGroupHandlers[gu->myTeam];
+
+	if (!groupHandler.HasGroup(groupID))
+		return nullptr;
+
+	return groupHandler.GetGroup(groupID);
+}
 
 /***
  *
@@ -4059,12 +4069,9 @@ int LuaUnsyncedRead::GetUnitGroup(lua_State* L)
  */
 int LuaUnsyncedRead::GetGroupUnits(lua_State* L)
 {
-	const int groupID = luaL_checkint(L, 1);
-
-	if (!uiGroupHandlers[gu->myTeam].HasGroup(groupID))
-		return 0; // nils
-
-	const CGroup* group = uiGroupHandlers[gu->myTeam].GetGroup(groupID);
+	const auto group = GetGroupFromArg(L, 1);
+	if (!group)
+		return 0;
 
 	PushNumberContainerAsArray(L, group->units);
 	return 1;
@@ -4079,12 +4086,9 @@ int LuaUnsyncedRead::GetGroupUnits(lua_State* L)
  */
 int LuaUnsyncedRead::GetGroupUnitsSorted(lua_State* L)
 {
-	const int groupID = luaL_checkint(L, 1);
-
-	if (!uiGroupHandlers[gu->myTeam].HasGroup(groupID))
-		return 0; // nils
-
-	const CGroup* group = uiGroupHandlers[gu->myTeam].GetGroup(groupID);
+	const auto group = GetGroupFromArg(L, 1);
+	if (!group)
+		return 0;
 
 	PushUnitListSortedByDef(L, group->units);
 	return 1;
@@ -4099,12 +4103,9 @@ int LuaUnsyncedRead::GetGroupUnitsSorted(lua_State* L)
  */
 int LuaUnsyncedRead::GetGroupUnitsCounts(lua_State* L)
 {
-	const int groupID = luaL_checkint(L, 1);
-
-	if (!uiGroupHandlers[gu->myTeam].HasGroup(groupID))
-		return 0; // nils
-
-	const CGroup* group = uiGroupHandlers[gu->myTeam].GetGroup(groupID);
+	const auto group = GetGroupFromArg(L, 1);
+	if (!group)
+		return 0;
 
 	PushSparseUnitTallyByDef(L, group->units);
 	return 1;
@@ -4119,12 +4120,9 @@ int LuaUnsyncedRead::GetGroupUnitsCounts(lua_State* L)
  */
 int LuaUnsyncedRead::GetGroupUnitsCount(lua_State* L)
 {
-	const int groupID = luaL_checkint(L, 1);
-
-	if (!uiGroupHandlers[gu->myTeam].HasGroup(groupID))
+	const auto group = GetGroupFromArg(L, 1);
+	if (!group)
 		return 0;
-
-	const CGroup* group = uiGroupHandlers[gu->myTeam].GetGroup(groupID);
 
 	lua_pushnumber(L, group->units.size());
 	return 1;


### PR DESCRIPTION
* fixes a `Spring.GetGroupUnitsCount` crash when passing an invalid group (e.g. 999999).
* extract the safety check so that all the relevant functions will stay consistent in the future.