### PR TITLE
QTPFS Path Repair

### DIFF
--- a/rts/Rendering/QTPFSPathDrawer.cpp
+++ b/rts/Rendering/QTPFSPathDrawer.cpp
@@ -118,9 +118,9 @@ void QTPFSPathDrawer::DrawCosts(const std::vector<const QTPFS::QTNode*>& nodes) 
 			continue;
 
 		font->SetTextColor(0.0f, 0.0f, 0.0f, 1.0f);
-		// font->glWorldPrint(pos, 5.0f, FloatToString(node->GetMoveCost(), "%8.2f"));
+		font->glWorldPrint(pos, 5.0f, FloatToString(node->GetMoveCost(), "%8.2f"));
 		// font->glWorldPrint(pos, 5.0f, IntToString(node->GetNodeNumber(), "%08x"));
-		font->glWorldPrint(pos, 5.0f, IntToString(node->GetIndex(), "%d"));
+		// font->glWorldPrint(pos, 5.0f, IntToString(node->GetDepth(), "%d"));
 	}
 
 	font->DrawWorldBuffered();

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -110,7 +110,7 @@ void CModInfo::ResetState()
 		pfRepathMaxRateInFrames = 150;
 		pfRawMoveSpeedThreshold = 0.f;
 		qtMaxNodesSearched = 8192;
-		qtRefreshPathMinDist = 2000.f;
+		qtRefreshPathMinDist = 512.f;
 		qtMaxNodesSearchedRelativeToMapOpenNodes = 0.25;
 		qtLowerQualityPaths = false;
 

--- a/rts/Sim/Path/QTPFS/Node.cpp
+++ b/rts/Sim/Path/QTPFS/Node.cpp
@@ -205,7 +205,7 @@ void QTPFS::QTNode::InitStatic() {
 }
 
 void QTPFS::QTNode::Init(
-	const QTNode* /*parent*/,
+	const QTNode* parent,
 	unsigned int nn,
 	unsigned int x1, unsigned int z1,
 	unsigned int x2, unsigned int z2,
@@ -231,7 +231,8 @@ void QTPFS::QTNode::Init(
 	assert(zsize() != 0);
 
 	moveCostAvg = -1.0f;
-	index = idx;
+	uint32_t depth = (parent != nullptr) ? (parent->GetDepth() + 1) : 0;
+	index = (idx & NODE_INDEX_MASK) + ((depth << DEPTH_BIT_OFFSET) & DEPTH_MASK);
 
 	neighbours.clear();
 }

--- a/rts/Sim/Path/QTPFS/Node.h
+++ b/rts/Sim/Path/QTPFS/Node.h
@@ -45,7 +45,9 @@ namespace QTPFS {
 		float2 GetNeighborEdgeTransitionPoint(const INode* ngb, const float3& pos, float alpha) const;
 		SRectangle ClipRectangle(const SRectangle& r) const;
 
-		unsigned int GetIndex() const { return index; }
+		unsigned int GetIndex() const { return index & NODE_INDEX_MASK; }
+		unsigned int GetDepth() const { return (index & DEPTH_MASK) >> DEPTH_BIT_OFFSET; }
+		unsigned int GetRawIndex() const { return index; }
 
 		~QTNode() = default;
 		QTNode() = default;
@@ -69,9 +71,10 @@ namespace QTPFS {
 		//     root-node identifier is always 0
 		//     <i> is a NODE_IDX index in [0, 3]
 		unsigned int GetChildID(unsigned int i, uint32_t rootMask) const {
-			uint32_t rootId = rootMask & nodeNumber;
-			uint32_t nodeId = ((~rootMask) & nodeNumber);
-			return rootId | ((nodeId << 2) + (i + 1));
+			// uint32_t rootId = rootMask & nodeNumber;
+			// uint32_t nodeId = ((~rootMask) & nodeNumber);
+			uint32_t shift = (MAX_DEPTH - (GetDepth() + 1)) * QTPFS_NODE_NUMBER_SHIFT_STEP;
+			return nodeNumber + ((i + 1) << shift);
 		}
 
 		std::uint64_t GetCheckSum(const NodeLayer& nl) const;
@@ -153,6 +156,16 @@ namespace QTPFS {
 		static unsigned int MAX_DEPTH;
 
 	private:
+		// Mask off the bits for node index, we can use higher bits for other purposes. We wouldn't normally, worry
+		// about so much about this, but when you have hundreds of thousands of nodes per movetype, the memory used
+		// adds up rather quickly so it is important to keep these objects as small as possible. 
+		static constexpr unsigned int NODE_INDEX_MASK = 0x000fffff;
+
+		static constexpr unsigned int EXIT_ONLY_BIT_OFFSET = 31;
+		static constexpr unsigned int EXIT_ONLY_MASK = (0x1 << EXIT_ONLY_BIT_OFFSET);
+		static constexpr unsigned int DEPTH_BIT_OFFSET = 20;
+		static constexpr unsigned int DEPTH_MASK = (0xf << DEPTH_BIT_OFFSET);
+
 		unsigned int nodeNumber = -1u;
 		unsigned int index = 0;
 
@@ -180,10 +193,12 @@ namespace QTPFS {
 
 		SearchNode(INode& srcNode)
 			: index(srcNode.index)
+			, nodeNumber(srcNode.nodeNumber)
 			{}
 
 		SearchNode(INode* srcNode)
 			: index(srcNode->index)
+			, nodeNumber(srcNode->nodeNumber)
 			{}
 
 		SearchNode(int nodeId)
@@ -202,8 +217,19 @@ namespace QTPFS {
 			zmin = other.zmin;
 			xmax = other.xmax;
 			zmax = other.zmax;
+			nodeNumber = other.nodeNumber;
+			badNode = other.badNode;
 			// searchState = other.searchState;
 			return *this;
+		}
+
+		void CopyGeneralNodeData(const SearchNode& other) {
+			index = other.index;
+			xmin = other.xmin;
+			zmin = other.zmin;
+			xmax = other.xmax;
+			zmax = other.zmax;
+			nodeNumber = other.nodeNumber;
 		}
 
 		float GetHeapPriority() const { return GetPathCost(NODE_PATH_COST_F); }
@@ -231,6 +257,9 @@ namespace QTPFS {
 		uint32_t GetStepIndex() const { return stepIndex; }
 		void SetStepIndex(uint32_t idx) { stepIndex = idx; }
 
+		bool isNodeBad() const { return badNode; /*selectedNetpoint.x == -1.f;*/ }
+		void SetNodeBad(bool state) { badNode = state; }
+
 		unsigned int index = 0;
 		// unsigned int searchState = 0;
 
@@ -249,6 +278,9 @@ namespace QTPFS {
 		int zmin = 0;
 		int xmax = 0;
 		int zmax = 0;
+
+		unsigned int nodeNumber = -1;
+		bool badNode = false;
 	};
 }
 

--- a/rts/Sim/Path/QTPFS/NodeLayer.h
+++ b/rts/Sim/Path/QTPFS/NodeLayer.h
@@ -191,6 +191,12 @@ public:
 			return GetPoolNode(i);
 		}
 
+		const QTNode* GetRootNode(int x, int z) const {
+			// This is fine, the class doesn't get modified in the process of the call.
+			// This call is to add const to the return value.
+			return const_cast<QTPFS::NodeLayer *>(this)->GetRootNode(x, z);
+		}
+
 public:
 
 		// NOTE:

--- a/rts/Sim/Path/QTPFS/Path.h
+++ b/rts/Sim/Path/QTPFS/Path.h
@@ -22,7 +22,7 @@ class CSolidObject;
 namespace QTPFS {
 	struct IPath {
 		struct PathNodeData {
-			uint32_t nodeId;
+			uint32_t nodeId = -1U;
 			uint32_t nodeNumber = -1U;
 			float2 netPoint;
 			int pathPointIndex = -1;
@@ -98,6 +98,7 @@ namespace QTPFS {
 			haveFullPath = other.haveFullPath;
 			havePartialPath = other.havePartialPath;
 			boundingBoxOverride = other.boundingBoxOverride;
+			isRawPath = other.isRawPath;
 			points = other.points;
 			nodes = other.nodes;
 
@@ -129,6 +130,7 @@ namespace QTPFS {
 			haveFullPath = other.haveFullPath;
 			havePartialPath = other.havePartialPath;
 			boundingBoxOverride = other.boundingBoxOverride;
+			isRawPath = other.isRawPath;
 			points = std::move(other.points);
 			nodes = std::move(other.nodes);
 
@@ -174,7 +176,7 @@ namespace QTPFS {
 			const unsigned int begin = (nextPointIndex >= 2U) ? nextPointIndex - 2U : 0U;
 			// const unsigned int end = (repathAtPointIndex > 0U) ? repathAtPointIndex + 1U : points.size();
 			const unsigned int end = points.size();
-
+			
 			for (unsigned int n = begin; n < end; n++) {
 				boundingBoxMins.x = std::min(boundingBoxMins.x, points[n].x);
 				boundingBoxMins.z = std::min(boundingBoxMins.z, points[n].z);
@@ -248,6 +250,10 @@ namespace QTPFS {
 			nodes[i].SetNodeBad(isBad);
 		}
 
+		const PathNodeData& GetNode(unsigned int i) const {
+			return nodes[i];
+		};
+
 		void RemoveNode(size_t index) {
 			if (index >= nodes.size()) { return; }
 			unsigned int start = index, end = nodes.size() - 1;
@@ -261,7 +267,8 @@ namespace QTPFS {
 			nodes[i].xmax = xmax;
 			nodes[i].zmax = zmax;
 		}
-		const PathNodeData& GetNode(unsigned int i) const { return nodes[i]; };
+		// There are always (points - 1) valid path nodes.
+		uint32_t GetGoodNodeCount() const { return points.size() - 1; };
 
 		void SetSourcePoint(const float3& p) { /* checkPointInBounds(p); */ assert(points.size() >= 2); points[                0] = p; }
 		void SetTargetPoint(const float3& p) { /* checkPointInBounds(p); */ assert(points.size() >= 2); points[points.size() - 1] = p; }
@@ -323,6 +330,9 @@ namespace QTPFS {
 		unsigned int GetFirstNodeIdOfCleanPath() const { return firstNodeIdOfCleanPath; }
 		void SetFirstNodeIdOfCleanPath(int nodeId) { firstNodeIdOfCleanPath = nodeId; }
 
+		bool IsRawPath() const { return isRawPath; }
+		void SetIsRawPath(bool enable) { isRawPath = enable; }
+
 	private:
 		unsigned int pathID = 0;
 		int pathType = 0;
@@ -347,6 +357,7 @@ namespace QTPFS {
 		bool haveFullPath = true;
 		bool havePartialPath = false;
 		bool boundingBoxOverride = false;
+		bool isRawPath = false;
 
 		std::vector<float3> points;
 		std::vector<PathNodeData> nodes;

--- a/rts/Sim/Path/QTPFS/PathCache.cpp
+++ b/rts/Sim/Path/QTPFS/PathCache.cpp
@@ -1,10 +1,15 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 // #undef NDEBUG
 
+#include <bit>
 #include <cassert>
 
 #include "PathCache.h"
+
+#include "Node.h"
+#include "NodeLayer.h"
 #include "PathDefines.h"
+#include "PathSearch.h"
 
 #include "Sim/Misc/GlobalConstants.h"
 #include "Sim/Misc/CollisionHandler.h"
@@ -37,17 +42,30 @@ static void GetRectangleCollisionVolume(const SRectangle& r, CollisionVolume& v,
 	#undef CV
 }
 
-bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, int pathType) {
+bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, const NodeLayer& nodeLayer) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	auto pathView = registry.view<IPath>(/*entt::exclude<PathIsDirty>*/);
 	if (pathView.empty())
 		return false;
 
 	// NOTE: not static, we run in multiple threads
-	CollisionVolume rv;
-	float3 rm;
+	// CollisionVolume rv;
+	// float3 rm;
 
-	GetRectangleCollisionVolume(r, rv, rm);
+	// GetRectangleCollisionVolume(r, rv, rm);
+
+	// get root node - get layer as input, not the pathType
+	int pathType = nodeLayer.GetNodelayer();
+
+	// create virtual node
+	const QTPFS::INode* rootNode = nodeLayer.GetRootNode(r.x1, r.z1);
+
+	// TODO refactor search for node generation?
+	uint32_t damageDepth = 0;
+	const int damageWidth = r.GetWidth();
+	const uint32_t damagedNodeNumber = PathSearch::GenerateVirtualNodeNumber(nodeLayer, rootNode, damageWidth, r.x1, r.z1, &damageDepth);
+	const uint32_t damageDepthShift = (QTPFS::QTNode::MAX_DEPTH - damageDepth) * QTPFS_NODE_NUMBER_SHIFT_STEP;
+	const uint32_t damageDepthMask = (-1U) << (damageDepthShift);
 
 	// LOG("%s: pathType %d has %d entires at start", __func__, pathType, (int)dirtyPaths[pathType].size());
 
@@ -55,17 +73,101 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, int pathType) {
 	// deformation, for which some or all of its waypoints
 	// might now be invalid and need to be recomputed
 
+	// auto testPathIntersect = [&r, &rv, &rm](const IPath* path, int i) {
+	// 	const float3& p0 = path->GetPoint(i    );
+	// 	const float3& p1 = path->GetPoint(i + 1);
+
+	// 	LOG("%s: p0 = (%f,%f)[%d,%d] p1 = (%f,%f)[%d,%d]", __func__
+	// 		, p0.x, p0.z, int(p0.x / SQUARE_SIZE), int(p0.z / SQUARE_SIZE)
+	// 		, p1.x, p1.z, int(p1.x / SQUARE_SIZE), int(p1.z / SQUARE_SIZE)
+	// 		);
+
+	// 	const bool p0InRect =
+	// 		((p0.x >= (r.x1 * SQUARE_SIZE) && p0.x < (r.x2 * SQUARE_SIZE)) &&
+	// 		(p0.z >= (r.z1 * SQUARE_SIZE) && p0.z < (r.z2 * SQUARE_SIZE)));
+	// 	const bool p1InRect =
+	// 		((p1.x >= (r.x1 * SQUARE_SIZE) && p1.x < (r.x2 * SQUARE_SIZE)) &&
+	// 		(p1.z >= (r.z1 * SQUARE_SIZE) && p1.z < (r.z2 * SQUARE_SIZE)));
+	// 	const bool havePointInRect = (p0InRect || p1InRect);
+	// 	if (havePointInRect) { return true; }
+
+	// 	// NOTE:
+	// 	//     box-volume tests in its own space, but points are
+	// 	//     in world-space so we must inv-transform them first
+	// 	//     (p0 --> p0 - rm, p1 --> p1 - rm)
+	// 	const bool
+	// 		xRangeInRect = (p0.x >= (r.x1 * SQUARE_SIZE) && p1.x <  (r.x2 * SQUARE_SIZE)),
+	// 		xRangeExRect = (p0.x <  (r.x1 * SQUARE_SIZE) && p1.x >= (r.x2 * SQUARE_SIZE)),
+	// 		zRangeInRect = (p0.z >= (r.z1 * SQUARE_SIZE) && p1.z <  (r.z2 * SQUARE_SIZE)),
+	// 		zRangeExRect = (p0.z <  (r.z1 * SQUARE_SIZE) && p1.z >= (r.z2 * SQUARE_SIZE));
+	// 	const bool edgeCrossesRect =
+	// 		(xRangeExRect && zRangeInRect) ||
+	// 		(xRangeInRect && zRangeExRect) ||
+	// 		CCollisionHandler::IntersectBox(&rv, p0 - rm, p1 - rm, NULL);
+
+	// 	// remember the ID of each path affected by the deformation
+	// 	return edgeCrossesRect;
+	// };
+
+	bool pathWasChecked = false;
+	auto testNodeDamage = [/*&testPathIntersect,*/ damagedNodeNumber, damageDepthMask, damageWidth, &pathWasChecked, &r]
+			( const QTPFS::IPath::PathNodeData& node
+			, const IPath* path
+			, int i
+			) {
+		// if (path->GetID() == 290455867) {
+		// 	LOG("%s: does [%x] overlap [%x] ?", __func__
+		// 		, damagedNodeNumber
+		// 		, node.nodeNumber);
+
+		// 	LOG("%s: [%d,%d][%d,%d] overlaps [%d,%d][%d,%d]", __func__
+		// 		, r.x1, r.z1, r.x2, r.z2
+		// 		, node.xmin, node.zmin, node.xmax, node.zmax);
+		// }
+
+		pathWasChecked = false;
+		int nodeWidth = node.xmax - node.xmin;
+		if (nodeWidth <= damageWidth) {
+			bool nodesOverlap = ( damagedNodeNumber == (node.nodeNumber & damageDepthMask) );
+			// if (path->GetID() == 290455867)
+			// 	LOG("Damage mask=%x nodesOverlap=%d", damageDepthMask, int(nodesOverlap));
+			return nodesOverlap;
+		} else {
+			// the rect is sized to either 16x16 or the size of the quad it is in, so if the current node is bigger
+			// than the damage rect, then it can't possibly be overlapping - (damaged nodes are never revisted by a
+			// path.)
+			return false;
+
+			// uint32_t zerosCount = std::countr_zero(node.nodeNumber);
+			// uint32_t nodeDepth = std::min(QTPFS::INode::MAX_DEPTH, zerosCount / QTPFS_NODE_NUMBER_SHIFT_STEP);
+			// uint32_t maskShift = nodeDepth * QTPFS_NODE_NUMBER_SHIFT_STEP;
+			// uint32_t mask = (-1U) << maskShift;
+			// bool nodesOverlap = ( node.nodeNumber == (damagedNodeNumber & mask) );
+			// LOG("Node depth=%d maskShift=%d mask=%x nodesOverlap=%d", nodeDepth, maskShift, mask, int(nodesOverlap));
+			// if (!nodesOverlap) { return false; }
+
+			// assert( false );
+			// // Slower path, but will likely never be called because damage rects are expanded if hitting a larger node
+			// // so the quads won't be larger than the damage rect first time, and any impacted nodes detected won't be
+			// // walked in future dirty checks for the given path.
+			// pathWasChecked = true;
+
+			// // damage area is within this quad, but it may not affect the path.
+			// return testPathIntersect(path, i);
+		}
+	};
+
 	// go in reverse so that entries can be removed without impacting the loop.
 	for (auto entity : pathView) {
 		// if (deadPaths.contains(it->first)) continue; // ... so we don't need this
 
 		// LOG("%s: %x is Dirty=%d", __func__, (int)entity, (int)registry.all_of<PathIsDirty>(entity));
 
-		if (registry.any_of<PathIsDirty, PathSearchRef>(entity)) continue;
+		if (registry.any_of<PathIsDirty, PathSearchRef>(entity)) { continue; }
 
 		IPath* path = &pathView.get<IPath>(entity);
 
-		if (path->IsSynced() == false) continue;
+		if (path->IsSynced() == false) { continue; }
 		if (path->GetPathType() != pathType) { continue; }
 		// auto-repath should already be triggered.
 		if (path->GetRepathTriggerIndex() != 0 && path->GetNextPointIndex() > path->GetRepathTriggerIndex()) {
@@ -84,68 +186,81 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, int pathType) {
 		if ((r.z1 * SQUARE_SIZE) > pathMaxs.z) { continue; }
 
 		// First check the boundary boxes
-		bool searchQuads = path->IsBoundingBoxOverriden();
 		bool intersectsQuads = false;
-		if (searchQuads) {
-			auto& pathNodeList = path->GetNodeList();
-			for (auto& node : pathNodeList) {
-				if (r.x2 < node.xmin) { continue; }
-				if (r.z2 < node.zmin) { continue; }
-				if (r.x1 > node.xmax) { continue; }
-				if (r.z1 > node.zmax) { continue; }
+		auto& pathNodeList = path->GetNodeList();
+		const bool pathWasClean = path->IsBoundingBoxOverriden();
 
-				intersectsQuads = true;
-				break;
+		unsigned int pathGoodFromNodeId = path->GetFirstNodeIdOfCleanPath();
+		// if (path->GetID() == 290455867) {
+		// 	LOG("%s: %d nodeSize=%d start=%d", __func__, pathType, int(pathNodeList.size()), pathGoodFromNodeId);
+		// 	LOG("%s: pathNodeList=%d, NumPoints=%d", __func__, int(pathNodeList.size()), int(path->NumPoints()));
+		// }
+
+		// reverse search to determine where any path repair will be needed up to.
+		for (int i = pathNodeList.size(); i > pathGoodFromNodeId; --i) {
+			const QTPFS::IPath::PathNodeData& node = pathNodeList[i-1];
+
+			// If the path is shared, then we need to check bad nodes so that path sharing can be stopped if required.
+			// Otherwise, bad nodes can be ignored.
+			if (node.IsNodeBad()) {
+				if (pathWasClean & !intersectsQuads) {
+					if (testNodeDamage(node, path, i-1))
+						intersectsQuads = true;
+				}
+				continue;
 			}
-		}
 
-		bool searchPaths = (!searchQuads || intersectsQuads);
+			if (!testNodeDamage(node, path, i-1)) { continue; }
+
+			// int pIndex = (i - 1) + int(path->NumPoints() - pathNodeList.size());
+			// if (pIndex > 0) {
+			// 	const float3& p0 = path->GetPoint(pIndex);
+			// 	const float3& p1 = path->GetPoint(pIndex - 1);
+
+			// 	LOG("%s: node [%d,%d][%d,%d] p0 = (%f,%f)[%d,%d] p1 = (%f,%f)[%d,%d]", __func__
+			// 		, node.xmin, node.zmin, node.xmax, node.zmax
+			// 		, p0.x, p0.z, int(p0.x / SQUARE_SIZE), int(p0.z / SQUARE_SIZE)
+			// 		, p1.x, p1.z, int(p1.x / SQUARE_SIZE), int(p1.z / SQUARE_SIZE)
+			// 		);
+			// }
+
+			// LOG("%s: node %d is hit", __func__, i-1);
+
+			pathGoodFromNodeId = i;
+			intersectsQuads = true;
+			break;
+		}
+		// if (path->GetID() == 290455867) 
+		// 	LOG("%s: now pathGoodFromNodeId=%d", __func__, pathGoodFromNodeId);
+
 		bool intersectsPath = false;
 		int autoRefreshOnNode = 0;
-		if (searchPaths) {
+
+		// If a reverse search finds no collisions through the whole path, then a forward search isn't needed.
+		if (pathGoodFromNodeId > 0) {
 			// figure out if <path> has at least one edge crossing <r>
 			// we only care about the segments we have not yet visited
+
+			// Forward search. A hit here tells us, when the path needs to be regenerated.
 			const unsigned int minIdx = std::max(path->GetNextPointIndex(), 2U) - 2;
-			const unsigned int maxIdx = (path->GetRepathTriggerIndex() > 0)
-							? path->GetRepathTriggerIndex()
-							: std::max(path->NumPoints(), 1u) - 1;
 
+			// The last two path points reside in the last node.
+			const unsigned int triggerIndex = path->GetRepathTriggerIndex();
+			const unsigned int maxIdx = (triggerIndex > 0) ? triggerIndex : pathNodeList.size();
+			const unsigned int rPathBadAtNodeId = pathGoodFromNodeId - 1;
+		
 			for (unsigned int i = minIdx; i < maxIdx; i++) {
-				const float3& p0 = path->GetPoint(i    );
-				const float3& p1 = path->GetPoint(i + 1);
+				const QTPFS::IPath::PathNodeData& node = pathNodeList[i];
 
-				const bool p0InRect =
-					((p0.x >= (r.x1 * SQUARE_SIZE) && p0.x < (r.x2 * SQUARE_SIZE)) &&
-					(p0.z >= (r.z1 * SQUARE_SIZE) && p0.z < (r.z2 * SQUARE_SIZE)));
-				const bool p1InRect =
-					((p1.x >= (r.x1 * SQUARE_SIZE) && p1.x < (r.x2 * SQUARE_SIZE)) &&
-					(p1.z >= (r.z1 * SQUARE_SIZE) && p1.z < (r.z2 * SQUARE_SIZE)));
-				const bool havePointInRect = (p0InRect || p1InRect);
+				// Bad nodes only occur at the end, if found, then stop. They do not affect the path the unit is
+				// following.
+				if (node.IsNodeBad()) { break; }
 
-				// NOTE:
-				//     box-volume tests in its own space, but points are
-				//     in world-space so we must inv-transform them first
-				//     (p0 --> p0 - rm, p1 --> p1 - rm)
-				const bool
-					xRangeInRect = (p0.x >= (r.x1 * SQUARE_SIZE) && p1.x <  (r.x2 * SQUARE_SIZE)),
-					xRangeExRect = (p0.x <  (r.x1 * SQUARE_SIZE) && p1.x >= (r.x2 * SQUARE_SIZE)),
-					zRangeInRect = (p0.z >= (r.z1 * SQUARE_SIZE) && p1.z <  (r.z2 * SQUARE_SIZE)),
-					zRangeExRect = (p0.z <  (r.z1 * SQUARE_SIZE) && p1.z >= (r.z2 * SQUARE_SIZE));
-				const bool edgeCrossesRect =
-					(xRangeExRect && zRangeInRect) ||
-					(xRangeInRect && zRangeExRect) ||
-					CCollisionHandler::IntersectBox(&rv, p0 - rm, p1 - rm, NULL);
-
-				// LOG("%s: %x havePointInRect=%d edgeCrossesRect=%d", __func__, (int)entity
-				// 		, (int)havePointInRect, (int)edgeCrossesRect);
+				intersectsPath = (i >= rPathBadAtNodeId) || testNodeDamage(node, path, i);
 
 				// remember the ID of each path affected by the deformation
-				if (havePointInRect || edgeCrossesRect) {
-					// assert(tempPaths.find(path->GetID()) == tempPaths.end());
-					// assert(std::find(dirtyPaths[pathType].begin(), dirtyPaths[pathType].end(), entity) == dirtyPaths[pathType].end());
-					intersectsPath = true;
-
-					bool triggerImmediateRepath = i <= (minIdx + 1);
+				if (intersectsPath) {
+					bool triggerImmediateRepath = ( i <= (minIdx + 1) );
 					if (!triggerImmediateRepath)
 						autoRefreshOnNode = i + 1; // trigger happens when waypoints are requested, which always grabs one ahead.
 
@@ -155,12 +270,18 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, int pathType) {
 			}
 		}
 
+		// Reverse search.
+
 		if (intersectsQuads || intersectsPath) {
 			DirtyPathDetail dirtyPathDetail;
 			dirtyPathDetail.pathEntity = entity;
 			dirtyPathDetail.clearSharing = true;
 			dirtyPathDetail.clearPath = intersectsPath && (autoRefreshOnNode == 0);
 			dirtyPathDetail.autoRepathTrigger = autoRefreshOnNode;
+			dirtyPathDetail.nodesAreCleanFromNodeId = pathGoodFromNodeId;
+
+			// if (path->GetID() == 290455867)
+			// 	LOG("%s: trig=%d, clean=%d", __func__, dirtyPathDetail.autoRepathTrigger, dirtyPathDetail.nodesAreCleanFromNodeId);
 
 			dirtyPaths[pathType].emplace_back(dirtyPathDetail);
 		}

--- a/rts/Sim/Path/QTPFS/PathCache.cpp
+++ b/rts/Sim/Path/QTPFS/PathCache.cpp
@@ -125,15 +125,11 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, const NodeLayer& nodeL
 
 		if (path->IsSynced() == false) { continue; }
 		if (path->GetPathType() != pathType) { continue; }
-		// auto-repath should already be triggered. - TODO remove this.
-		// if (path->GetRepathTriggerIndex() != 0 && path->GetNextPointIndex() > path->GetRepathTriggerIndex()) {
-		// 	continue;
-		// }
 
 		// LOG("%s: %x is processing", __func__, (int)entity);
 
 		const float3& pathMins = path->GetBoundingBoxMins();
-		const float3& pathMaxs = path->GetBoundingBoxMaxs(); // why is node wrong size?
+		const float3& pathMaxs = path->GetBoundingBoxMaxs();
 
 		// if rectangle does not overlap bounding-box, skip this path
 		if ((r.x2 * SQUARE_SIZE) < pathMins.x) { continue; }

--- a/rts/Sim/Path/QTPFS/PathCache.cpp
+++ b/rts/Sim/Path/QTPFS/PathCache.cpp
@@ -48,12 +48,6 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, const NodeLayer& nodeL
 	if (pathView.empty())
 		return false;
 
-	// NOTE: not static, we run in multiple threads
-	// CollisionVolume rv;
-	// float3 rm;
-
-	// GetRectangleCollisionVolume(r, rv, rm);
-
 	// get root node - get layer as input, not the pathType
 	int pathType = nodeLayer.GetNodelayer();
 
@@ -67,61 +61,30 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, const NodeLayer& nodeL
 	const uint32_t damageDepthShift = (QTPFS::QTNode::MAX_DEPTH - damageDepth) * QTPFS_NODE_NUMBER_SHIFT_STEP;
 	const uint32_t damageDepthMask = (-1U) << (damageDepthShift);
 
-	// LOG("%s: pathType %d has %d entires at start", __func__, pathType, (int)dirtyPaths[pathType].size());
+
+	// LOG("%s: damaged %x", __func__
+	// 		, damagedNodeNumber);
+
 
 	// "mark" any live path crossing the area of a terrain
 	// deformation, for which some or all of its waypoints
 	// might now be invalid and need to be recomputed
 
-	// auto testPathIntersect = [&r, &rv, &rm](const IPath* path, int i) {
-	// 	const float3& p0 = path->GetPoint(i    );
-	// 	const float3& p1 = path->GetPoint(i + 1);
-
-	// 	LOG("%s: p0 = (%f,%f)[%d,%d] p1 = (%f,%f)[%d,%d]", __func__
-	// 		, p0.x, p0.z, int(p0.x / SQUARE_SIZE), int(p0.z / SQUARE_SIZE)
-	// 		, p1.x, p1.z, int(p1.x / SQUARE_SIZE), int(p1.z / SQUARE_SIZE)
-	// 		);
-
-	// 	const bool p0InRect =
-	// 		((p0.x >= (r.x1 * SQUARE_SIZE) && p0.x < (r.x2 * SQUARE_SIZE)) &&
-	// 		(p0.z >= (r.z1 * SQUARE_SIZE) && p0.z < (r.z2 * SQUARE_SIZE)));
-	// 	const bool p1InRect =
-	// 		((p1.x >= (r.x1 * SQUARE_SIZE) && p1.x < (r.x2 * SQUARE_SIZE)) &&
-	// 		(p1.z >= (r.z1 * SQUARE_SIZE) && p1.z < (r.z2 * SQUARE_SIZE)));
-	// 	const bool havePointInRect = (p0InRect || p1InRect);
-	// 	if (havePointInRect) { return true; }
-
-	// 	// NOTE:
-	// 	//     box-volume tests in its own space, but points are
-	// 	//     in world-space so we must inv-transform them first
-	// 	//     (p0 --> p0 - rm, p1 --> p1 - rm)
-	// 	const bool
-	// 		xRangeInRect = (p0.x >= (r.x1 * SQUARE_SIZE) && p1.x <  (r.x2 * SQUARE_SIZE)),
-	// 		xRangeExRect = (p0.x <  (r.x1 * SQUARE_SIZE) && p1.x >= (r.x2 * SQUARE_SIZE)),
-	// 		zRangeInRect = (p0.z >= (r.z1 * SQUARE_SIZE) && p1.z <  (r.z2 * SQUARE_SIZE)),
-	// 		zRangeExRect = (p0.z <  (r.z1 * SQUARE_SIZE) && p1.z >= (r.z2 * SQUARE_SIZE));
-	// 	const bool edgeCrossesRect =
-	// 		(xRangeExRect && zRangeInRect) ||
-	// 		(xRangeInRect && zRangeExRect) ||
-	// 		CCollisionHandler::IntersectBox(&rv, p0 - rm, p1 - rm, NULL);
-
-	// 	// remember the ID of each path affected by the deformation
-	// 	return edgeCrossesRect;
-	// };
-
 	bool pathWasChecked = false;
-	auto testNodeDamage = [/*&testPathIntersect,*/ damagedNodeNumber, damageDepthMask, damageWidth, &pathWasChecked, &r]
+	auto testNodeDamage = [/*&testPathIntersect,*/ &nodeLayer, damagedNodeNumber, damageDepthMask, damageWidth, &pathWasChecked, &r]
 			( const QTPFS::IPath::PathNodeData& node
 			, const IPath* path
 			, int i
 			) {
-		// if (path->GetID() == 290455867) {
-		// 	LOG("%s: does [%x] overlap [%x] ?", __func__
+		// if (path->GetID() == 131) {
+		// 	LOG("%s: %d does [%x] overlap [%x] %d ?", __func__, i
 		// 		, damagedNodeNumber
-		// 		, node.nodeNumber);
+		// 		, node.nodeNumber
+		// 		, node.nodeId);
 
-		// 	LOG("%s: [%d,%d][%d,%d] overlaps [%d,%d][%d,%d]", __func__
+		// 	LOG("%s: %d [%d,%d][%d,%d] overlaps %d [%d,%d][%d,%d]", __func__, i
 		// 		, r.x1, r.z1, r.x2, r.z2
+		// 		, node.nodeId
 		// 		, node.xmin, node.zmin, node.xmax, node.zmax);
 		// }
 
@@ -130,30 +93,13 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, const NodeLayer& nodeL
 		if (nodeWidth <= damageWidth) {
 			bool nodesOverlap = ( damagedNodeNumber == (node.nodeNumber & damageDepthMask) );
 			// if (path->GetID() == 290455867)
-			// 	LOG("Damage mask=%x nodesOverlap=%d", damageDepthMask, int(nodesOverlap));
+				// LOG("Damage mask=%x nodesOverlap=%d", damageDepthMask, int(nodesOverlap));
 			return nodesOverlap;
 		} else {
 			// the rect is sized to either 16x16 or the size of the quad it is in, so if the current node is bigger
 			// than the damage rect, then it can't possibly be overlapping - (damaged nodes are never revisted by a
 			// path.)
 			return false;
-
-			// uint32_t zerosCount = std::countr_zero(node.nodeNumber);
-			// uint32_t nodeDepth = std::min(QTPFS::INode::MAX_DEPTH, zerosCount / QTPFS_NODE_NUMBER_SHIFT_STEP);
-			// uint32_t maskShift = nodeDepth * QTPFS_NODE_NUMBER_SHIFT_STEP;
-			// uint32_t mask = (-1U) << maskShift;
-			// bool nodesOverlap = ( node.nodeNumber == (damagedNodeNumber & mask) );
-			// LOG("Node depth=%d maskShift=%d mask=%x nodesOverlap=%d", nodeDepth, maskShift, mask, int(nodesOverlap));
-			// if (!nodesOverlap) { return false; }
-
-			// assert( false );
-			// // Slower path, but will likely never be called because damage rects are expanded if hitting a larger node
-			// // so the quads won't be larger than the damage rect first time, and any impacted nodes detected won't be
-			// // walked in future dirty checks for the given path.
-			// pathWasChecked = true;
-
-			// // damage area is within this quad, but it may not affect the path.
-			// return testPathIntersect(path, i);
 		}
 	};
 
@@ -163,16 +109,16 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, const NodeLayer& nodeL
 
 		// LOG("%s: %x is Dirty=%d", __func__, (int)entity, (int)registry.all_of<PathIsDirty>(entity));
 
-		if (registry.any_of<PathIsDirty, PathSearchRef>(entity)) { continue; }
+		// if (registry.any_of<PathIsDirty, PathSearchRef>(entity)) { continue; }
 
 		IPath* path = &pathView.get<IPath>(entity);
 
 		if (path->IsSynced() == false) { continue; }
 		if (path->GetPathType() != pathType) { continue; }
-		// auto-repath should already be triggered.
-		if (path->GetRepathTriggerIndex() != 0 && path->GetNextPointIndex() > path->GetRepathTriggerIndex()) {
-			continue;
-		}
+		// auto-repath should already be triggered. - TODO remove this.
+		// if (path->GetRepathTriggerIndex() != 0 && path->GetNextPointIndex() > path->GetRepathTriggerIndex()) {
+		// 	continue;
+		// }
 
 		// LOG("%s: %x is processing", __func__, (int)entity);
 
@@ -236,19 +182,22 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, const NodeLayer& nodeL
 		bool intersectsPath = false;
 		int autoRefreshOnNode = 0;
 
+		const unsigned int minIdx = std::max(path->GetNextPointIndex(), 2U) - 2;
+
 		// If a reverse search finds no collisions through the whole path, then a forward search isn't needed.
 		if (pathGoodFromNodeId > 0) {
 			// figure out if <path> has at least one edge crossing <r>
 			// we only care about the segments we have not yet visited
 
 			// Forward search. A hit here tells us, when the path needs to be regenerated.
-			const unsigned int minIdx = std::max(path->GetNextPointIndex(), 2U) - 2;
-
 			// The last two path points reside in the last node.
 			const unsigned int triggerIndex = path->GetRepathTriggerIndex();
 			const unsigned int maxIdx = (triggerIndex > 0) ? triggerIndex : pathNodeList.size();
 			const unsigned int rPathBadAtNodeId = pathGoodFromNodeId - 1;
-		
+
+			// if (path->GetID() == 131)
+			// 	LOG("%s: minIdx %d, maxIdx %d", __func__, minIdx, maxIdx);
+
 			for (unsigned int i = minIdx; i < maxIdx; i++) {
 				const QTPFS::IPath::PathNodeData& node = pathNodeList[i];
 
@@ -270,18 +219,24 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, const NodeLayer& nodeL
 			}
 		}
 
-		// Reverse search.
-
 		if (intersectsQuads || intersectsPath) {
+			bool remainingPathIsDirty = (pathGoodFromNodeId > minIdx);
+
 			DirtyPathDetail dirtyPathDetail;
 			dirtyPathDetail.pathEntity = entity;
 			dirtyPathDetail.clearSharing = true;
-			dirtyPathDetail.clearPath = intersectsPath && (autoRefreshOnNode == 0);
+			dirtyPathDetail.clearPath = intersectsPath && (autoRefreshOnNode == 0) && remainingPathIsDirty;
 			dirtyPathDetail.autoRepathTrigger = autoRefreshOnNode;
-			dirtyPathDetail.nodesAreCleanFromNodeId = pathGoodFromNodeId;
 
-			// if (path->GetID() == 290455867)
-			// 	LOG("%s: trig=%d, clean=%d", __func__, dirtyPathDetail.autoRepathTrigger, dirtyPathDetail.nodesAreCleanFromNodeId);
+			// No point noting that the path is clean before the point the owner has reached. The boundary check cuts
+			// out the path before the owner's position.
+			dirtyPathDetail.nodesAreCleanFromNodeId = std::max(pathGoodFromNodeId, minIdx);
+
+			// if (path->GetID() == 131)
+			// 	LOG("%s: trig=%d, clearPath=%d, clean=%d", __func__
+			// 			, dirtyPathDetail.autoRepathTrigger
+			// 			, int(dirtyPathDetail.clearPath)
+			// 			, dirtyPathDetail.nodesAreCleanFromNodeId);
 
 			dirtyPaths[pathType].emplace_back(dirtyPathDetail);
 		}

--- a/rts/Sim/Path/QTPFS/PathCache.h
+++ b/rts/Sim/Path/QTPFS/PathCache.h
@@ -5,6 +5,7 @@
 
 #include <vector>
 
+#include "NodeLayer.h"
 #include "PathEnums.h"
 #include "Path.h"
 #include "System/UnorderedMap.hpp"
@@ -25,11 +26,12 @@ namespace QTPFS {
 		struct DirtyPathDetail {
 			entt::entity pathEntity;
 			int autoRepathTrigger;
+			int nodesAreCleanFromNodeId;
 			bool clearSharing;
 			bool clearPath;
 		};
 
-		bool MarkDeadPaths(const SRectangle& r, int pathType);
+		bool MarkDeadPaths(const SRectangle& r, const NodeLayer& nodeLayer);
 
 		void Init(int pathTypes) {
 			dirtyPaths.clear();

--- a/rts/Sim/Path/QTPFS/PathDefines.h
+++ b/rts/Sim/Path/QTPFS/PathDefines.h
@@ -10,7 +10,9 @@
 #define QTPFS_SMOOTH_PATHS
 // #define QTPFS_CONSERVATIVE_NODE_SPLITS
 // #define QTPFS_DEBUG_NODE_HEAP
+
 #define QTPFS_CORNER_CONNECTED_NODES
+
 // #define QTPFS_SLOW_ACCURATE_TESSELATION
 // #define QTPFS_ORTHOPROJECTED_EDGE_TRANSITIONS
 #define QTPFS_ENABLE_MICRO_OPTIMIZATION_HACKS
@@ -32,6 +34,11 @@
 #define QTPFS_SHARE_PATH_MIN_SIZE 2
 #define QTPFS_SHARE_PATH_MAX_SIZE 16
 #define QTPFS_PARTIAL_SHARE_PATH_MAX_SIZE 32
+
+#define QTPFS_MAP_DAMAGE_SIZE 16
+
+// Though there are four quads per level, having nothing is like a 5th state. So 3 bits, not 2, is needed per level.
+#define QTPFS_NODE_NUMBER_SHIFT_STEP 3
 
 namespace QTPFS {
     constexpr int SEARCH_DIRS = 2;

--- a/rts/Sim/Path/QTPFS/PathManager.h
+++ b/rts/Sim/Path/QTPFS/PathManager.h
@@ -141,7 +141,8 @@ namespace QTPFS {
 		unsigned int RequeueSearch(
 			IPath* oldPath,
 			const bool allowRawSearch,
-			const bool allowPartialSearch
+			const bool allowPartialSearch,
+			const bool allowRepair
 		);
 
 	private:

--- a/rts/Sim/Path/QTPFS/PathSearch.cpp
+++ b/rts/Sim/Path/QTPFS/PathSearch.cpp
@@ -101,11 +101,11 @@ void QTPFS::PathSearch::Initialize(
 	bwd.srcPoint = fwd.tgtPoint;
 	bwd.tgtPoint = fwd.srcPoint;
 
-	// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+	// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 	// 	LOG("%s: bwd.tgtPoint (%f, %f, %f)", __func__, bwd.tgtPoint.x, bwd.tgtPoint.y, bwd.tgtPoint.z);
 	// }
 
-	// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+	// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 	// 	LOG("%s: owner %d (%f,%f,%f)", __func__
 	// 		, owner->id, owner->pos.x, owner->pos.y, owner->pos.z
 	// 		);
@@ -190,7 +190,22 @@ void QTPFS::PathSearch::InitializeThread(SearchThreadData* threadData) {
 			int firstCleanNodeId = pathToRepair->GetFirstNodeIdOfCleanPath();
 			const QTPFS::IPath::PathNodeData& firstCleanNode = pathToRepair->GetNode(firstCleanNodeId);
 
-			return nodeLayer->GetPoolNode(firstCleanNode.nodeId);
+			// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+			// 	LOG("%s: goodRecord %d [%x] g=%d (%d,%d)-(%d,%d) [%f,%f]", __func__
+			// 		, firstCleanNode.nodeId, firstCleanNode.nodeNumber
+			// 		, int(!firstCleanNode.IsNodeBad())
+			// 		, firstCleanNode.xmin, firstCleanNode.zmin, firstCleanNode.xmax, firstCleanNode.zmax
+			// 		, firstCleanNode.netPoint.x, firstCleanNode.netPoint.y
+			// 		);
+			// }
+
+			auto curNode = nodeLayer->GetPoolNode(firstCleanNode.nodeId);
+			assert(curNode->xmin() == firstCleanNode.xmin);
+			assert(curNode->xmax() == firstCleanNode.xmax);
+			assert(curNode->zmin() == firstCleanNode.zmin);
+			assert(curNode->zmax() == firstCleanNode.zmax);
+
+			return curNode;
 		}
 		return nodeLayer->GetNode(fwd.tgtPoint.x / SQUARE_SIZE, fwd.tgtPoint.z / SQUARE_SIZE);
 	};
@@ -271,7 +286,7 @@ void QTPFS::PathSearch::InitializeThread(SearchThreadData* threadData) {
 	// 		, searchLimitMins.x, searchLimitMins.y, searchLimitMins.z
 	// 		, searchLimitMaxs.x, searchLimitMaxs.y, searchLimitMaxs.z);
 
-	// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+	// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 	// 	LOG("%s: revMinNode0 [%d] %d [%x] g=%d (%d,%d)-(%d,%d)", __func__, searchID
 	// 		, bwd.minSearchNode->index, bwd.minSearchNode->nodeNumber
 	// 		, int(!bwd.minSearchNode->isNodeBad())
@@ -279,7 +294,7 @@ void QTPFS::PathSearch::InitializeThread(SearchThreadData* threadData) {
 	// 		);
 	// }
 
-	// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+	// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 	// 	LOG("%s: srcNode (%d:%x) tgtNode (%d:%x)", __func__
 	// 		, srcNode->GetIndex(), srcNode->GetNodeNumber()
 	// 		, tgtNode->GetIndex(), tgtNode->GetNodeNumber()
@@ -312,6 +327,10 @@ void QTPFS::PathSearch::PreLoadNode(uint32_t dir, uint32_t nodeId, uint32_t prev
 	CopyNodeBoundaries(searchNode, *curNode);
 	searchNode.nodeNumber = curNode->GetNodeNumber();
 	searchNode.badNode = (stepIndex == 999999);
+
+	// if (searchID == 357564596)
+	// 	LOG("Add node in advance %d linked to %d : [%d,%d][%d,%d]"
+	// 		, nodeId, prevNodeId, searchNode.xmin, searchNode.zmin, searchNode.xmax, searchNode.zmax);
 
 	#ifndef NDEBUG
 	if (prevNodeId != -1) {
@@ -347,7 +366,7 @@ void QTPFS::PathSearch::LoadPartialPath(IPath* path) {
 			#ifndef NDEBUG
 			// a failure here is likely due to a path not being marked as dirty when quads in the path have been damaged.
 			INode* nn1 = nodeLayer->GetPoolNode(node.nodeId);
-			// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+			// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 			// 	LOG("%s: node bwd check %d [%x] g=%d (%d,%d)-(%d,%d) vs [%x] (%d,%d)-(%d,%d) [%f,%f]", __func__
 			// 		, node.nodeId, node.nodeNumber, int(!node.IsNodeBad())
 			// 		, node.xmin, node.zmin, node.xmax, node.zmax
@@ -380,7 +399,7 @@ void QTPFS::PathSearch::LoadPartialPath(IPath* path) {
 		uint32_t prevNodeId = -1;
 		std::for_each(nodes.rbegin(), nodes.rend(), [this, &prevNodeId, &prevNetPoint, &stepIndex](const IPath::PathNodeData& node){
 			// INode* nn1 = nodeLayer->GetPoolNode(node.nodeId);
-			// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+			// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 			// 	LOG("%s: node fwd check %d [%x] g=%d (%d,%d)-(%d,%d) vs [%x] (%d,%d)-(%d,%d) [%f,%f]", __func__
 			// 		, node.nodeId, node.nodeNumber, int(!node.IsNodeBad())
 			// 		, node.xmin, node.zmin, node.xmax, node.zmax
@@ -425,7 +444,7 @@ void QTPFS::PathSearch::LoadRepairPath() {
 			#ifndef NDEBUG
 			// a failure here is likely due to a path not being marked as dirty when quads in the path have been damaged.
 			INode* nn1 = nodeLayer->GetPoolNode(node.nodeId);
-			// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+			// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 			// 	LOG("%s: node repair bwd check %d [%x] g=%d (%d,%d)-(%d,%d) vs [%x] (%d,%d)-(%d,%d) [%f,%f] prevNodeId=%d stepIndex=%d", __func__
 			// 		, node.nodeId, node.nodeNumber, int(!node.IsNodeBad())
 			// 		, node.xmin, node.zmin, node.xmax, node.zmax
@@ -440,6 +459,12 @@ void QTPFS::PathSearch::LoadRepairPath() {
 			assert(nn1->xmax() == node.xmax);
 			assert(nn1->zmin() == node.zmin);
 			assert(nn1->zmax() == node.zmax);
+
+			if (prevNodeId != -1) {
+				INode* nn0 = nodeLayer->GetPoolNode(prevNodeId);
+				assert(nn1->GetNeighborRelation(nn0) != 0);
+				assert(nn0->GetNeighborRelation(nn1) != 0);
+			}
 			#endif
 
 		PreLoadNode(SearchThreadData::SEARCH_BACKWARD, node.nodeId, prevNodeId, prevNetPoint, stepIndex--);
@@ -447,14 +472,32 @@ void QTPFS::PathSearch::LoadRepairPath() {
 		prevNetPoint = node.netPoint;
 	}
 
-	auto& bwdNodes = searchThreadData->allSearchedNodes[SearchThreadData::SEARCH_BACKWARD];
-	auto& bwdData = directionalSearchData[SearchThreadData::SEARCH_BACKWARD];
+	auto& fwd = directionalSearchData[SearchThreadData::SEARCH_FORWARD];
+	auto& fwdSearchNodes = searchThreadData->allSearchedNodes[SearchThreadData::SEARCH_FORWARD];
+	
+	auto& bwd = directionalSearchData[SearchThreadData::SEARCH_BACKWARD];
+	auto& bwdSearchNodes = searchThreadData->allSearchedNodes[SearchThreadData::SEARCH_BACKWARD];
 
 	int nodeId = pathToRepair->GetNode(nodeCount - 1).nodeId;
-	assert( bwdNodes.isSet(nodeId) );
+	assert( bwdSearchNodes.isSet(nodeId) );
 
-	SearchNode& searchNode = bwdNodes[nodeId];
-	bwdData.repairPathRealSrcSearchNode = &searchNode;
+	SearchNode& searchNode = bwdSearchNodes[nodeId];
+	bwd.repairPathRealSrcSearchNode = &searchNode;
+
+	// Check wether the repair is starting on the clean path.
+	if (bwdSearchNodes.isSet(fwd.srcSearchNode->GetIndex())) {
+		const QTPFS::SearchNode& bwdNode = bwdSearchNodes[fwd.srcSearchNode->index];
+		if (bwdNode.GetStepIndex() > 0) {
+			const float2& edgePoint = bwdNode.GetNeighborEdgeTransitionPoint();
+			const float3 newTgtPoint{edgePoint.x, 0.f, edgePoint.y};
+
+			fwd.tgtPoint = goalPos;
+			fwd.tgtSearchNode = fwd.srcSearchNode;
+			bwd.tgtPoint = newTgtPoint;
+			bwd.tgtSearchNode = bwdNode.prevNode;
+			bwd.srcSearchNode = bwd.repairPathRealSrcSearchNode;
+		}
+	}
 }
 
 // #pragma GCC pop_options
@@ -471,9 +514,14 @@ bool QTPFS::PathSearch::Execute(unsigned int searchStateOffset) {
 	if (haveFullPath) {
 		// Ensure the node data is pulled
 		if ( !rawPathCheck ) {
+			{
 			auto* curNode = nodeLayer->GetPoolNode(fwd.srcSearchNode->GetIndex());
 			InitSearchNodeData(fwd.srcSearchNode, curNode);
+			}
+			{ // bwd node may not be the same as fwd if path repair is on
+			auto* curNode = nodeLayer->GetPoolNode(bwd.srcSearchNode->GetIndex());
 			InitSearchNodeData(bwd.srcSearchNode, curNode);
+			}
 		}
 		return true;
 	}
@@ -657,7 +705,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 			return;
 
 		SearchNode* revCurNode = &revSearchNodes[fwd.tgtSearchNode->GetIndex()];
-		// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && dir == SearchThreadData::SEARCH_BACKWARD){
+		// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && dir == SearchThreadData::SEARCH_BACKWARD){
 		// 	LOG("%s: revMinNode-- %d [%x] g=%d (%d,%d)-(%d,%d) [%f,%f]", __func__
 		// 		, revCurNode->index, revCurNode->nodeNumber
 		// 		, int(!revCurNode->isNodeBad())
@@ -687,7 +735,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 				AssertPointIsOnNodeEdge(fwd.tgtPoint, prevFwdNode);
 				AssertPointIsOnNodeEdge(fwd.tgtPoint, revCurNode);
 
-				// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+				// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 				// 	LOG("%s: [%d] fwd.tgtPoint (%f, %f, %f)", __func__, dir, fwd.tgtPoint.x, fwd.tgtPoint.y, fwd.tgtPoint.z);
 				// 	LOG("%s: [%d] bwd.tgtPoint (%f, %f, %f)", __func__, dir, bwd.tgtPoint.x, bwd.tgtPoint.y, bwd.tgtPoint.z);
 				// }
@@ -698,7 +746,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 				haveFullPath = true;
 				useFwdPathOnly = false;
 				searchEarlyDrop = false;
-				//if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && dir == SearchThreadData::SEARCH_BACKWARD){
+				//if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && dir == SearchThreadData::SEARCH_BACKWARD){
 					// LOG("true path found when all other hope is lost.");
 				//}
 				return;
@@ -718,7 +766,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 				fwdCurNode->prevNode = prevFwdNode;
 				fwdCurNode->selectedNetpoint = nextTransitionPoint;
 
-				// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+				// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 				// 	LOG("%s: [%d] revMinNode added %d [%x] g=%d (%d,%d)-(%d,%d) [%f,%f]", __func__, dir
 				// 		, revCurNode->index, revCurNode->nodeNumber
 				// 		, int(!revCurNode->isNodeBad())
@@ -738,14 +786,14 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 					fwdCurNode->selectedNetpoint = nextTransitionPoint;
 				}
 
-				// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && dir == SearchThreadData::SEARCH_BACKWARD){
+				// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && dir == SearchThreadData::SEARCH_BACKWARD){
 				// 	LOG("Exists");
 				// }
 			}
 			prevFwdNode = fwdCurNode;
 			nextTransitionPoint = revCurNode->selectedNetpoint;
 
-			// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+			// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 			// 	LOG("%s: [%d] revMinNode-- %d [%x] g=%d (%d,%d)-(%d,%d)", __func__, dir
 			// 		, revCurNode->index, revCurNode->nodeNumber
 			// 		, int(!revCurNode->isNodeBad())
@@ -756,13 +804,13 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 			revCurNode = revCurNode->GetPrevNode();
 		}
 
-		// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && dir == SearchThreadData::SEARCH_BACKWARD){
+		// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && dir == SearchThreadData::SEARCH_BACKWARD){
 		// 	LOG("Switch to: %d", fwdCurNode->GetIndex());
 		// }
 		fwd.tgtSearchNode = fwdCurNode;//&fwdSearchNodes[revCurNode->GetIndex()];
 		fwd.minSearchNode = fwd.tgtSearchNode;
 
-		// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && dir == SearchThreadData::SEARCH_BACKWARD){
+		// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && dir == SearchThreadData::SEARCH_BACKWARD){
 		// 	LOG("%s: revMinNode5 %d [%x] g=%d (%d,%d)-(%d,%d)", __func__
 		// 		, fwd.minSearchNode->index, fwd.minSearchNode->nodeNumber
 		// 		, int(!fwd.minSearchNode->isNodeBad())
@@ -793,7 +841,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 
 	assert(fwd.srcSearchNode != nullptr);
 
-	// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+	// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 	// 	LOG("%s: revTgtNode1 %d [%x] g=%d (%d,%d)-(%d,%d)", __func__
 	// 		, bwd.tgtSearchNode->index, bwd.tgtSearchNode->nodeNumber
 	// 		, int(!bwd.tgtSearchNode->isNodeBad())
@@ -862,7 +910,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 						fwd.tgtSearchNode = curSearchNode->GetPrevNode();
 						bwd.tgtSearchNode = &bwdNode;
 
-						// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+						// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 						// 	LOG("%s: revTgtNode5 %d [%x] g=%d (%d,%d)-(%d,%d)", __func__
 						// 		, bwd.tgtSearchNode->index, bwd.tgtSearchNode->nodeNumber
 						// 		, int(!bwd.tgtSearchNode->isNodeBad())
@@ -879,7 +927,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 
 					searchThreadData->ResetQueue(SearchThreadData::SEARCH_BACKWARD);
 
-					// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+					// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 					// 	LOG("%s: bwd.tgtPoint1 (%f, %f, %f)", __func__, bwd.tgtPoint.x, bwd.tgtPoint.y, bwd.tgtPoint.z);
 					// }
 				}
@@ -913,7 +961,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 			bwdNodesSearched++;
 			IterateNodes(SearchThreadData::SEARCH_BACKWARD);
 
-			// if (curSearchNode->GetIndex() == 20076 && searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && gs->frameNum == 10213)
+			// if (curSearchNode->GetIndex() == 20076 && searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ && gs->frameNum == 10213)
 			// 	LOG("Whoops!");
 
 			if (bwdNodesSearched >= fwdNodeSearchLimit)
@@ -946,18 +994,18 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 					bwd.tgtSearchNode = curSearchNode;
 					searchThreadData->ResetQueue(SearchThreadData::SEARCH_BACKWARD);
 
-	// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
-	// 	LOG("%s: revTgtNode6 %d [%x] g=%d (%d,%d)-(%d,%d)", __func__
-	// 		, bwd.tgtSearchNode->index, bwd.tgtSearchNode->nodeNumber
-	// 		, int(!bwd.tgtSearchNode->isNodeBad())
-	// 		, bwd.tgtSearchNode->xmin, bwd.tgtSearchNode->zmin, bwd.tgtSearchNode->xmax,bwd.tgtSearchNode->zmax
-	// 		);
-	// 	LOG("%s: revMinNode6 %d [%x] g=%d (%d,%d)-(%d,%d)", __func__
-	// 		, bwd.minSearchNode->index, bwd.minSearchNode->nodeNumber
-	// 		, int(!bwd.minSearchNode->isNodeBad())
-	// 		, bwd.minSearchNode->xmin, bwd.minSearchNode->zmin, bwd.minSearchNode->xmax,bwd.minSearchNode->zmax
-	// 		);
-	// }
+					// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+					// 	LOG("%s: revTgtNode6 %d [%x] g=%d (%d,%d)-(%d,%d)", __func__
+					// 		, bwd.tgtSearchNode->index, bwd.tgtSearchNode->nodeNumber
+					// 		, int(!bwd.tgtSearchNode->isNodeBad())
+					// 		, bwd.tgtSearchNode->xmin, bwd.tgtSearchNode->zmin, bwd.tgtSearchNode->xmax,bwd.tgtSearchNode->zmax
+					// 		);
+					// 	LOG("%s: revMinNode6 %d [%x] g=%d (%d,%d)-(%d,%d)", __func__
+					// 		, bwd.minSearchNode->index, bwd.minSearchNode->nodeNumber
+					// 		, int(!bwd.minSearchNode->isNodeBad())
+					// 		, bwd.minSearchNode->xmin, bwd.minSearchNode->zmin, bwd.minSearchNode->xmax,bwd.minSearchNode->zmax
+					// 		);
+					// }
 				}
 
 				haveFullPath = (isFullSearch) ? bwdPathConnected : bwdPathConnected & fwdPathConnected;
@@ -966,7 +1014,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 					if (curSearchNode->GetPrevNode() == nullptr) {
 						useFwdPathOnly = true;
 						fwd.tgtSearchNode = &fwdNode;
-						// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+						// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 						// 	LOG("%s: revTgtNode7 %d [%x] g=%d (%d,%d)-(%d,%d)", __func__
 						// 		, bwd.tgtSearchNode->index, bwd.tgtSearchNode->nodeNumber
 						// 		, int(!bwd.tgtSearchNode->isNodeBad())
@@ -977,7 +1025,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 						bwd.tgtSearchNode = curSearchNode->GetPrevNode();
 						fwd.tgtSearchNode = &fwdNode;
 
-						// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+						// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 						// 	LOG("%s: revTgtNode4 %d [%x] g=%d (%d,%d)-(%d,%d)", __func__
 						// 		, bwd.tgtSearchNode->index, bwd.tgtSearchNode->nodeNumber
 						// 		, int(!bwd.tgtSearchNode->isNodeBad())
@@ -991,7 +1039,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 						AssertPointIsOnNodeEdge(bwd.tgtPoint, curSearchNode);
 						AssertPointIsOnNodeEdge(bwd.tgtPoint, &fwdNode);
 
-						// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+						// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 						// 	LOG("%s: bwd.tgtPoint2 (%f, %f, %f)", __func__, bwd.tgtPoint.x, bwd.tgtPoint.y, bwd.tgtPoint.z);
 						// }
 					}
@@ -1095,7 +1143,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 		// in reverse searches.
 		bwd.tgtSearchNode = bwd.minSearchNode;
 
-		// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+		// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 		// 	LOG("%s: revTgtNode3 %d [%x] g=%d (%d,%d)-(%d,%d)", __func__
 		// 		, bwd.tgtSearchNode->index, bwd.tgtSearchNode->nodeNumber
 		// 		, int(!bwd.tgtSearchNode->isNodeBad())
@@ -1118,7 +1166,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 	}
 	#endif
 
-	// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+	// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 	// 	LOG("%s: revTgtNode2 %d [%x] g=%d (%d,%d)-(%d,%d)", __func__
 	// 		, bwd.tgtSearchNode->index, bwd.tgtSearchNode->nodeNumber
 	// 		, int(!bwd.tgtSearchNode->isNodeBad())
@@ -1243,7 +1291,7 @@ void QTPFS::PathSearch::IterateNodes(unsigned int searchDir) {
 	if (otherNodes.isSet(curSearchNode->GetIndex())){
 		// Check whether it has been processed yet
 		if (IsNodeActive(otherNodes[curSearchNode->GetIndex()])) {
-			// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ /*&& searchDir == SearchThreadData::SEARCH_BACKWARD*/){
+			// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ /*&& searchDir == SearchThreadData::SEARCH_BACKWARD*/){
 			// 	LOG("%s: NodeActive [%d] %d [%x] g=%d (%d,%d)-(%d,%d)", __func__, searchDir
 			// 		, searchData.minSearchNode->index, searchData.minSearchNode->nodeNumber
 			// 		, int(!searchData.minSearchNode->isNodeBad())
@@ -1260,7 +1308,7 @@ void QTPFS::PathSearch::IterateNodes(unsigned int searchDir) {
 	if (curSearchNode->GetPathCost(NODE_PATH_COST_H) < searchData.minSearchNode->GetPathCost(NODE_PATH_COST_H))
 		searchData.minSearchNode = curSearchNode;
 
-	// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ /*&& searchDir == SearchThreadData::SEARCH_BACKWARD*/){
+	// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ /*&& searchDir == SearchThreadData::SEARCH_BACKWARD*/){
 	// 	LOG("%s: MinNode2  [%d] %d [%x] g=%d (%d,%d)-(%d,%d)", __func__, searchDir
 	// 		, searchData.minSearchNode->index, searchData.minSearchNode->nodeNumber
 	// 		, int(!searchData.minSearchNode->isNodeBad())
@@ -1276,7 +1324,7 @@ void QTPFS::PathSearch::IterateNodes(unsigned int searchDir) {
 	assert(curSearchNode->GetIndex() == curOpenNode.nodeIndex);
 	auto* curNode = nodeLayer->GetPoolNode(curOpenNode.nodeIndex);
 
-	// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ /*&& searchDir == SearchThreadData::SEARCH_BACKWARD*/){
+	// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ /*&& searchDir == SearchThreadData::SEARCH_BACKWARD*/){
 	// 	LOG("%s: MinNode2. [%d] %d [%x] g=%d (%d,%d)-(%d,%d)", __func__, searchDir
 	// 		, searchData.minSearchNode->index, searchData.minSearchNode->nodeNumber
 	// 		, int(!searchData.minSearchNode->isNodeBad())
@@ -1427,7 +1475,7 @@ void QTPFS::PathSearch::IterateNodeNeighbors(const INode* curNode, unsigned int 
 		// LOG("%s: [%d] nxtNode=%d updating gc from %f -> %f", __func__, searchDir, nxtNodesId
 		// 		, nextSearchNode->GetPathCost(NODE_PATH_COST_G), gCosts[netPointIdx]);
 
-		// 	if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ /*&& searchDir == SearchThreadData::SEARCH_BACKWARD*/){
+		// 	if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */ /*&& searchDir == SearchThreadData::SEARCH_BACKWARD*/){
 
 		// LOG("%s: [%d] adding node (%d) gcost %f < %f [old p:%f]", __func__, searchDir
 		// 		, nextSearchNode->GetIndex()
@@ -1629,7 +1677,7 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 				prvNode = tmpNode;
 				#endif
 
-				// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+				// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 				// 	LOG("%s: revBadNodeRecord %d [%x] g=%d (%d,%d)-(%d,%d) [%f,%f]", __func__
 				// 		, tmpNode->index, tmpNode->nodeNumber
 				// 		, int(!newPoint.isBad)
@@ -1650,7 +1698,7 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 
 			float3 prvPoint = bwd.tgtPoint;
 
-			// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+			// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 			// 	LOG("%s: bwd.tgtPoint is (%f, %f, %f)", __func__, bwd.tgtPoint.x, bwd.tgtPoint.y, bwd.tgtPoint.z);
 			// }
 
@@ -1714,7 +1762,7 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 				tmpNode->SetPrevNode(nullptr);
 				#endif
 
-				// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+				// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 				// 	LOG("%s: revGoodRecord %d [%x] g=%d (%d,%d)-(%d,%d) [%f,%f]", __func__
 				// 		, tmpNode->index, tmpNode->nodeNumber
 				// 		, int(!tmpNode->isNodeBad())
@@ -1730,6 +1778,7 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 
 		const SearchNode* tmpNode = fwd.tgtSearchNode;
 		
+		#ifndef NDEBUG
 		if (points.size() > 0) {
 			const auto tmpPoint = bwd.tgtPoint;
 			TracePoint* nextNode = &points[0];
@@ -1746,6 +1795,8 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 				AssertPointIsOnNodeEdge(tmpPoint, nextNode);
 			}
 		}
+		#endif
+
 		const SearchNode* nextNode = (tmpNode != nullptr) ? tmpNode->GetPrevNode() : nullptr;
 
 		float3 prvPoint = fwd.tgtPoint;
@@ -1754,7 +1805,7 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 			const float2& tmpPoint2 = tmpNode->GetNeighborEdgeTransitionPoint();
 			const float3  tmpPoint  = {tmpPoint2.x, 0.0f, tmpPoint2.y};
 
-			// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+			// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 			// 	LOG("%s: goodRecord %d [%x] g=%d (%d,%d)-(%d,%d) [%f,%f]", __func__
 			// 		, tmpNode->index, tmpNode->nodeNumber
 			// 		, int(!tmpNode->isNodeBad())
@@ -1854,7 +1905,7 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 			}
 			#endif
 
-			// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+			// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 			// 	LOG("%s: last goodRecord %d [%x] g=%d (%d,%d)-(%d,%d) [%f,%f]", __func__
 			// 		, tmpNode->index, tmpNode->nodeNumber
 			// 		, int(!tmpNode->isNodeBad())
@@ -1864,85 +1915,6 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 			// }
 		}
 	}
-
-	// // Add the missing nodes for the clean part of the path that is being repaired.
-	// // TODO: step index < 1 for this to work.
-	// if (doPathRepair) {
-	// 	const uint32_t firstCleanNodeId = pathToRepair->GetFirstNodeIdOfCleanPath();
-	// 	const uint32_t nodeCount = pathToRepair->GetGoodNodeCount();
-
-	// 	// Only copy over the data needed to compare prvNode to tmpNode
-	// 	QTPFS::IPath::PathNodeData lastRevNode;
-	// 	lastRevNode.xmin = bwd.srcSearchNode->xmin;
-	// 	lastRevNode.xmax = bwd.srcSearchNode->xmax;
-	// 	lastRevNode.zmin = bwd.srcSearchNode->zmin;
-	// 	lastRevNode.zmax = bwd.srcSearchNode->zmax;
-	// 	lastRevNode.nodeId = bwd.srcSearchNode->GetIndex();
-		
-	// 	const QTPFS::IPath::PathNodeData* prevNode = &lastRevNode;
-	// 	float3 prvPoint(bwd.srcSearchNode->selectedNetpoint.x, 0.f, bwd.srcSearchNode->selectedNetpoint.y);
-
-	// 	// The +1 is  because the bwd.srcSearchNode will be the firstCleanNodeId node. So start from the next one on.
-	// 	for (auto i = firstCleanNodeId + 1; i < nodeCount; ++i) {
-	// 		const QTPFS::IPath::PathNodeData* tmpNode = &pathToRepair->GetNode(i);
-
-	// 		const float2& tmpPoint2 = tmpNode->netPoint;
-	// 		const float3  tmpPoint  = {tmpPoint2.x, 0.0f, tmpPoint2.y};
-
-	// 		assert(tmpPoint.x >= 0.f);
-	// 		assert(tmpPoint.z >= 0.f);
-	// 		assert(tmpPoint.x / SQUARE_SIZE < mapDims.mapx);
-	// 		assert(tmpPoint.z / SQUARE_SIZE < mapDims.mapy);
-
-	// 		assert(!math::isinf(tmpPoint.x) && !math::isinf(tmpPoint.z));
-	// 		assert(!math::isnan(tmpPoint.x) && !math::isnan(tmpPoint.z));
-
-	// 		#ifndef NDEBUG
-	// 		if (prevNode != nullptr) {
-	// 			assert(tmpNode->nodeId != prevNode->nodeId);
-
-	// 			INode* nn0 = nodeLayer->GetPoolNode(prevNode->nodeId);
-	// 			INode* nn1 = nodeLayer->GetPoolNode(tmpNode->nodeId);
-
-	// 			assert(nn1->GetNeighborRelation(nn0) != 0);
-	// 			assert(nn0->GetNeighborRelation(nn1) != 0);
-
-	// 			AssertPointIsOnNodeEdge(tmpPoint, tmpNode);
-	// 			AssertPointIsOnNodeEdge(tmpPoint, prevNode);
-	// 		}
-	// 		assert(prvPoint != ZeroVector
-	// 				|| (prevNode->nodeId == bwd.srcSearchNode->GetIndex()
-	// 						&& fwd.srcSearchNode->GetIndex() == bwd.srcSearchNode->GetIndex()));
-	// 		assert(tmpPoint != prvPoint);
-
-	// 		#endif
-
-	// 		assert( !isPresent(points, *tmpNode) );
-
-	// 		points.emplace_back(tmpPoint
-	// 				, tmpNode->nodeId
-	// 				, tmpNode->nodeNumber
-	// 				, tmpNode->xmin, tmpNode->zmin
-	// 				, tmpNode->xmax, tmpNode->zmax);
-
-	// 		boundaryMins.x = std::min(boundaryMins.x, float(tmpNode->xmin*SQUARE_SIZE));
-	// 		boundaryMins.z = std::min(boundaryMins.z, float(tmpNode->zmin*SQUARE_SIZE));
-	// 		boundaryMaxs.x = std::max(boundaryMaxs.x, float(tmpNode->xmax*SQUARE_SIZE));
-	// 		boundaryMaxs.z = std::max(boundaryMaxs.z, float(tmpNode->zmax*SQUARE_SIZE));
-
-	// 		// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
-	// 		// 	LOG("%s: repair node added to end %d [%x] g=%d (%d,%d)-(%d,%d) [%f,%f]", __func__
-	// 		// 		, tmpNode->nodeId, tmpNode->nodeNumber
-	// 		// 		, int(!tmpNode->badNode)
-	// 		// 		, tmpNode->xmin, tmpNode->zmin, tmpNode->xmax, tmpNode->zmax
-	// 		// 		, tmpNode->netPoint.x, tmpNode->netPoint.y
-	// 		// 		);
-	// 		// }
-
-	// 		prvPoint = tmpPoint;
-	// 		prevNode = tmpNode;
-	// 	}
-	// }
 
 	// if source equals target, we need only two points
 	if (!points.empty()) {
@@ -2020,7 +1992,7 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 		}
 		#endif
 
-		// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+		// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 		// 	auto* curNode = &path->GetNode(nodeIndex);
 		// 	LOG("%s: traceNode %d [%x] g=%d (%d,%d)-(%d,%d) [%f,%f] [b? %d]", __func__
 		// 		, curNode->nodeId, curNode->nodeNumber
@@ -2069,7 +2041,7 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 			}
 		}
 
-		// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+		// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 		// 	LOG("%s: repathIndex=%d pathIsBigEnoughForRepath=%d min=%f pathDist=%f path=%d last=%d", __func__
 		// 			, repathIndex, int(pathIsBigEnoughForRepath), minRepathLength, pathDist
 		// 			, path->GetID(), int(points.size()-1));
@@ -2082,7 +2054,7 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 	path->SetGoalPosition(goalPos);
 	path->SetRepathTriggerIndex(repathIndex);
 
-		// 	if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
+		// 	if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */){
 		// 	LOG("%s: repathIndex=%d path=%d last=%d", __func__
 		// 			, path->GetRepathTriggerIndex()
 		// 			, path->GetID(), int(points.size()-1));
@@ -2488,7 +2460,7 @@ bool QTPFS::PathSearch::SharedFinalize(const IPath* srcPath, IPath* dstPath) {
 
 	auto& fwd = directionalSearchData[SearchThreadData::SEARCH_FORWARD];
 
-	// if (searchID == 257949903 /*&& pathOwner != nullptr && pathOwner->id == 30809 */) {
+	// if (searchID == 357564596 /*&& pathOwner != nullptr && pathOwner->id == 30809 */) {
 	// 	LOG("%s: %d %d", __func__
 	// 		, srcPath->GetID(), dstPath->GetID()
 	// 		);
@@ -2516,6 +2488,7 @@ bool QTPFS::PathSearch::SharedFinalize(const IPath* srcPath, IPath* dstPath) {
 	dstPath->SetSearchTime(srcPath->GetSearchTime());
 	dstPath->SetRepathTriggerIndex(srcPath->GetRepathTriggerIndex());
 	dstPath->SetGoalPosition(goalPos);
+	dstPath->SetIsRawPath(srcPath->IsRawPath());
 
 	haveFullPath = srcPath->IsFullPath();
 	havePartPath = srcPath->IsPartialPath();

--- a/rts/Sim/Path/QTPFS/PathSearch.h
+++ b/rts/Sim/Path/QTPFS/PathSearch.h
@@ -98,6 +98,7 @@ namespace QTPFS {
 			, haveFullPath(false)
 			, havePartPath(false)
 			, pathOwner(nullptr)
+			, tryPathRepair(false)
 			{}
 		PathSearch(unsigned int pathSearchType)
 			: PathSearch()
@@ -111,7 +112,9 @@ namespace QTPFS {
 			const CSolidObject* owner
 		);
 		void InitializeThread(SearchThreadData* threadData);
+		void PreLoadNode(uint32_t dir, uint32_t nodeId, uint32_t prevNodeId, const float2& netPoint, uint32_t stepIndex);
 		void LoadPartialPath(IPath* path);
+		void LoadRepairPath();
 		bool Execute(unsigned int searchStateOffset = 0);
 		void Finalize(IPath* path);
 		bool SharedFinalize(const IPath* srcPath, IPath* dstPath);
@@ -145,10 +148,20 @@ namespace QTPFS {
 			SearchNode *srcSearchNode, *tgtSearchNode;
 			float3 srcPoint, tgtPoint;
 			SearchNode *minSearchNode;
+			SearchNode *repairPathRealSrcSearchNode;
 		};
 
 		void ResetState(SearchNode* node, struct DirectionalSearchData& searchData);
 		void UpdateNode(SearchNode* nextNode, SearchNode* prevNode, unsigned int netPointIdx);
+
+		void InitSearchNodeData(QTPFS::SearchNode *curSearchNode, QTPFS::INode *curNode) const {
+			curSearchNode->xmin = curNode->xmin();
+			curSearchNode->xmax = curNode->xmax();
+			curSearchNode->zmin = curNode->zmin();
+			curSearchNode->zmax = curNode->zmax();
+			curSearchNode->nodeNumber = curNode->GetNodeNumber();
+		}
+
 
 		void IterateNodes(unsigned int searchDir);
 		void IterateNodeNeighbors(const INode* curNode, unsigned int searchDir);
@@ -209,6 +222,8 @@ namespace QTPFS {
 
 		float2 netPoints[QTPFS_MAX_NETPOINTS_PER_NODE_EDGE];
 		float3 goalPos;
+		float3 searchLimitMins;
+		float3 searchLimitMaxs;
 
 		float gDists[QTPFS_MAX_NETPOINTS_PER_NODE_EDGE];
 		float hDists[QTPFS_MAX_NETPOINTS_PER_NODE_EDGE];
@@ -237,16 +252,20 @@ public:
 		bool synced = false;
 		bool pathRequestWaiting = false;
 		bool doPartialSearch = false;
+		bool tryPathRepair = false;
 		bool rejectPartialSearch = false;
 		bool allowPartialSearch = false;
 		bool expectIncompletePartialSearch = false;
 		bool searchEarlyDrop = false;
 		bool initialized = false;
 		bool partialReverseTrace = false;
+		bool doPathRepair = false;
 
 		bool fwdPathConnected = false;
 		bool bwdPathConnected = false;
 		bool useFwdPathOnly = false;
+
+		// int postLoadRepairPathIndexOverride = 0;
 
 		static float MAP_RELATIVE_MAX_NODES_SEARCHED;
 		static int MAP_MAX_NODES_SEARCHED;

--- a/rts/Sim/Path/QTPFS/PathSearch.h
+++ b/rts/Sim/Path/QTPFS/PathSearch.h
@@ -97,7 +97,7 @@ namespace QTPFS {
 			, hCostMult(0.0f)
 			, haveFullPath(false)
 			, havePartPath(false)
-
+			, pathOwner(nullptr)
 			{}
 		PathSearch(unsigned int pathSearchType)
 			: PathSearch()
@@ -126,6 +126,8 @@ namespace QTPFS {
 		int GetPathType() const { return pathType; }
 
 		void SetGoalDistance(float dist) { goalDistance = dist; }
+
+		const CSolidObject* Getowner() const { return pathOwner; }
 
 	private:
 		struct DirectionalSearchData {
@@ -175,8 +177,11 @@ namespace QTPFS {
 		const PathHashType GenerateHash2(uint32_t p1, uint32_t p2) const;
 
 		const PathHashType GenerateVirtualHash(const INode* srcNode, const INode* tgtNode) const;
-		const std::uint32_t GenerateVirtualNodeNumber(const INode* startNode, int nodeMaxSize, int x, int z) const;
 
+		public:
+		static const std::uint32_t GenerateVirtualNodeNumber(const QTPFS::NodeLayer& nodeLayer, const INode* startNode, int nodeMaxSize, int x, int z, uint32_t* depth = nullptr);
+
+		private:
 		QTPFS::SearchThreadData* searchThreadData;
 
 		// Identifies the layer, target quad and source quad for a search query so that similar

--- a/rts/Sim/Path/QTPFS/PathThreads.h
+++ b/rts/Sim/Path/QTPFS/PathThreads.h
@@ -51,6 +51,7 @@ namespace QTPFS {
 
         T& InsertINode(int nodeId) {
             assert(size_t(nodeId) < sparseIndex.size());
+            assert( sparseIndex[nodeId] == 0 );
             InsertAtIndex(T(nodeId), nodeId);
             return operator[](nodeId);
         }
@@ -64,10 +65,12 @@ namespace QTPFS {
 
         auto& operator[](const size_t i) {
             assert(i < sparseIndex.size());
+            assert( sparseIndex[i] != 0 );
             return denseData[sparseIndex[i]];
         }
         const auto& operator[](const size_t i) const {
             assert(i < sparseIndex.size());
+            assert( sparseIndex[i] != 0 );
             return denseData[sparseIndex[i]];
         }
 

--- a/rts/Sim/Path/QTPFS/Systems/RequeuePathsSystem.cpp
+++ b/rts/Sim/Path/QTPFS/Systems/RequeuePathsSystem.cpp
@@ -4,6 +4,7 @@
 
 #include "Sim/Path/IPathManager.h"
 #include "Sim/Path/QTPFS/Components/Path.h"
+#include "Sim/Path/QTPFS/Components/RemoveDeadPaths.h"
 #include "Sim/Path/QTPFS/PathManager.h"
 #include "Sim/Path/QTPFS/Registry.h"
 
@@ -36,7 +37,7 @@ void RequeuePathsSystem::Update()
             requeueSearch = false;
 
             // The path is already scheduled to be requeued.
-            bool dirtyPath = registry.any_of<PathIsDirty>(pathEntity);
+            bool dirtyPath = registry.any_of<PathIsDirty, PathDelayedDelete>(pathEntity);
             if (dirtyPath) { continue; }
 
             pm->RequeueSearch(&registry.get<IPath>(pathEntity), true, false, true);

--- a/rts/Sim/Path/QTPFS/Systems/RequeuePathsSystem.cpp
+++ b/rts/Sim/Path/QTPFS/Systems/RequeuePathsSystem.cpp
@@ -39,7 +39,7 @@ void RequeuePathsSystem::Update()
             bool dirtyPath = registry.any_of<PathIsDirty>(pathEntity);
             if (dirtyPath) { continue; }
 
-            pm->RequeueSearch(&registry.get<IPath>(pathEntity), true, false);
+            pm->RequeueSearch(&registry.get<IPath>(pathEntity), true, false, true);
             registry.emplace_or_replace<PathUpdatedCounterIncrease>(pathEntity);
             
         }


### PR DESCRIPTION
QTPFS Path Repair tracks damage to paths, not just whether a path was damaged, so that when it is time to repath, only the damaged portion needs to be be repathed. This repath is constrained in area to avoid creating bad paths such as forcing the reconnection if it is more appropriate to do a full repath. The pathing system will switch to using a full repath if it isn't appropriate to repair or it can't feasibly repair the path.

This change is intended to reduce the time needed to update paths in response to damage. Previously the whole remainign path had to be recalculated starting from where the owner had got to.