### PR TITLE
Fix SetUnitPosition documentation

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -3653,13 +3653,28 @@ int LuaSyncedCtrl::SetUnitMass(lua_State* L)
 }
 
 
-/***
+/*** Set unit position (2D)
+ *
+ * Sets a unit's position in 2D, at terrain height.
+ *
  * @function Spring.SetUnitPosition
  * @number unitID
  * @number x
- * @number[opt] y
  * @number z
- * @bool[opt] alwaysAboveSea
+ * @bool[opt=false] floating If true, over water the position is on surface. If false, on seafloor.
+ * @treturn nil
+ */
+
+
+/*** Set unit position (3D)
+ *
+ * Sets a unit's position in 3D, at an arbitrary height.
+ *
+ * @function Spring.SetUnitPosition
+ * @number unitID
+ * @number x
+ * @number y
+ * @number z
  * @treturn nil
  */
 int LuaSyncedCtrl::SetUnitPosition(lua_State* L)

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -3657,6 +3657,7 @@ int LuaSyncedCtrl::SetUnitMass(lua_State* L)
  * @function Spring.SetUnitPosition
  * @number unitID
  * @number x
+ * @number[opt] y
  * @number z
  * @bool[opt] alwaysAboveSea
  * @treturn nil

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -3654,10 +3654,10 @@ int LuaSyncedCtrl::SetUnitMass(lua_State* L)
 
 
 /*** Set unit position (2D)
+ * @function Spring.SetUnitPosition
  *
  * Sets a unit's position in 2D, at terrain height.
  *
- * @function Spring.SetUnitPosition
  * @number unitID
  * @number x
  * @number z
@@ -3667,10 +3667,10 @@ int LuaSyncedCtrl::SetUnitMass(lua_State* L)
 
 
 /*** Set unit position (3D)
+ * @function Spring.SetUnitPosition
  *
  * Sets a unit's position in 3D, at an arbitrary height.
  *
- * @function Spring.SetUnitPosition
  * @number unitID
  * @number x
  * @number y


### PR DESCRIPTION
Documentation claims only 3 params (x, z, alwaysAboveSea) but there's a hidden optional y param.