### PR TITLE
refactor for_mt_chunk, adding max chunk size.

### DIFF
--- a/rts/Map/ReadMap.cpp
+++ b/rts/Map/ReadMap.cpp
@@ -621,7 +621,7 @@ void CReadMap::UpdateCenterHeightmap(const SRectangle& rect, bool initialize) co
 					, std::max(heightmapSynced[idxBL], heightmapSynced[idxBR])
 					);
 		}
-	}, -256);
+	}, 256);
 }
 
 
@@ -716,7 +716,7 @@ void CReadMap::UpdateFaceNormals(const SRectangle& rect, bool initialize)
 				centerNormalsUnsynced[y * mapDims.mapx + x] = centerNormalsSynced[y * mapDims.mapx + x];
 			}
 		}
-	}, -64);
+	}, 64);
 }
 
 
@@ -758,7 +758,7 @@ void CReadMap::UpdateSlopemap(const SRectangle& rect, bool initialize)
 
 			slopeMap[y * mapDims.hmapx + x] = 1.0f - slope;
 		}
-	}, -128);
+	}, 128);
 }
 
 

--- a/rts/Rendering/Common/ModelDrawerData.h
+++ b/rts/Rendering/Common/ModelDrawerData.h
@@ -35,8 +35,8 @@ public:
 	bool GetFullRead() const override { return true; }
 	int  GetReadAllyTeam() const override { return AllAccessTeam; }
 protected:
-	static constexpr int MT_CHUNK_OR_MIN_CHUNK_SIZE_SMMA = -128;
-	static constexpr int MT_CHUNK_OR_MIN_CHUNK_SIZE_UPDT = -256;
+	static constexpr int MT_CHUNK_OR_MIN_CHUNK_SIZE_SMMA = 128;
+	static constexpr int MT_CHUNK_OR_MIN_CHUNK_SIZE_UPDT = 256;
 };
 
 


### PR DESCRIPTION
The current implementation is tricky to understand (and that's largely me to blame for that) and using negative numbers is unintuitive. The chunk sizes mostly became somewhat meaningless because the number of jobs were fixed and so the work would be done in chunks of work/threads regardless of the inputs provided (unless there was too few work to start with.)

I've adjusted it to be easier to understand and easier to configure with a min and max that works as you would expect them to. Which allows batches to be more finely controlled to allow devs find the best balance between avoid cross-cpu talk and minimising work tails (where few cores are busy finishing work while the other cores sit idle.)