### PR TITLE
avoid collision with macro _L in ctype.h (is pulled in on OpenBSD)

### DIFF
--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -1391,9 +1391,9 @@ int LuaUtils::PushDebugTraceback(lua_State* L)
 
 
 
-LuaUtils::ScopedDebugTraceBack::ScopedDebugTraceBack(lua_State* _L)
-	: L(_L)
-	, errFuncIdx(PushDebugTraceback(_L))
+LuaUtils::ScopedDebugTraceBack::ScopedDebugTraceBack(lua_State* lst)
+	: L(lst)
+	, errFuncIdx(PushDebugTraceback(lst))
 {
 	assert(errFuncIdx >= 0);
 }


### PR DESCRIPTION
As discussed on Discord. Linux also has `_L` in ctype.h, but it seems this file is only pulled in on OpenBSD, probably via `#include <cctype>`. Renaming this variable fixes the collision.