### PR TITLE
backport __pairs metamethod to our tweaked version of Lua

### DIFF
--- a/rts/lib/lua/src/lbaselib.cpp
+++ b/rts/lib/lua/src/lbaselib.cpp
@@ -235,6 +235,13 @@ static int luaB_next (lua_State *L) {
 }
 
 
+/*** 
+ * Meta <code>__pairs</code> backported from Lua 5.2,
+ * originally <code>lua_pushvalue(L, lua_upvalueindex(1)); </code> was <code>lua_pushcfunction(L, luaB_next);</code>
+ * <br>
+ * but that requires "light C function" support,
+ * which makes lua_pushcfunction not allocate extra memory for the GC to clean up.
+ */
 static int luaB_pairs (lua_State *L) {
   luaL_checkany(L, 1);
   if (luaL_getmetafield(L, 1, "__pairs") == LUA_TNIL) {  /* no metamethod? */

--- a/rts/lib/lua/src/lbaselib.cpp
+++ b/rts/lib/lua/src/lbaselib.cpp
@@ -236,10 +236,15 @@ static int luaB_next (lua_State *L) {
 
 
 static int luaB_pairs (lua_State *L) {
-  luaL_checktype(L, 1, LUA_TTABLE);
-  lua_pushvalue(L, lua_upvalueindex(1));  /* return generator, */
-  lua_pushvalue(L, 1);  /* state, */
-  lua_pushnil(L);  /* and initial value */
+  luaL_checkany(L, 1);
+  if (luaL_getmetafield(L, 1, "__pairs") == LUA_TNIL) {  /* no metamethod? */
+    lua_pushcfunction(L, luaB_next);  /* return generator, */
+    lua_pushvalue(L, 1);  /* state, */
+    lua_pushnil(L);  /* and initial value */
+  } else {
+    lua_pushvalue(L, 1);  /* argument 'self' to metamethod */
+    lua_call(L, 1, 3);  /* get 3 values from metamethod */
+  }
   return 3;
 }
 
@@ -645,7 +650,8 @@ static void base_open (lua_State *L) {
   lua_setglobal(L, "_VERSION");  /* set global _VERSION */
   /* `ipairs' and `pairs' need auxiliary functions as upvalues */
   auxopen(L, "ipairs", luaB_ipairs, ipairsaux);
-  auxopen(L, "pairs", luaB_pairs, luaB_next);
+  lua_pushcfunction(L, luaB_pairs);
+  lua_setfield(L, -2, "pairs");
   /* `newproxy' needs a weaktable as upvalue */
   lua_createtable(L, 0, 1);  /* new table `w' */
   lua_pushvalue(L, -1);  /* `w' will be its own metatable */

--- a/rts/lib/lua/src/lbaselib.cpp
+++ b/rts/lib/lua/src/lbaselib.cpp
@@ -238,7 +238,7 @@ static int luaB_next (lua_State *L) {
 static int luaB_pairs (lua_State *L) {
   luaL_checkany(L, 1);
   if (luaL_getmetafield(L, 1, "__pairs") == LUA_TNIL) {  /* no metamethod? */
-    lua_pushcfunction(L, luaB_next);  /* return generator, */
+    lua_pushvalue(L, lua_upvalueindex(1));  /* return generator, */
     lua_pushvalue(L, 1);  /* state, */
     lua_pushnil(L);  /* and initial value */
   } else {
@@ -650,8 +650,7 @@ static void base_open (lua_State *L) {
   lua_setglobal(L, "_VERSION");  /* set global _VERSION */
   /* `ipairs' and `pairs' need auxiliary functions as upvalues */
   auxopen(L, "ipairs", luaB_ipairs, ipairsaux);
-  lua_pushcfunction(L, luaB_pairs);
-  lua_setfield(L, -2, "pairs");
+  auxopen(L, "pairs", luaB_pairs, luaB_next);
   /* `newproxy' needs a weaktable as upvalue */
   lua_createtable(L, 0, 1);  /* new table `w' */
   lua_pushvalue(L, -1);  /* `w' will be its own metatable */


### PR DESCRIPTION
I copied what I could from the changes to Lua 5.2 to backport making __pairs work as a metamethod.

This greatly improves compatibility with sollua as it assumes that __pairs actually exists and tries to use it
Also makes some of the Lua integrations for RmlUI better to use.