### PR TITLE
Check quadfield size modrule properly

### DIFF
--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -11,6 +11,8 @@
 #include "System/Exceptions.h"
 #include "System/SpringMath.h"
 
+#include <bit>
+
 CModInfo modInfo;
 
 void CModInfo::ResetState()
@@ -327,5 +329,8 @@ void CModInfo::Init(const std::string& modFileName)
 		if ((airMipLevel < 0) || (airMipLevel > 30))
 			throw content_error("Sensors\\Los\\AirLosMipLevel out of bounds. The minimum value is 0. The maximum value is 30.");
 	}
+
+	if (!std::has_single_bit <unsigned> (quadFieldQuadSizeInElmos))
+		throw content_error("quadFieldQuadSizeInElmos modrule has to be a power of 2");
 }
 


### PR DESCRIPTION
There's this assertion, but that doesn't trigger in release builds.
https://github.com/beyond-all-reason/spring/blob/0094744afa0838a0724386cb6426b6cf05a086a9/rts/Sim/Misc/QuadField.cpp#L123-L124

Besides, best to check the value right where it is read.