### PR TITLE
Engine formation fronts treat power as value

### DIFF
--- a/rts/Game/SelectedUnitsAI.cpp
+++ b/rts/Game/SelectedUnitsAI.cpp
@@ -492,7 +492,7 @@ void CSelectedUnitsHandlerAI::CreateUnitOrder(std::vector< std::pair<float, int>
 
 		// give weaponless units a long range to make them go to the back
 		const float range = (unit->maxRange < 1.0f)? 2000: unit->maxRange;
-		const float value = ((ud->cost.metal * 60) + ud->cost.energy) / ud->health * range;
+		const float value = ud->power / ud->health * range;
 
 		out.emplace_back(value, unitID);
 	}


### PR DESCRIPTION
* for #939, fungible resources. Previous value was M+60E.
* power defaults to M+60E and most games don't change it.
* all known games use Lua customformations anyway.