### PR TITLE
Fix weapon aiming checks to use weapon's actual position and rotation.

### DIFF
--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -353,12 +353,11 @@ bool CWeapon::CheckAimingAngle() const
 	RECOIL_DETAILED_TRACY_ZONE;
 	// check fire angle constraints
 	// TODO: write a per-weapontype CheckAim()?
-	const float3 worldTargetDir = (currentTargetPos - owner->pos).SafeNormalize();
-	const float3 worldMainDir = owner->GetObjectSpaceVec(mainDir);
+	const float3 worldTargetDir = (currentTargetPos - aimFromPos).SafeNormalize();
 
 	// weapon finished a previously started AimWeapon thread and wants to
 	// fire, but target is no longer within contraints --> wait for re-aim
-	return (CheckTargetAngleConstraint(worldTargetDir, worldMainDir));
+	return (CheckTargetAngleConstraint(worldTargetDir, weaponDir));
 }
 
 
@@ -1003,7 +1002,7 @@ bool CWeapon::TestRange(const float3 tgtPos, const SWeaponTarget& trg) const
 		return false;
 
 	// NOTE: mainDir is in unit-space
-	return (CheckTargetAngleConstraint((tgtPos - aimFromPos).SafeNormalize(), owner->GetObjectSpaceVec(mainDir)));
+	return (CheckTargetAngleConstraint((tgtPos - aimFromPos).SafeNormalize(), weaponDir));
 }
 
 


### PR DESCRIPTION
Weapon rotating turrets with an aim constraint can find themselves unable to fire unless the front of the unit has rotated enough towards the weapon's target so that the starting direction of the weapon + the unit's front is within the tolerance. The issue can manifest with say armraz, where the guns are unable to fire (if a constraint is enforced see https://github.com/beyond-all-reason/spring/pull/1452) until the unit turns the legs around to face the target.