### PR TITLE
Don't change heading on a unit that doesn't need it.

### DIFF
--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -518,6 +518,8 @@ CGroundMoveType::CGroundMoveType(CUnit* owner):
 
 	forceStaticObjectCheck = true;
 
+	flatFrontDir = (owner->frontdir * XZVector).Normalize();
+
 	Connect();
 }
 
@@ -1385,11 +1387,16 @@ void CGroundMoveType::ChangeHeading(short newHeading) {
 	if (owner->GetTransporter() != nullptr)
 		return;
 
+	if (wantedHeading != newHeading)
+		wantedHeading = newHeading;
+	if (owner->heading == wantedHeading)
+		return;
+
 	#if (MODEL_TURN_INERTIA == 0)
 	const short rawDeltaHeading = pathController.GetDeltaHeading(pathID, wantedHeading, owner->heading, turnRate);
 	#else
 	// model rotational inertia (more realistic for ships)
-	const short rawDeltaHeading = pathController.GetDeltaHeading(pathID, (wantedHeading = newHeading), owner->heading, turnRate, turnAccel, BrakingDistance(turnSpeed, turnAccel), &turnSpeed);
+	const short rawDeltaHeading = pathController.GetDeltaHeading(pathID, wantedHeading, owner->heading, turnRate, turnAccel, BrakingDistance(turnSpeed, turnAccel), &turnSpeed);
 	#endif
 	const short absDeltaHeading = rawDeltaHeading * Sign(rawDeltaHeading);
 

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -1387,8 +1387,7 @@ void CGroundMoveType::ChangeHeading(short newHeading) {
 	if (owner->GetTransporter() != nullptr)
 		return;
 
-	if (wantedHeading != newHeading)
-		wantedHeading = newHeading;
+	wantedHeading = newHeading;
 	if (owner->heading == wantedHeading)
 		return;
 


### PR DESCRIPTION
An optimization that had been previously applied, but with a fix that addresses unit not alwasy animating correctly when created.