### PR TITLE
Fix #1523, stack issue with warning spam

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -1854,9 +1854,6 @@ void CLuaHandle::UnitArrivedAtGoal(const CUnit* unit)
 	RECOIL_DETAILED_TRACY_ZONE;
 
 	static const LuaHashString cmdStr(__func__);
-	if (!cmdStr.GetGlobalFunc(L))
-		return;
-
 	UnitCallIn(cmdStr, unit);
 }
 


### PR DESCRIPTION
`UnitCallIn` already puts the function on the stack. Fixes #1523 