### PR TITLE
Fix mouse warping on wayland.

### DIFF
--- a/rts/System/Input/MouseInput.cpp
+++ b/rts/System/Input/MouseInput.cpp
@@ -214,6 +214,13 @@ bool IMouseInput::SetPos(int2 pos)
 
 bool IMouseInput::WarpPos(int2 pos)
 {
+	#if __unix__
+		/* Needed for SDL2+Wayland where warping isn't allowed otherwise, works fine with X11.
+		 * One would think there should be a corresponding `SDL_ShowCursor(SDL_ENABLE);` below,
+		 * but apparently this prevents this work-around from working (?!). */
+		SDL_ShowCursor(SDL_DISABLE);
+	#endif
+
 	SDL_WarpMouseInWindow(globalRendering->GetWindow(), pos.x, pos.y);
 
 	// SDL_WarpMouse generates SDL_MOUSEMOTION events


### PR DESCRIPTION
SDL2 does not support warping on Wayland if the Cursor is visible.

https://github.com/libsdl-org/SDL/blob/efaa58732abb3faf3900b2d93a166b955fbd8ed0/src/video/wayland/SDL_waylandmouse.c#L646

This fixes: https://github.com/ZeroK-RTS/Zero-K/issues/5005
I tested it, verified it works, please check if this breaks other platforms.