### PR TITLE
Rmlui/element binding fixes

### DIFF
--- a/rts/Rml/SolLua/bind/Element.cpp
+++ b/rts/Rml/SolLua/bind/Element.cpp
@@ -201,7 +201,9 @@ namespace Rml::SolLua
 				sol::resolve<void(Rml::Element&, const Rml::String&, const Rml::String&, sol::this_state)>(&functions::addEventListener),
 				sol::resolve<void(Rml::Element&, const Rml::String&, const Rml::String&, sol::this_state, bool)>(&functions::addEventListener)
 			),
-			"AppendChild", [](Rml::Element& self, Rml::ElementPtr& e) { self.AppendChild(std::move(e)); },
+			"AppendChild", [](Rml::Element& self, Rml::ElementPtr& e) { 
+				return self.AppendChild(std::move(e));
+			},
 			"Blur", &Rml::Element::Blur,
 			"Click", &Rml::Element::Click,
 			"DispatchEvent", sol::resolve<bool(const Rml::String&, const Rml::Dictionary&)>(&Rml::Element::DispatchEvent),
@@ -213,12 +215,16 @@ namespace Rml::SolLua
 			"QuerySelectorAll", &functions::getQuerySelectorAll,
 			"HasAttribute", &Rml::Element::HasAttribute,
 			"HasChildNodes", &Rml::Element::HasChildNodes,
-			"InsertBefore", [](Rml::Element& self, Rml::ElementPtr& element, Rml::Element* adjacent_element) { self.InsertBefore(std::move(element), adjacent_element); },
+			"InsertBefore", [](Rml::Element& self, Rml::ElementPtr& element, Rml::Element* adjacent_element) { 
+				return self.InsertBefore(std::move(element), adjacent_element);
+			},
 			"IsClassSet", &Rml::Element::IsClassSet,
 			"RemoveAttribute", &Rml::Element::RemoveAttribute,
 			"RemoveChild", &Rml::Element::RemoveChild,
-			"ReplaceChild", [](Rml::Element& self, Rml::ElementPtr& inserted_element, Rml::Element* replaced_element) { self.ReplaceChild(std::move(inserted_element), replaced_element); },
 			"ScrollIntoView", [](Rml::Element& self, sol::variadic_args va) { if (va.size() == 0) self.ScrollIntoView(true); else self.ScrollIntoView(va[0].as<bool>()); },
+			"ReplaceChild", [](Rml::Element& self, Rml::ElementPtr& inserted_element, Rml::Element* replaced_element) {
+				return self.ReplaceChild(std::move(inserted_element), replaced_element); 
+			},
 			"SetAttribute", static_cast<void(Rml::Element::*)(const Rml::String&, const Rml::String&)>(&Rml::Element::SetAttribute),
 			"SetClass", &Rml::Element::SetClass,
 			//--

--- a/rts/Rml/SolLua/bind/Element.cpp
+++ b/rts/Rml/SolLua/bind/Element.cpp
@@ -221,9 +221,14 @@ namespace Rml::SolLua
 			"IsClassSet", &Rml::Element::IsClassSet,
 			"RemoveAttribute", &Rml::Element::RemoveAttribute,
 			"RemoveChild", &Rml::Element::RemoveChild,
-			"ScrollIntoView", [](Rml::Element& self, sol::variadic_args va) { if (va.size() == 0) self.ScrollIntoView(true); else self.ScrollIntoView(va[0].as<bool>()); },
 			"ReplaceChild", [](Rml::Element& self, Rml::ElementPtr& inserted_element, Rml::Element* replaced_element) {
 				return self.ReplaceChild(std::move(inserted_element), replaced_element); 
+			},
+			"ScrollIntoView", [](Rml::Element& self, sol::variadic_args va) { 
+				if (va.size() == 0) 
+					self.ScrollIntoView(true); 
+				else 
+					self.ScrollIntoView(va[0].as<bool>()); 
 			},
 			"SetAttribute", static_cast<void(Rml::Element::*)(const Rml::String&, const Rml::String&)>(&Rml::Element::SetAttribute),
 			"SetClass", &Rml::Element::SetClass,
@@ -240,7 +245,7 @@ namespace Rml::SolLua
 			"GetValue",[](Rml::Element& self) {
 				if (self.GetTagName() == "input") {
 					return dynamic_cast<Rml::ElementFormControlInput*>(&self)->GetValue();
-				}else if (self.GetTagName() == "textarea") {
+				} else if (self.GetTagName() == "textarea") {
 					return dynamic_cast<Rml::ElementFormControlTextArea*>(&self)->GetValue();
 				}
 				return std::string();

--- a/rts/Rml/SolLua/bind/Element.cpp
+++ b/rts/Rml/SolLua/bind/Element.cpp
@@ -151,9 +151,26 @@ namespace Rml::SolLua
 				return prop->ToString();
 			}
 
-			void Set(const std::string& name, const std::string& value)
+			void Set(const sol::this_state L, const std::string& name, const sol::object& value)
 			{
-				m_element->SetProperty(name, value);
+				if (value.get_type() == sol::type::nil) {
+					m_element->RemoveProperty(name);
+					return;
+				}
+				
+				if (value.get_type() == sol::type::string) {
+					auto str = value.as<std::string&>();
+
+					if (str.empty()) {
+						m_element->RemoveProperty(name);
+					} else {
+						m_element->SetProperty(name, str);
+					}
+
+					return;
+				}
+
+				sol::type_error(L, sol::type::string, value.get_type());
 			}
 
 			auto Pairs()
@@ -188,7 +205,7 @@ namespace Rml::SolLua
 		///////////////////////////
 
 		namespace_table.new_usertype<style::StyleProxy>("StyleProxy", sol::no_constructor,
-			sol::meta_function::index, &style::StyleProxy::Get,
+														sol::meta_function::index, &style::StyleProxy::Set,
 			sol::meta_function::new_index, &style::StyleProxy::Set,
 			sol::meta_function::pairs, &style::StyleProxy::Pairs
 		);


### PR DESCRIPTION
improvements and fixes to the Rml::Element SolLua bindings

the following Lua code blocks now work

```lua
local _target = document:GetElementById('target')
local _div = document:CreateElement('div')
_div:SetClass('element', true)
_div = _target:AppendChild(_div)
_div.style.width = '20px'
_div.style.height = '50px'

local _div_prepend = document:CreateElement('div')
_div_prepend.inner_rml = "p"
_div_prepend = _target:InsertBefore(_div_prepend, _div)

local _div_replace = document:CreateElement('div')
_div_replace.inner_rml = "r"

_div = _target:ReplaceChild(_div_replace, _div)
_div.inner_rml = 'asdf'
_div = _target:AppendChild(_div)
_div.style.width = nil
_div.style.height = ''
```

```lua
local textureElement = document:GetElementById('tex')

for k, v in textureElement.style:__pairs() do
	Spring.Echo(k .. ': ' .. v)
end
```