### PR TITLE
Fix build floating unit on water duplication bug

### DIFF
--- a/rts/Sim/Units/CommandAI/CommandQueue.h
+++ b/rts/Sim/Units/CommandAI/CommandQueue.h
@@ -43,6 +43,15 @@ class CCommandQueue {
 		inline void push_back(const Command& cmd);
 		inline void push_front(const Command& cmd);
 
+		void emplace_back(Command&& cmd) {
+			queue.emplace_back(cmd);
+			queue.back().SetTag(GetNextTag());
+		}
+		void emplace_front(Command&& cmd) {
+			queue.emplace_front(cmd);
+			queue.front().SetTag(GetNextTag());
+		}
+
 		inline iterator insert(iterator pos, const Command& cmd);
 
 		inline void pop_back()

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -787,13 +787,16 @@ bool CBuilder::StartBuild(BuildInfo& buildInfo, CFeature*& feature, bool& inWait
 			// of the buildee's yardmap, fallback check
 			if (u == nullptr)
 				u = CGameHelper::GetClosestFriendlyUnit(nullptr, buildInfo.pos, buildDistance, allyteam);
-			else {
-				// StopBuild sets this to false, fix it here if picking up the same buildee again
-				terraforming = (u == prvBuild && u->terraformLeft > 0.0f);
+			
+			if (u != nullptr) {
+				if (CanAssistUnit(u, buildInfo.def)) {
+					// StopBuild sets this to false, fix it here if picking up the same buildee again
+					terraforming = (u == prvBuild && u->terraformLeft > 0.0f);
 
-				AddDeathDependence(curBuild = const_cast<CUnit*>(u), DEPENDENCE_BUILD);
-				ScriptStartBuilding(u->pos, false);
-				return true;
+					AddDeathDependence(curBuild = const_cast<CUnit*>(u), DEPENDENCE_BUILD);
+					ScriptStartBuilding(u->pos, false);
+					return true;
+				}
 			}
 		} return false;
 

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -730,7 +730,7 @@ bool CBuilder::StartBuild(BuildInfo& buildInfo, CFeature*& feature, bool& inWait
 
 	buildInfo.pos = CGameHelper::Pos2BuildPos(buildInfo, true);
 
-	auto isBuildeeFloating = [](BuildInfo& buildInfo) {
+	auto isBuildeeFloating = [](const BuildInfo& buildInfo) {
 		if (buildInfo.def->RequireMoveDef()) {
 			MoveDef* md = moveDefHandler.GetMoveDefByPathType(buildInfo.def->pathType);
 			return (md->FloatOnWater());

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -799,6 +799,10 @@ bool CBuilder::StartBuild(BuildInfo& buildInfo, CFeature*& feature, bool& inWait
 					ScriptStartBuilding(u->pos, false);
 					return true;
 				}
+
+				// let BuggerOff handle this case (TODO: non-landed aircraft should not count)
+				if (buildInfo.FootPrintOverlap(u->pos, u->GetFootPrint(SQUARE_SIZE * 0.5f)))
+					return false;
 			}
 		} return false;
 

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -739,6 +739,8 @@ bool CBuilder::StartBuild(BuildInfo& buildInfo, CFeature*& feature, bool& inWait
 		}
 	};
 
+	// Units that cannot be underwater need their build checks kept above water or else collision detections will
+	// produce the wrong results.
 	if (isBuildeeFloating(buildInfo))
 		buildInfo.pos.y = (buildInfo.pos.y < 0.f) ? 0.f : buildInfo.pos.y;
 
@@ -787,7 +789,7 @@ bool CBuilder::StartBuild(BuildInfo& buildInfo, CFeature*& feature, bool& inWait
 			// of the buildee's yardmap, fallback check
 			if (u == nullptr)
 				u = CGameHelper::GetClosestFriendlyUnit(nullptr, buildInfo.pos, buildDistance, allyteam);
-			
+
 			if (u != nullptr) {
 				if (CanAssistUnit(u, buildInfo.def)) {
 					// StopBuild sets this to false, fix it here if picking up the same buildee again


### PR DESCRIPTION
Issue: When mutltiple builders are tasked with building something floating on the surface of the water and get there at different frames, it can trigger mutliple versions of the same unit are started on the same location.