### PR TITLE
Decal Lua API a bit more user-friendly

### DIFF
--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4604,7 +4604,7 @@ int LuaUnsyncedCtrl::SetGroundDecalTexture(lua_State* L)
  * @function Spring.SetGroundDecalAlpha
  * @number decalID
  * @number[opt=currAlpha] alpha Between 0 and 1
- * @number[opt=currAlphaFalloff] alphaFalloff Between 0 and 1, per frame
+ * @number[opt=currAlphaFalloff] alphaFalloff Between 0 and 1, per second
  * @treturn bool decalSet
  */
 int LuaUnsyncedCtrl::SetGroundDecalAlpha(lua_State* L)
@@ -4616,7 +4616,7 @@ int LuaUnsyncedCtrl::SetGroundDecalAlpha(lua_State* L)
 	}
 
 	decal->alpha = luaL_optfloat(L, 2, decal->alpha);
-	decal->alphaFalloff = luaL_optfloat(L, 3, decal->alphaFalloff);
+	decal->alphaFalloff = luaL_optfloat(L, 3, decal->alphaFalloff * GAME_SPEED) / GAME_SPEED;
 
 	lua_pushboolean(L, true);
 	return 1;

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -4462,9 +4462,7 @@ int LuaUnsyncedRead::GetLogSections(lua_State* L) {
  *
  * @function Spring.GetAllGroundDecals
  *
- * Note, won't ever return an empty table (if there's no decals it returns nil)
- *
- * @treturn nil|{[number],...} decalIDs
+ * @treturn {[number],...} decalIDs
  */
 int LuaUnsyncedRead::GetAllGroundDecals(lua_State* L)
 {
@@ -4475,8 +4473,10 @@ int LuaUnsyncedRead::GetAllGroundDecals(lua_State* L)
 		numValid += d.IsValid() || d.info.type == GroundDecal::Type::DECAL_LUA;
 	}
 
-	if (numValid == 0)
-		return 0;
+	if (numValid == 0) {
+		lua_newtable(L);
+		return 1;
+	}
 
 	int i = 1;
 	lua_createtable(L, numValid, 0);
@@ -4624,7 +4624,7 @@ int LuaUnsyncedRead::GetGroundDecalTextures(lua_State* L)
  * @function Spring.GetGroundDecalAlpha
  * @number decalID
  * @treturn nil|number alpha Between 0 and 1
- * @treturn number alphaFalloff Between 0 and 1, per frame
+ * @treturn number alphaFalloff Between 0 and 1, per second
  */
 int LuaUnsyncedRead::GetGroundDecalAlpha(lua_State* L)
 {
@@ -4634,7 +4634,7 @@ int LuaUnsyncedRead::GetGroundDecalAlpha(lua_State* L)
 	}
 
 	lua_pushnumber(L, decal->alpha);
-	lua_pushnumber(L, decal->alphaFalloff);
+	lua_pushnumber(L, decal->alphaFalloff * GAME_SPEED);
 
 	return 2;
 }


### PR DESCRIPTION
* alpha falloff now set/get per second (instead of frame)

* GetAllDecals returns an empty table instead of nil if there are no decals. Returning nil both prevents idiomatic code (cannot pass the returned value straight into interfaces that expect a table) and is a micropessimisation (adds the overhead of nil check into the case where decals exist, while the 0 decals case is the earlygame which doesn't need help).