### PR TITLE
Spring damper math utils

### DIFF
--- a/rts/System/CMakeLists.txt
+++ b/rts/System/CMakeLists.txt
@@ -31,6 +31,7 @@ make_global_var(sources_engine_System_common
 		"${CMAKE_CURRENT_SOURCE_DIR}/LoadSave/LuaLoadSaveHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LogOutput.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Main.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Math/SpringDampers.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Matrix44f.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/RectangleOverlapHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/SpringTime.cpp"

--- a/rts/System/Math/SpringDampers.cpp
+++ b/rts/System/Math/SpringDampers.cpp
@@ -1,0 +1,107 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html
+
+	Spring Damper Functions are MIT Licensed Copyright 2021 Daniel Holden
+	https://github.com/orangeduck/Spring-It-On
+	https://theorangeduck.com/page/spring-roll-call
+*/
+
+#include "SpringDampers.h"
+#include <numbers>
+
+float halflife_to_damping(float halflife, float eps)
+{
+	static constexpr float ln2x4 = 4.0f * std::numbers::ln2_v<float>;
+	return ln2x4 / (halflife + eps);
+}
+
+float fast_negexp(float x)
+{
+	return 1.0f / (1.0f + x + 0.48f*x*x + 0.235f*x*x*x);
+}
+
+float spring_damper_damping(float halflife)
+{
+	return halflife_to_damping(halflife) / 2.0f;
+}
+
+float spring_damper_eydt(float y, float dt)
+{
+	return fast_negexp(y*dt);
+}
+
+void simple_spring_damper_exact(
+	float& x,
+	float& v,
+	float x_goal,
+	float damping,
+	float eydt,
+	float dt)
+{
+	float j0 = x - x_goal;
+	float j1 = v + j0*damping;
+
+	x = eydt*(j0 + j1*dt) + x_goal;
+	v = eydt*(v - j1*damping*dt);
+}
+
+void simple_spring_damper_exact_vector_part(
+	float& cur,
+	float& v,
+	float goal,
+	float damping,
+	float eydt,
+	float dt)
+{
+	float xj0 = cur - goal;
+	float xj1 = v + xj0*damping;
+
+	cur = eydt*(xj0 + xj1*dt) + goal;
+	v = eydt*(v - xj1*damping*dt);
+}
+
+void simple_spring_damper_exact_vector(
+	float3& cur,
+	float3& v,
+	float3 goal,
+	float damping,
+	float eydt,
+	float dt)
+{
+	simple_spring_damper_exact_vector_part(cur.x, v.x, goal.x, damping, eydt, dt);
+	simple_spring_damper_exact_vector_part(cur.y, v.y, goal.y, damping, eydt, dt);
+	simple_spring_damper_exact_vector_part(cur.z, v.z, goal.z, damping, eydt, dt);
+}
+
+void timed_spring_damper_exact_vector(
+	float3& x,
+	float3& v,
+	float3& xi,
+	float3 goal,
+	float t_goal,
+	float halflife,
+	float damping,
+	float eydt,
+	float dt,
+	float apprehension)
+{
+	float min_time = std::max(t_goal, dt);
+	float t_goal_future = dt + apprehension * halflife;
+
+	float xv_goal = (goal.x - xi.x) / min_time;
+	float x_goal_future = t_goal_future < t_goal ?
+			xi.x + xv_goal * t_goal_future : goal.x;
+	simple_spring_damper_exact(x.x, v.x, x_goal_future, damping, eydt, dt);
+	xi.x += xv_goal * dt;
+
+	float yv_goal = (goal.y - xi.y) / min_time;
+	float y_goal_future = t_goal_future < t_goal ?
+			xi.y + yv_goal * t_goal_future : goal.y;
+	simple_spring_damper_exact(x.y, v.y, y_goal_future, damping, eydt, dt);
+	xi.y += yv_goal * dt;
+
+	float zv_goal = (goal.z - xi.z) / min_time;
+	float z_goal_future = t_goal_future < t_goal ?
+			xi.z + zv_goal * t_goal_future : goal.z;
+	simple_spring_damper_exact(x.z, v.z, z_goal_future, damping, eydt, dt);
+	xi.z += zv_goal * dt;
+}

--- a/rts/System/Math/SpringDampers.h
+++ b/rts/System/Math/SpringDampers.h
@@ -1,0 +1,49 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include "System/float3.h"
+
+float halflife_to_damping(float halflife, float eps = 1e-5f);
+
+float fast_negexp(float x);
+
+float spring_damper_damping(float halflife);
+
+float spring_damper_eydt(float y, float dt);
+
+void simple_spring_damper_exact(
+	float& x,
+	float& v,
+	float x_goal,
+	float damping,
+	float eydt,
+	float dt);
+
+void simple_spring_damper_exact_vector_part(
+	float& cur,
+	float& v,
+	float goal,
+	float damping,
+	float eydt,
+	float dt);
+
+void simple_spring_damper_exact_vector(
+	float3& cur,
+	float3& v,
+	float3 goal,
+	float damping,
+	float eydt,
+	float dt);
+
+void timed_spring_damper_exact_vector(
+	float3& x,
+	float3& v,
+	float3& xi,
+	float3 goal,
+	float t_goal,
+	float halflife,
+	float damping,
+	float eydt,
+	float dt,
+	float apprehension = 2.0f);

--- a/rts/System/Math/expDecay.h
+++ b/rts/System/Math/expDecay.h
@@ -1,0 +1,17 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include "System/float3.h"
+
+inline float expDecay(float a, float b, float decay, float dt)
+{
+	return b+(a-b)*math::exp(-decay*dt);
+}
+
+inline void expDecay(float3& a, float3 b, float decay, float dt)
+{
+	a.x = expDecay(a.x, b.x, decay, dt);
+	a.y = expDecay(a.y, b.y, decay, dt);
+	a.z = expDecay(a.z, b.z, decay, dt);
+}


### PR DESCRIPTION
@loveridge I've extracted some of your spring damper utils into a separate PR, since math seems uncontroversial. If you OK it can be merged right away. I've moved things around though (`expDecay` is extracted into its own file away from `CameraHandler.cpp`, and things live in `rts/System/Math/` instead of directly in `rts/System/`) so your full PR will need to be adjusted a bit.