### PR TITLE
Fix units switching between two targets rapidly

### DIFF
--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -761,7 +761,7 @@ size_t CGameHelper::GenerateWeaponTargets(const CWeapon* weapon, const CUnit* av
 				}
 
 				if (targetLOSState & LOS_PREVLOS) {
-					targetPriority /= (damageMul * targetUnit->power * (0.7f + gsRNG.NextFloat() * 0.6f));
+					targetPriority /= (damageMul * targetUnit->power);
 					targetPriority *= tgtPriorityMults[((targetUnit->category & weapon->badTargetCategory) != 0) * 2];
 					targetPriority *= tgtPriorityMults[(targetUnit->IsCrashing()) * 3];
 					targetPriority *= tgtPriorityMults[(targetUnit == lastAttacker) * 4];


### PR DESCRIPTION
Addresses the issue where units can sometimes find themselves switching bacl and forth between two targets that are similar distance and angle. For slower rotating turrets, this can prevent them opening fire. Units without a specific attack target check for targets on slow update, the random element can cause two similarly viable targets to cause units to switch between the targets each time.

https://cdn.discordapp.com/attachments/724924957074915358/1230113372322795540/golswing.mp4?ex=6632235a&is=661fae5a&hm=ede9cabe20e2cf7894ef3f279dacf9721199d8e574a382af3863848d8cc9f193&