### PR TITLE
Terraform at original rate w/ enforced update at end.

### DIFF
--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -149,25 +149,23 @@ bool CBuilder::UpdateTerraform(const Command&)
 
 	assert(!mapDamage->Disabled());
 
-	static constexpr int b = 3;
-
 	const auto SmoothBorders = [this, heightmap, &terraformScale]() {
 		// smooth the x-borders
 		for (int z = tz1; z <= tz2; z++) {
-			for (int x = 1; x <= 3; x++) {
-				if (tx1 - 3 >= 0) {
+			for (int x = 1; x <= TERRA_SMOOTHING_RADIUS; x++) {
+				if (tx1 - TERRA_SMOOTHING_RADIUS >= 0) {
 					const float ch3 = heightmap[z * mapDims.mapxp1 + tx1];
 					const float ch = heightmap[z * mapDims.mapxp1 + tx1 - x];
-					const float ch2 = heightmap[z * mapDims.mapxp1 + tx1 - 3];
-					const float amount = ((ch3 * (3 - x) + ch2 * x) / 3 - ch) * terraformScale;
+					const float ch2 = heightmap[z * mapDims.mapxp1 + tx1 - TERRA_SMOOTHING_RADIUS];
+					const float amount = ((ch3 * (TERRA_SMOOTHING_RADIUS - x) + ch2 * x) / TERRA_SMOOTHING_RADIUS - ch) * terraformScale;
 
 					readMap->AddHeight(z * mapDims.mapxp1 + tx1 - x, amount);
 				}
-				if (tx2 + 3 < mapDims.mapx) {
+				if (tx2 + TERRA_SMOOTHING_RADIUS < mapDims.mapx) {
 					const float ch3 = heightmap[z * mapDims.mapxp1 + tx2];
 					const float ch = heightmap[z * mapDims.mapxp1 + tx2 + x];
-					const float ch2 = heightmap[z * mapDims.mapxp1 + tx2 + 3];
-					const float amount = ((ch3 * (3 - x) + ch2 * x) / 3 - ch) * terraformScale;
+					const float ch2 = heightmap[z * mapDims.mapxp1 + tx2 + TERRA_SMOOTHING_RADIUS];
+					const float amount = ((ch3 * (TERRA_SMOOTHING_RADIUS - x) + ch2 * x) / TERRA_SMOOTHING_RADIUS - ch) * terraformScale;
 
 					readMap->AddHeight(z * mapDims.mapxp1 + tx2 + x, amount);
 				}
@@ -175,21 +173,21 @@ bool CBuilder::UpdateTerraform(const Command&)
 		}
 
 		// smooth the z-borders
-		for (int z = 1; z <= 3; z++) {
+		for (int z = 1; z <= TERRA_SMOOTHING_RADIUS; z++) {
 			for (int x = tx1; x <= tx2; x++) {
-				if ((tz1 - 3) >= 0) {
+				if ((tz1 - TERRA_SMOOTHING_RADIUS) >= 0) {
 					const float ch3 = heightmap[(tz1)*mapDims.mapxp1 + x];
 					const float ch = heightmap[(tz1 - z) * mapDims.mapxp1 + x];
-					const float ch2 = heightmap[(tz1 - 3) * mapDims.mapxp1 + x];
-					const float adjust = ((ch3 * (3 - z) + ch2 * z) / 3 - ch) * terraformScale;
+					const float ch2 = heightmap[(tz1 - TERRA_SMOOTHING_RADIUS) * mapDims.mapxp1 + x];
+					const float adjust = ((ch3 * (TERRA_SMOOTHING_RADIUS - z) + ch2 * z) / TERRA_SMOOTHING_RADIUS - ch) * terraformScale;
 
 					readMap->AddHeight((tz1 - z) * mapDims.mapxp1 + x, adjust);
 				}
-				if ((tz2 + 3) < mapDims.mapy) {
+				if ((tz2 + TERRA_SMOOTHING_RADIUS) < mapDims.mapy) {
 					const float ch3 = heightmap[(tz2)*mapDims.mapxp1 + x];
 					const float ch = heightmap[(tz2 + z) * mapDims.mapxp1 + x];
-					const float ch2 = heightmap[(tz2 + 3) * mapDims.mapxp1 + x];
-					const float adjust = ((ch3 * (3 - z) + ch2 * z) / 3 - ch) * terraformScale;
+					const float ch2 = heightmap[(tz2 + TERRA_SMOOTHING_RADIUS) * mapDims.mapxp1 + x];
+					const float adjust = ((ch3 * (TERRA_SMOOTHING_RADIUS - z) + ch2 * z) / TERRA_SMOOTHING_RADIUS - ch) * terraformScale;
 
 					readMap->AddHeight((tz2 + z) * mapDims.mapxp1 + x, adjust);
 				}
@@ -549,7 +547,7 @@ void CBuilder::Update()
 void CBuilder::SlowUpdate()
 {
 	if (terraforming) {
-		int tsr = TERRA_SMOOTHING_RADIUS;
+		constexpr int tsr = TERRA_SMOOTHING_RADIUS;
 		mapDamage->RecalcArea(tx1 - tsr, tx2 + tsr, tz1 - tsr, tz2 + tsr);
 	}
 
@@ -690,7 +688,7 @@ void CBuilder::StopBuild(bool callScript)
 	curCapture = nullptr;
 
 	if (terraforming) {
-		int tsr = TERRA_SMOOTHING_RADIUS;
+		constexpr int tsr = TERRA_SMOOTHING_RADIUS;
 		mapDamage->RecalcArea(tx1 - tsr, tx2 + tsr, tz1 - tsr, tz2 + tsr);
 	}
 

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -548,8 +548,10 @@ void CBuilder::Update()
 
 void CBuilder::SlowUpdate()
 {
-	if (terraforming)
-		mapDamage->RecalcArea(tx1 - 3, tx2 + 3, tz1 - 3, tz2 + 3);
+	if (terraforming) {
+		int tsr = TERRA_SMOOTHING_RADIUS;
+		mapDamage->RecalcArea(tx1 - tsr, tx2 + tsr, tz1 - tsr, tz2 + tsr);
+	}
 
 	CUnit::SlowUpdate();
 }
@@ -687,8 +689,10 @@ void CBuilder::StopBuild(bool callScript)
 	curResurrect = nullptr;
 	curCapture = nullptr;
 
-	if (terraforming)
-		mapDamage->RecalcArea(tx1 - 3, tx2 + 3, tz1 - 3, tz2 + 3);
+	if (terraforming) {
+		int tsr = TERRA_SMOOTHING_RADIUS;
+		mapDamage->RecalcArea(tx1 - tsr, tx2 + tsr, tz1 - tsr, tz2 + tsr);
+	}
 
 	terraforming = false;
 

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -221,11 +221,9 @@ bool CBuilder::UpdateTerraform(const Command&)
 				}
 			}
 			SmoothBorders();
-			mapDamage->RecalcArea(tx1 - b, tx2 + b, tz1 - b, tz2 + b);
 
 			if (curBuildee->terraformLeft <= 0.0f) {
 				terraforming = false;
-
 				curBuildee->groundLevelled = true;
 
 				if (eventHandler.TerraformComplete(this, curBuildee)) {
@@ -255,11 +253,9 @@ bool CBuilder::UpdateTerraform(const Command&)
 			}
 		}
 		SmoothBorders();
-		mapDamage->RecalcArea(tx1 - b, tx2 + b, tz1 - b, tz2 + b);
 
 		if (myTerraformLeft <= 0.0f) {
 			terraforming = false;
-
 			StopBuild();
 		}
 	} break;
@@ -553,7 +549,7 @@ void CBuilder::Update()
 void CBuilder::SlowUpdate()
 {
 	if (terraforming)
-		mapDamage->RecalcArea(tx1, tx2, tz1, tz2);
+		mapDamage->RecalcArea(tx1 - 3, tx2 + 3, tz1 - 3, tz2 + 3);
 
 	CUnit::SlowUpdate();
 }
@@ -690,6 +686,9 @@ void CBuilder::StopBuild(bool callScript)
 	helpTerraform = nullptr;
 	curResurrect = nullptr;
 	curCapture = nullptr;
+
+	if (terraforming)
+		mapDamage->RecalcArea(tx1 - 3, tx2 + 3, tz1 - 3, tz2 + 3);
 
 	terraforming = false;
 

--- a/rts/Sim/Units/UnitTypes/Builder.h
+++ b/rts/Sim/Units/UnitTypes/Builder.h
@@ -62,6 +62,8 @@ public:
 	      NanoPieceCache& GetNanoPieceCache()       { return nanoPieceCache; }
 
 public:
+	constexpr static int TERRA_SMOOTHING_RADIUS = 3;
+
 	bool range3D; ///< spheres instead of infinite cylinders for range tests
 
 	float buildDistance;


### PR DESCRIPTION
Map recalc is expensive. It was originally done at SlowUpdate. This change puts it back to that for terraform jobs, except that there is a forced update at the end to ensure the final state of the terrain is accounted for.