### PR TITLE
Rmlui/init shutdown reworking

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -821,7 +821,7 @@ void CGame::LoadInterface()
 		GameSetupDrawer::Enable();
 	}
 
-	RmlGui::Initialize(globalRendering->GetWindow(), globalRendering->GetContext(), globalRendering->winSizeX, globalRendering->winSizeY);
+	RmlGui::Initialize();
 }
 
 void CGame::LoadLua(bool dryRun, bool onlyUnsynced)

--- a/rts/Rml/Backends/RmlUi_Backend.h
+++ b/rts/Rml/Backends/RmlUi_Backend.h
@@ -74,7 +74,8 @@ namespace RmlGui
 
 	void OnContextCreate(Rml::Context* context);
 	void OnContextDestroy(Rml::Context* context);
-
+	void MarkContextForRemoval(Rml::Context* context);
+	
 	void BeginFrame();
 	void PresentFrame();
 

--- a/rts/Rml/Backends/RmlUi_Backend.h
+++ b/rts/Rml/Backends/RmlUi_Backend.h
@@ -42,7 +42,7 @@
 
 namespace RmlGui
 {
-	bool Initialize(SDL_Window* target_window, SDL_GLContext target_glcontext, int winX, int winY);
+	bool Initialize();
 	bool InitializeLua(lua_State* lua_state);
 	bool RemoveLua();
 

--- a/rts/Rml/SolLua/bind/Global.cpp
+++ b/rts/Rml/SolLua/bind/Global.cpp
@@ -44,6 +44,17 @@ namespace Rml::SolLua
 		{
 			return Rml::RegisterEventType(type, interruptible, bubbles, Rml::DefaultActionPhase::None);
 		}
+		
+		auto removeContext(Rml::Context* context) {
+			RmlGui::MarkContextForRemoval(context);
+		}
+		
+		auto removeContextByName(const Rml::String& name) {
+			auto context = Rml::GetContext(name);
+			if (context != nullptr) {
+				RmlGui::MarkContextForRemoval(context);
+			}
+		}
 	}
 
 	void bind_global(sol::table& namespace_table, SolLuaPlugin* slp)
@@ -55,10 +66,15 @@ namespace Rml::SolLua
 				// context will be resized right away by other code
 				// send {0, 0} in to avoid triggering a pointless resize event in the Rml code
 				auto context = Rml::CreateContext(name, {0, 0});
-				slp->AddContextTracking(context);
+				if (context != nullptr) {
+					slp->AddContextTracking(context);
+				}
 				return context;
 			},
-			"RemoveContext", sol::resolve<bool (const Rml::String&)>(&Rml::RemoveContext),
+			"RemoveContext", sol::overload(
+				&functions::removeContext,
+				&functions::removeContextByName
+			),
 			"LoadFontFace", sol::overload(
 				&functions::loadFontFace1,
 				&functions::loadFontFace2,

--- a/rts/Rml/SolLua/plugin/SolLuaPlugin.cpp
+++ b/rts/Rml/SolLua/plugin/SolLuaPlugin.cpp
@@ -2,6 +2,7 @@
 
 #include "RmlUi/Core/Context.h"
 #include "SolLuaInstancer.h"
+#include "Rml/Backends/RmlUi_Backend.h"
 #include <RmlUi/Core.h>
 
 #include <algorithm>
@@ -45,7 +46,7 @@ namespace Rml::SolLua
 			d->Close();
 		}
 		for(auto c: luaContexts) {
-			Rml::RemoveContext(c->GetName());
+			RmlGui::MarkContextForRemoval(c);
 		}
 	}
 


### PR DESCRIPTION
simplified init/shutdown code

deferred the removal of Rml Contexts, allowing for removal of the mutex I naively threw in 
(the mutex didn't solve things in the end anyway)

slight work on tidying up event handling code (no functionality change)