### PR TITLE
add GetUnitPhysicalState for lua

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -87,6 +87,7 @@ Lua:
  - add `Spring.GetFacingFromHeading(number heading) -> number facing` for unit conversion.
    Add `Spring.GetHeadingFromFacing(number facing) -> number heading`, ditto.
  - add `Spring.SetUnitPhysicalStateBit(number unitID, number stateBit) -> Set a unit's PhysicalState.
+ - add `Spring.GetUnitPhysicalState(number unitID) -> Gets the unit's PhysicalState bitmask.
  - Lua C Macros (cast and registry) prefixed lua_ to fix compilation issues.
  - Protect Spring.GetGroupUnitsCount from crashing when given an invalid group id.
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -194,6 +194,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetUnitShieldState);
 	REGISTER_LUA_CFUNC(SetUnitShieldRechargeDelay);
 	REGISTER_LUA_CFUNC(SetUnitFlanking);
+	REGISTER_LUA_CFUNC(GetUnitPhysicalState);
 	REGISTER_LUA_CFUNC(SetUnitPhysicalStateBit);
 	REGISTER_LUA_CFUNC(SetUnitTravel);
 	REGISTER_LUA_CFUNC(SetUnitFuel);
@@ -3087,6 +3088,22 @@ int LuaSyncedCtrl::SetUnitPhysicalStateBit(lua_State* L)
 
 	unit->SetPhysicalStateBit(statebit);
 	return 0;
+}
+
+/***
+ * @function Spring.GetUnitPhysicalState
+ * @number unitID
+ * @treturn number Unit's PhysicalState bitmask
+ */
+int LuaSyncedCtrl::GetUnitPhysicalState(lua_State* L)
+{
+	CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	lua_pushnumber(L, unit->physicalState);
+	return 1;
 }
 
 

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -104,6 +104,7 @@ class LuaSyncedCtrl
 		static int SetUnitShieldRechargeDelay(lua_State* L);
 		static int SetUnitFlanking(lua_State* L);
 		static int SetUnitPhysicalStateBit(lua_State* L);
+		static int GetUnitPhysicalState(lua_State* L);
 		static int SetUnitTravel(lua_State* L);
 		static int SetUnitFuel(lua_State* L);
 		static int SetUnitMoveGoal(lua_State* L);


### PR DESCRIPTION
For https://github.com/beyond-all-reason/spring/issues/1520
Can be used to determine if a unit has any of the following:
```c++
enum PhysicalState {
	PSTATE_BIT_ONGROUND    = (1 << 0),
	PSTATE_BIT_INWATER     = (1 << 1),
	PSTATE_BIT_UNDERWATER  = (1 << 2),
	PSTATE_BIT_UNDERGROUND = (1 << 3),
	PSTATE_BIT_INAIR       = (1 << 4),
	PSTATE_BIT_INVOID      = (1 << 5),

	PSTATE_BIT_MOVING   = (1 <<  6),
	PSTATE_BIT_FLYING   = (1 <<  7),
	PSTATE_BIT_FALLING  = (1 <<  8),
	PSTATE_BIT_SKIDDING = (1 <<  9),
	PSTATE_BIT_CRASHING = (1 << 10),
	PSTATE_BIT_BLOCKING = (1 << 11),
};
```