### PR TITLE
implement lua unit script multi-calls

### DIFF
--- a/cont/base/springcontent/gamedata/unit_script_header.lua
+++ b/cont/base/springcontent/gamedata/unit_script_header.lua
@@ -24,6 +24,13 @@ local Turn = UnitScript.Turn
 local Spin = UnitScript.Spin
 local StopSpin = UnitScript.StopSpin
 
+local MultiSetPieceVisibility = UnitScript.MultiSetPieceVisibility
+local MultiMove = UnitScript.MultiMove
+local MultiTurn = UnitScript.MultiTurn
+local MultiSpin = UnitScript.MultiSpin
+local MultiStopSpin = UnitScript.MultiStopSpin
+local MultiExplode = UnitScript.MultiExplode
+
 local StartThread = UnitScript.StartThread
 local Signal = UnitScript.Signal
 local SetSignalMask = UnitScript.SetSignalMask

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -89,6 +89,7 @@ Lua:
  - add `Spring.SetUnitPhysicalStateBit(number unitID, number stateBit) -> Set a unit's PhysicalState.
  - Lua C Macros (cast and registry) prefixed lua_ to fix compilation issues.
  - Protect Spring.GetGroupUnitsCount from crashing when given an invalid group id.
+ - Add new variadic variants for some Lua unit script functions: MultiTurn, MultiMove, MultiSpin, etc.
 
 
 Game Setup:

--- a/rts/Sim/Units/Scripts/LuaUnitScript.cpp
+++ b/rts/Sim/Units/Scripts/LuaUnitScript.cpp
@@ -1028,6 +1028,11 @@ bool CLuaUnitScript::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(StopSpin);
 	REGISTER_LUA_CFUNC(Turn);
 	REGISTER_LUA_CFUNC(Move);
+	REGISTER_LUA_CFUNC(MultiSetPieceVisibility);
+	REGISTER_LUA_CFUNC(MultiSpin);
+	REGISTER_LUA_CFUNC(MultiStopSpin);
+	REGISTER_LUA_CFUNC(MultiTurn);
+	REGISTER_LUA_CFUNC(MultiExplode);
 	REGISTER_LUA_CFUNC(IsInTurn);
 	REGISTER_LUA_CFUNC(IsInMove);
 	REGISTER_LUA_CFUNC(IsInSpin);
@@ -1466,6 +1471,56 @@ int CLuaUnitScript::Move(lua_State* L)
 	return 0;
 }
 
+
+// Do not call with a function that returns values to lua
+int CLuaUnitScript::MultiExec(lua_State *L, int (*const func)(lua_State*), const int expectedArgs) {
+	RECOIL_DETAILED_TRACY_ZONE;
+
+	int numArgs = lua_gettop(L);
+	if (numArgs % expectedArgs != 0 && numArgs > 0) {
+		luaL_error(L, "%s(): requires a multiple of %d arguments", __func__, expectedArgs);
+		return 0;
+	}
+	while(numArgs > 0) {
+		func(L);
+		for(int x = expectedArgs; x > 0; x--) {
+			lua_replace(L, x);
+		}
+		numArgs -= expectedArgs;
+	}
+
+	return 0;
+}
+
+int CLuaUnitScript::MultiSetPieceVisibility(lua_State* L)
+{
+	return MultiExec(L, &SetPieceVisibility, 2);
+}
+
+int CLuaUnitScript::MultiSpin(lua_State* L)
+{
+	return MultiExec(L, &Spin, 4);
+}
+
+int CLuaUnitScript::MultiStopSpin(lua_State* L)
+{
+	return MultiExec(L, &StopSpin, 3);
+}
+
+int CLuaUnitScript::MultiTurn(lua_State* L)
+{
+	return MultiExec(L, &Turn, 4);
+}
+
+int CLuaUnitScript::MultiExplode(lua_State* L)
+{
+	return MultiExec(L, &Explode, 2);
+}
+
+int CLuaUnitScript::MultiMove(lua_State* L)
+{
+	return MultiExec(L, &Move, 4);
+}
 
 int CLuaUnitScript::IsInAnimation(lua_State* L, const char* caller, AnimType type)
 {

--- a/rts/Sim/Units/Scripts/LuaUnitScript.cpp
+++ b/rts/Sim/Units/Scripts/LuaUnitScript.cpp
@@ -1032,6 +1032,7 @@ bool CLuaUnitScript::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(MultiSpin);
 	REGISTER_LUA_CFUNC(MultiStopSpin);
 	REGISTER_LUA_CFUNC(MultiTurn);
+	REGISTER_LUA_CFUNC(MultiMove);
 	REGISTER_LUA_CFUNC(MultiExplode);
 	REGISTER_LUA_CFUNC(IsInTurn);
 	REGISTER_LUA_CFUNC(IsInMove);

--- a/rts/Sim/Units/Scripts/LuaUnitScript.h
+++ b/rts/Sim/Units/Scripts/LuaUnitScript.h
@@ -173,6 +173,14 @@ private:
 	static int WaitForTurn(lua_State* L);
 	static int WaitForMove(lua_State* L);
 
+	static int MultiExec(lua_State *L, int (*const func)(lua_State*), const int expectedArgs);
+	static int MultiSetPieceVisibility(lua_State* L);
+	static int MultiSpin(lua_State* L);
+	static int MultiStopSpin(lua_State* L);
+	static int MultiExplode(lua_State* L);
+	static int MultiTurn(lua_State* L);
+	static int MultiMove(lua_State* L);
+
 	// Lua COB function to work around lack of working CBCobThreadFinish
 	static int SetDeathScriptFinished(lua_State* L);
 


### PR DESCRIPTION
Multi calls as described in https://github.com/beyond-all-reason/spring/issues/1068

It saves about 2-3 microseconds per unit for a unit with many Turn/other invocations. Tested with the walking animation for the dirtbag:

![image](https://github.com/beyond-all-reason/spring/assets/13026303/666809af-7c23-474a-beab-ec785bbc66bf)
