### PR TITLE
Update select-command.markdown

### DIFF
--- a/doc/site/articles/select-command.markdown
+++ b/doc/site/articles/select-command.markdown
@@ -193,7 +193,7 @@ Some examples. Again, "unit" also includes buildings.
 
 - `AllMap+_Buildoptions_Building+_ClearSelection_SelectNum_1+`
   
-  Selects any (one) building that can produce units, map-wide (i.e. Factories). Repeatedly running this command will cycle through all factories. Unlike the above example, this selector will **not** snap the camera to the factory. Replace `SelectNum_1` with `SelectOne` in order to achieve this.
+  Selects any (one) building that can produce units (i.e. factories), map-wide. Repeatedly running this command will cycle through all factories. Unlike the above example, this selector will **not** snap the camera to the factory. Replace `SelectNum_1` with `SelectOne` in order to achieve this.
 
 - `AllMap+_Radar+_ClearSelection_SelectAll+`
 


### PR DESCRIPTION
A common request in #keybind-help on the BAR discord is a selector that will allow the cycling of factories specifically (excluding constuctor units), as both Default and Grid uikeys only add in keybinds for a selector that cycles the camera to an idle builder.

Adding this example to the guide will hopefully help new players who come here in search of selector inspiration. 

I elected to add it after the idle builder example, as that uses SelectOne (snap camera to) as its conclusion. Offering this example after highlights a working example of the difference between the SelectNum_1 and SelectOne conclusions, when Clear_Selection preceeds it.

(owtfox)