### PR TITLE
Rmlui/texture element rounded border

### DIFF
--- a/rts/Rml/Components/ElementLuaTexture.cpp
+++ b/rts/Rml/Components/ElementLuaTexture.cpp
@@ -328,7 +328,6 @@ void ElementLuaTexture::UpdateRect()
 
 			// We have new, valid coordinates; force the geometry to be regenerated.
 			valid_rect = true;
-			geometry_dirty = true;
 			rect_source = RectSource::Attribute;
 		}
 	}
@@ -337,6 +336,8 @@ void ElementLuaTexture::UpdateRect()
 		rect = {};
 		rect_source = RectSource::None;
 	}
+
+	geometry_dirty = true;
 }
 
 }  // namespace RmlGui


### PR DESCRIPTION
Add support for rounded border to custom <texture> element

Fix the geometry not being updated when it's rect attribute was set to "" (blank)

![GIF 4-14-2024 12-08-17 AM](https://github.com/beyond-all-reason/spring/assets/4379469/0e91289a-8518-4059-aea5-c5768656e977)

example rml code
```html
<texture
    src="#101"
    style="border-radius: 50px; height: 256px; width: 256px"
    data-event-mouseover="my_rect = '10 10 236 236'"
    data-event-mouseout="my_rect = ''"
    data-attr-rect="my_rect"
/>
```