### PR TITLE
Container util: remove functor template copypasta

### DIFF
--- a/rts/System/ContainerUtil.h
+++ b/rts/System/ContainerUtil.h
@@ -23,18 +23,11 @@ namespace spring {
 		}
 	}
 
-	template<typename ForwardIt, typename T, typename Compare>
-	ForwardIt BinarySearch(ForwardIt first, ForwardIt last, const T& value, Compare comp)
+	template<typename ForwardIt, typename T, typename Compare = std::less <>>
+	ForwardIt BinarySearch(ForwardIt first, ForwardIt last, const T& value, Compare comp = {})
 	{
 		first = std::lower_bound(first, last, value, comp);
 		return (!(first == last) && !(comp(value, *first))) ? first : last;
-	}
-
-	template<typename ForwardIt, typename T>
-	ForwardIt BinarySearch(ForwardIt first, ForwardIt last, const T& value)
-	{
-		first = std::lower_bound(first, last, value);
-		return (!(first == last) && !(value < *first)) ? first : last;
 	}
 
 	template<typename T, typename UnaryPredicate>
@@ -94,23 +87,8 @@ namespace spring {
 		return true;
 	}
 
-	template<typename T, typename UniqPred>
-	static void VectorUnique(std::vector<T>& v) {
-		for (size_t i = 0; i < v.size(); i++) {
-			for (size_t j = i + 1; j < v.size(); /*NOOP*/) {
-				if (v[i] == v[j]) {
-					v[j] = std::move(v.back());
-					v.pop_back();
-				}
-				else {
-					j++;
-				}
-			}
-		}
-	}
-
-	template<typename T, typename UniqPred>
-	static void VectorUnique(std::vector<T>& v, UniqPred uniqPred) {
+	template<typename T, typename UniqPred = std::equal_to <>>
+	static void VectorUnique(std::vector<T>& v, UniqPred uniqPred = {}) {
 		for (size_t i = 0; i < v.size(); i++) {
 			for (size_t j = i + 1; j < v.size(); /*NOOP*/) {
 				if (uniqPred(v[i], v[j])) {
@@ -124,27 +102,11 @@ namespace spring {
 		}
 	}
 
-	template<typename T, typename SortPred>
-	static void VectorSortUnique(std::vector<T>& v, SortPred sortPred)
-	{
-		std::sort(v.begin(), v.end(), sortPred);
-		auto last = std::unique(v.begin(), v.end());
-		v.erase(last, v.end());
-	}
-
-	template<typename T, typename SortPred, typename UniqPred>
-	static void VectorSortUnique(std::vector<T>& v, SortPred sortPred, UniqPred uniqPred)
+	template<typename T, typename SortPred = std::less <>, typename UniqPred = std::equal_to <>>
+	static void VectorSortUnique(std::vector<T>& v, SortPred sortPred = {}, UniqPred uniqPred = {})
 	{
 		std::sort(v.begin(), v.end(), sortPred);
 		auto last = std::unique(v.begin(), v.end(), uniqPred);
-		v.erase(last, v.end());
-	}
-
-	template<typename T>
-	static void VectorSortUnique(std::vector<T>& v)
-	{
-		std::sort(v.begin(), v.end());
-		auto last = std::unique(v.begin(), v.end());
 		v.erase(last, v.end());
 	}
 


### PR DESCRIPTION
Provide default args instead of having a bunch of copypasted functions.