### PR TITLE
Add goal reached event

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -1841,6 +1841,26 @@ void CLuaHandle::UnitMoveFailed(const CUnit* unit)
 }
 
 
+/***
+ *
+ * @function UnitArrivedAtGoal
+ *
+ * @number unitID
+ * @number unitDefID
+ * @number unitTeam
+ */
+void CLuaHandle::UnitArrivedAtGoal(const CUnit* unit)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+
+	static const LuaHashString cmdStr(__func__);
+	if (!cmdStr.GetGlobalFunc(L))
+		return;
+
+	UnitCallIn(cmdStr, unit);
+}
+
+
 /*** Called just before a unit is invalid, after it finishes its death animation.
  *
  * @function RenderUnitDestroyed

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -168,6 +168,7 @@ class CLuaHandle : public CEventClient
 		bool UnitUnitCollision(const CUnit* collider, const CUnit* collidee) override;
 		bool UnitFeatureCollision(const CUnit* collider, const CFeature* collidee) override;
 		void UnitMoveFailed(const CUnit* unit) override;
+		void UnitArrivedAtGoal(const CUnit* unit) override;
 
 		void RenderUnitDestroyed(const CUnit* unit) override;
 

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -973,6 +973,9 @@ void CGroundMoveType::StartMoving(float3 moveGoalPos, float moveGoalRadius) {
 	currWayPointDist = 0.0f;
 	prevWayPointDist = 0.0f;
 
+	pathingArrived = false;
+	pathingFailed = false;
+
 	LOG_L(L_DEBUG, "[%s] starting engine for unit %i", __func__, owner->id);
 
 	if (atGoal)
@@ -2448,12 +2451,6 @@ void CGroundMoveType::Arrived(bool callScript)
 
 		// and the action is done
 		progressState = Done;
-
-		// update the position-parameter of our queue's front CMD_MOVE
-		// this is needed in case we Arrive()'ed non-directly (through
-		// colliding with another unit that happened to share our goal)
-		if (!owner->commandAI->HasMoreMoveCommands())
-			static_cast<CMobileCAI*>(owner->commandAI)->SetFrontMoveCommandPos(owner->pos);
 
 		owner->commandAI->SlowUpdate();
 

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -920,6 +920,9 @@ void CGroundMoveType::StartMovingRaw(const float3 moveGoalPos, float moveGoalRad
 
 	currWayPointDist = 0.0f;
 	prevWayPointDist = 0.0f;
+
+	pathingArrived = false;
+	pathingFailed = false;
 }
 
 void CGroundMoveType::StartMoving(float3 moveGoalPos, float moveGoalRadius) {
@@ -2444,6 +2447,8 @@ void CGroundMoveType::Arrived(bool callScript)
 	RECOIL_DETAILED_TRACY_ZONE;
 	// can only "arrive" if the engine is active
 	if (progressState == Active) {
+		eventHandler.UnitArrivedAtGoal(owner);
+
 		StopEngine(callScript);
 
 		if (owner->team == gu->myTeam)

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -71,6 +71,7 @@ public:
 	void TriggerCallArrived() {
 		atEndOfPath = true;
 		atGoal = true;
+		pathingArrived = true;
 	}
 
 

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -173,6 +173,7 @@ class CEventClient
 		virtual bool UnitFeatureCollision(const CUnit* collider, const CFeature* collidee) { return false; }
 		virtual void UnitMoved(const CUnit* unit) {}
 		virtual void UnitMoveFailed(const CUnit* unit) {}
+		virtual void UnitArrivedAtGoal(const CUnit* unit) {}
 
 		virtual void FeatureCreated(const CFeature* feature) {}
 		virtual void FeatureDestroyed(const CFeature* feature) {}

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -119,6 +119,7 @@ class CEventHandler
 		bool UnitFeatureCollision(const CUnit* collider, const CFeature* collidee);
 		void UnitMoved(const CUnit* unit);
 		void UnitMoveFailed(const CUnit* unit);
+		void UnitArrivedAtGoal(const CUnit* unit);
 
 		void FeatureCreated(const CFeature* feature);
 		void FeatureDestroyed(const CFeature* feature);
@@ -431,6 +432,7 @@ UNIT_CALLIN_NO_PARAM(UnitReverseBuilt);
 UNIT_CALLIN_NO_PARAM(UnitFinished)
 UNIT_CALLIN_NO_PARAM(UnitIdle)
 UNIT_CALLIN_NO_PARAM(UnitMoveFailed)
+UNIT_CALLIN_NO_PARAM(UnitArrivedAtGoal)
 UNIT_CALLIN_NO_PARAM(UnitEnteredUnderwater)
 UNIT_CALLIN_NO_PARAM(UnitEnteredWater)
 UNIT_CALLIN_NO_PARAM(UnitEnteredAir)

--- a/rts/System/Events.def
+++ b/rts/System/Events.def
@@ -75,6 +75,7 @@
 	SETUP_EVENT(UnitFeatureCollision, MANAGED_BIT | CONTROL_BIT)
 	SETUP_EVENT(UnitMoved,            MANAGED_BIT)
 	SETUP_EVENT(UnitMoveFailed,       MANAGED_BIT)
+	SETUP_EVENT(UnitArrivedAtGoal,    MANAGED_BIT)
 
 	SETUP_EVENT(FeatureCreated,   MANAGED_BIT)
 	SETUP_EVENT(FeatureDestroyed, MANAGED_BIT)


### PR DESCRIPTION
Fixes https://github.com/beyond-all-reason/spring/issues/1459

This fixes the issue where Zero-K rand the engine may not agree on exactly when a unit has reached its goal. The engine will send an UnitArrivedAtGoal event so that the game can tell that the engine believes the move is complete and so the game can take the necessary actions to ensure any further orders are carried out.

Zero-K can use the following diff file to add support for this new event.
[Use_UnitArrivedAtGoal_InRawMove.diff.zip](https://github.com/beyond-all-reason/spring/files/15223996/Use_UnitArrivedAtGoal_InRawMove.diff.zip)
*Though I didn't run into any issues with these Zero-K changes, there may be the need to add some protections around some of it. Think of it as starting point.*

Builds on the work undertaken in https://github.com/beyond-all-reason/spring/pull/1493