### PR TITLE
prevent burst weapons firing outside their intended arc

### DIFF
--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1744,7 +1744,7 @@ void CCommandAI::UpdateStockpileIcon()
 	}
 }
 
-void CCommandAI::WeaponFired(CWeapon* weapon, const bool searchForNewTarget)
+void CCommandAI::WeaponFired(CWeapon* weapon, const bool searchForNewTarget, bool raiseEvent)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (!inCommand || commandQue.empty())
@@ -1786,7 +1786,8 @@ void CCommandAI::WeaponFired(CWeapon* weapon, const bool searchForNewTarget)
 	// if this fails, we need to take a copy at top instead of a reference
 	assert(&c == &commandQue.front());
 
-	eoh->WeaponFired(*owner, *(weapon->weaponDef));
+	if (raiseEvent)
+		eoh->WeaponFired(*owner, *(weapon->weaponDef));
 
 	if (!orderFinished)
 		return;

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -45,7 +45,7 @@ public:
 	void GiveCommand(const Command& c, int playerNum, bool fromSynced       , bool fromLua); // net,Lua
 
 	void ClearTargetLock(const Command& fc);
-	void WeaponFired(CWeapon* weapon, const bool searchForNewTarget);
+	void WeaponFired(CWeapon* weapon, const bool searchForNewTarget, bool raiseEvent = true);
 
 	virtual bool CanWeaponAutoTarget(const CWeapon* weapon) const { return true; }
 	virtual int GetDefaultCmd(const CUnit* pointed, const CFeature* feature);

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -58,6 +58,9 @@ UnitDefWeapon::UnitDefWeapon(const WeaponDef* weaponDef, const LuaTable& weaponT
 
 	// allow weapon to swap muzzles every frame and accurately determine friendly fire, without waiting for slow update.
 	fastQueryPointUpdate = weaponTable.GetBool("fastQueryPointUpdate", fastQueryPointUpdate);
+
+	// stops units firing indiscriminately if the target is outside a burst attacks arc of fire for a moment
+	stopBurstWhenOutOfArc = weaponTable.GetBool("stopBurstWhenOutOfArc", stopBurstWhenOutOfArc);
 }
 
 

--- a/rts/Sim/Units/UnitDef.h
+++ b/rts/Sim/Units/UnitDef.h
@@ -45,6 +45,7 @@ struct UnitDefWeapon {
 
 	bool fastAutoRetargeting = false; ///< pick new targets as soon as possible, don't wait for slow update
 	bool fastQueryPointUpdate = false;	///< check in with unitscript to get most current query piece before every friendly fire check, don't wait for slow update
+	bool stopBurstWhenOutOfArc = false; ///< stops units firing indiscriminately if the target is outside a burst attacks arc of fire for a moment
 	float weaponAimAdjustPriority = 1.f;		///< relative importance of picking enemy targets that are in front
 };
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -529,6 +529,18 @@ void CWeapon::UpdateSalvo()
 	salvoLeft--;
 	nextSalvo = gs->frameNum + salvoDelay;
 
+	if (!CheckAimingAngle()) {
+		UpdateWeaponPieces(false); // calls script->QueryWeapon()
+		UpdateWeaponVectors();
+		if (salvoLeft == 0) {
+			owner->script->EndBurst(weaponNum);
+
+			const bool searchForNewTarget = (currentTarget == owner->curTarget);
+			owner->commandAI->WeaponFired(this, searchForNewTarget, false);
+		}
+		return;
+	}
+
 	// Decloak
 	if (owner->unitDef->decloakOnFire)
 		owner->ScriptDecloak(HaveUnitTarget()? currentTarget.unit: nullptr, this);

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -531,7 +531,15 @@ void CWeapon::UpdateSalvo()
 	salvoLeft--;
 	nextSalvo = gs->frameNum + salvoDelay;
 
-	if (!CheckAimingAngle()) {
+	float targetInArc = true;
+	if (weaponDef->maxFireAngle > -1.0f) {
+		const float3 currentTargetDir = (currentTargetPos - aimFromPos).SafeNormalize2D();
+		const float3 simpleWeaponDir = float3(weaponDir).SafeNormalize2D();
+		if (simpleWeaponDir.dot2D(currentTargetDir) < weaponDef->maxFireAngle)
+			targetInArc = false;
+	}
+
+	if (!targetInArc || !CheckAimingAngle()) {
 		if (stopBurstWhenOutOfArc) {
 			// Hold fire, but continue to aim towards the target.
 			UpdateWeaponPieces(false); // calls script->QueryWeapon()

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -531,8 +531,9 @@ void CWeapon::UpdateSalvo()
 	salvoLeft--;
 	nextSalvo = gs->frameNum + salvoDelay;
 
-	float targetInArc = true;
-	if (weaponDef->maxFireAngle > -1.0f) {
+	bool haveTarget = HaveTarget();
+	bool targetInArc = haveTarget;
+	if (targetInArc && weaponDef->maxFireAngle > -1.0f) {
 		const float3 currentTargetDir = (currentTargetPos - aimFromPos).SafeNormalize2D();
 		const float3 simpleWeaponDir = float3(weaponDir).SafeNormalize2D();
 		if (simpleWeaponDir.dot2D(currentTargetDir) < weaponDef->maxFireAngle)
@@ -556,8 +557,10 @@ void CWeapon::UpdateSalvo()
 		} else {
 			// Fire indiscriminately wherever the the weapon is pointing.
 			// currentTargetPos gets restored every frame in Update(), so we can change it here without breaking aiming
-			// when the target is back in arc.
-			currentTargetPos = aimFromPos + (weaponDir * range);
+			// when the target is back in arc. If we don't have a target, then the currentTargetPos will be pointing at
+			// the last target point and so can be left.
+			if (haveTarget)
+				currentTargetPos = aimFromPos + (weaponDir * range);
 		}
 	}
 

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -203,6 +203,7 @@ public:
 	float weaponAimAdjustPriority;
 	bool fastAutoRetargeting;
 	bool fastQueryPointUpdate;
+	bool stopBurstWhenOutOfArc;
 
 protected:
 	SWeaponTarget currentTarget;

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -188,5 +188,6 @@ void CWeaponLoader::InitWeapon(CUnit* owner, CWeapon* weapon, const UnitDefWeapo
 	weapon->weaponAimAdjustPriority = defWeapon->weaponAimAdjustPriority;
 	weapon->fastAutoRetargeting = defWeapon->fastAutoRetargeting;
 	weapon->fastQueryPointUpdate = defWeapon->fastQueryPointUpdate;
+	weapon->stopBurstWhenOutOfArc = defWeapon->stopBurstWhenOutOfArc;
 }
 


### PR DESCRIPTION
Burst weapons will honour these settings on the weapon (in the unitDef):

`maxAngleDif`  for units that allow weapons to fire independent of the unit's facing
`maxForwardAngleDif` for units that lock their weapons towards the front of the unit

Fixes https://github.com/beyond-all-reason/spring/issues/1451