### PR TITLE
Implement 54d8a38 even properlier

### DIFF
--- a/rts/Rendering/SmoothHeightMeshDrawer.cpp
+++ b/rts/Rendering/SmoothHeightMeshDrawer.cpp
@@ -41,7 +41,7 @@ SmoothHeightMeshDrawer::~SmoothHeightMeshDrawer() {
 
 void SmoothHeightMeshDrawer::DrawInMiniMap()
 {
-	if (!(drawEnabled && gs->cheatEnabled))
+	if (!drawEnabled)
 		return;
 
 	glMatrixMode(GL_PROJECTION);
@@ -80,7 +80,7 @@ void SmoothHeightMeshDrawer::DrawInMiniMap()
 }
 
 void SmoothHeightMeshDrawer::Draw(float yoffset) {
-	if (!(drawEnabled && gs->cheatEnabled))
+	if (!drawEnabled)
 		return;
 
 	glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);


### PR DESCRIPTION
Let people keep the debug airmesh view if they disable cheats after enabling `/airmesh`, since now they are forced to keep cheats enabled for the whole game even if they only wanted it for that one command.