### PR TITLE
Don't assert on external data

### DIFF
--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -863,7 +863,8 @@ void CGame::ClientReadNet()
 						commands.push_back(cmd);
 					}
 
-					assert(aiInstID == MAX_AIS);
+					if (aiInstID != MAX_AIS)
+						throw netcode::UnpackPacketException("Invalid AI instance ID");
 
 					// apply the "AI" commands (which actually originate from LuaUnsyncedCtrl)
 					if (pairwise) {


### PR DESCRIPTION
And don't accept it in non-debug (assert-disabled) builds either.

The value here comes from a network packet, which may be spoofed so its contents should not be asserted.