### PR TITLE
Don't warn for unlinked `Script.LuaXYZ` calls

### DIFF
--- a/doc/site/articles/wupget-communication.markdown
+++ b/doc/site/articles/wupget-communication.markdown
@@ -32,10 +32,13 @@ i.e. it is the one accessible directly by the engine to be called from the outsi
 * this only works if the global in question is a function, and you won't receive any return values
 * you could put "normal" vars there, but it is discouraged (use `GG`/`WG`)
 * the main use case for this is calling events "native style" where you do `Script.LuaXYZ.UnitDamaged` which is then handled by the wupget handler and distributed to individual wupgets
-* you can (and should) use the function notation to check if the function you're about to call exists, i.e. always do:
+* it is safe to call functions this way even if there is nothing on the other side.
+You can use the function notation to check whether anything is linked though, e.g. for optimisation:
 ```lua
 if Script.LuaXYZ("Bla") then
+  local args = ExpensiveCalculation()
   Script.LuaXYZ.Bla(args)
+end
 ```
 * other examples of events you could add: nuclear launch detected, language changed in settings, metal spot added at runtime.
 

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -255,10 +255,8 @@ int CLuaHandle::XCall(lua_State* srcState, const char* funcName)
 
 	// push the function
 	const LuaHashString funcHash(funcName);
-	if (!funcHash.GetGlobalFunc(L)) {
-		LOG_L(L_WARNING, "[LuaHandle::%s] tried to cross-call unlinked Script.%s.%s()", __func__, name.c_str(), funcName);
+	if (!funcHash.GetGlobalFunc(L))
 		return 0;
-	}
 
 	int retCount;
 


### PR DESCRIPTION
Unlinked is entirely fine. Engine doesn't complain when trying to call unlinked functions on its own, either.