### PR TITLE
Implement animated flipbook style textures for weapon projectiles.

### DIFF
--- a/rts/Sim/Projectiles/ExpGenSpawnable.cpp
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.cpp
@@ -228,7 +228,7 @@ void CExpGenSpawnable::AddEffectsQuad(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr
 void CExpGenSpawnable::AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl, const float3& ap, const float& p)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	float minS = std::numeric_limits<float>::max(); float minT = std::numeric_limits<float>::max();
+	float minS = std::numeric_limits<float>::max()   ; float minT = std::numeric_limits<float>::max()   ;
 	float maxS = std::numeric_limits<float>::lowest(); float maxT = std::numeric_limits<float>::lowest();
 	std::invoke([&](auto&&... arg) {
 		((minS = std::min(minS, arg.s)), ...);
@@ -255,14 +255,14 @@ void CExpGenSpawnable::AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC
 void CExpGenSpawnable::AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	float minS = std::numeric_limits<float>::max(); float minT = std::numeric_limits<float>::max();
+	float minS = std::numeric_limits<float>::max()   ; float minT = std::numeric_limits<float>::max()   ;
 	float maxS = std::numeric_limits<float>::lowest(); float maxT = std::numeric_limits<float>::lowest();
 	std::invoke([&](auto&&... arg) {
 		((minS = std::min(minS, arg.s)), ...);
 		((minT = std::min(minT, arg.t)), ...);
 		((maxS = std::max(maxS, arg.s)), ...);
 		((maxT = std::max(maxT, arg.t)), ...);
-		}, tl, tr, br, bl);
+	}, tl, tr, br, bl);
 
 	auto& rb = GetPrimaryRenderBuffer();
 

--- a/rts/Sim/Projectiles/ExpGenSpawnable.cpp
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.cpp
@@ -84,25 +84,30 @@ void CExpGenSpawnable::UpdateRotation()
 
 void CExpGenSpawnable::UpdateAnimParams()
 {
+	UpdateAnimParamsImpl(animParams, animProgress);
+}
+
+void CExpGenSpawnable::UpdateAnimParamsImpl(const float3& ap, float& p)
+{
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (static_cast<int>(animParams.x) <= 1 && static_cast<int>(animParams.y) <= 1) {
-		animProgress = 0.0f;
+	if (static_cast<int>(ap.x) <= 1 && static_cast<int>(ap.y) <= 1) {
+		p = 0.0f;
 		return;
 	}
 
 	const float t = (gs->frameNum - createFrame + globalRendering->timeOffset);
-	const float animSpeed = math::fabs(animParams.z);
-	if (animParams.z < 0.0f) {
+	const float animSpeed = math::fabs(ap.z);
+	if (ap.z < 0.0f) {
 		#if 0
-			animProgress = math::fmod(t, 2.0f * animSpeed) / animSpeed;
-			if (animProgress > 1.0)
-				animProgress = 2.0f - animProgress;
+			p = math::fmod(t, 2.0f * animSpeed) / animSpeed;
+			if (p > 1.0)
+				p = 2.0f - p;
 		#else
-			animProgress = 1.0f - math::fabs(math::fmod(t, 2.0f * animSpeed) / animSpeed - 1.0f);
+			p = 1.0f - math::fabs(math::fmod(t, 2.0f * animSpeed) / animSpeed - 1.0f);
 		#endif
 	}
 	else {
-		animProgress = math::fmod(t, animSpeed) / animSpeed;
+		p = math::fmod(t, animSpeed) / animSpeed;
 	}
 }
 
@@ -217,8 +222,13 @@ CExpGenSpawnable* CExpGenSpawnable::CreateSpawnable(int spawnableID)
 
 void CExpGenSpawnable::AddEffectsQuad(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const
 {
+	AddEffectsQuadImpl(tl, tr, br, bl, animParams, animProgress);
+}
+
+void CExpGenSpawnable::AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl, const float3& ap, const float& p)
+{
 	RECOIL_DETAILED_TRACY_ZONE;
-	float minS = std::numeric_limits<float>::max()   ; float minT = std::numeric_limits<float>::max()   ;
+	float minS = std::numeric_limits<float>::max(); float minT = std::numeric_limits<float>::max();
 	float maxS = std::numeric_limits<float>::lowest(); float maxT = std::numeric_limits<float>::lowest();
 	std::invoke([&](auto&&... arg) {
 		((minS = std::min(minS, arg.s)), ...);
@@ -230,7 +240,34 @@ void CExpGenSpawnable::AddEffectsQuad(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr
 	auto& rb = GetPrimaryRenderBuffer();
 
 	const auto uvInfo = float4{ minS, minT, maxS - minS, maxT - minT };
-	const auto animInfo = float3{ animParams.x, animParams.y, animProgress };
+	const auto animInfo = float3{ ap.x, ap.y, p };
+	constexpr float layer = 0.0f; //for future texture arrays
+
+	//pos, uvw, uvmm, col
+	rb.AddQuadTriangles(
+		{ tl.pos, float3{ tl.s, tl.t, layer }, uvInfo, animInfo, tl.c },
+		{ tr.pos, float3{ tr.s, tr.t, layer }, uvInfo, animInfo, tr.c },
+		{ br.pos, float3{ br.s, br.t, layer }, uvInfo, animInfo, br.c },
+		{ bl.pos, float3{ bl.s, bl.t, layer }, uvInfo, animInfo, bl.c }
+	);
+}
+
+void CExpGenSpawnable::AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	float minS = std::numeric_limits<float>::max(); float minT = std::numeric_limits<float>::max();
+	float maxS = std::numeric_limits<float>::lowest(); float maxT = std::numeric_limits<float>::lowest();
+	std::invoke([&](auto&&... arg) {
+		((minS = std::min(minS, arg.s)), ...);
+		((minT = std::min(minT, arg.t)), ...);
+		((maxS = std::max(maxS, arg.s)), ...);
+		((maxT = std::max(maxT, arg.t)), ...);
+		}, tl, tr, br, bl);
+
+	auto& rb = GetPrimaryRenderBuffer();
+
+	const auto uvInfo = float4{ minS, minT, maxS - minS, maxT - minT };
+	static constexpr auto animInfo = float3{ 1.0f, 1.0f , 0.0f };
 	constexpr float layer = 0.0f; //for future texture arrays
 
 	//pos, uvw, uvmm, col

--- a/rts/Sim/Projectiles/ExpGenSpawnable.h
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.h
@@ -42,7 +42,12 @@ protected:
 	void UpdateRotation();
 	void UpdateAnimParams();
 
+	void UpdateAnimParamsImpl(const float3& ap, float& p);
+
 	void AddEffectsQuad(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const;
+
+	static void AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl, const float3& ap, const float& p);
+	static void AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl);
 
 	static bool GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo);
 

--- a/rts/Sim/Projectiles/WeaponProjectiles/BeamLaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/BeamLaserProjectile.cpp
@@ -102,6 +102,8 @@ void CBeamLaserProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
+	UpdateWeaponAnimParams();
+
 	const float3 midPos = (targetPos + startPos) * 0.5f;
 	const float3 cameraDir = (midPos - camera->GetPos()).SafeANormalize();
 
@@ -121,19 +123,19 @@ void CBeamLaserProjectile::Draw()
 	const float3& pos1 = startPos;
 	const float3& pos2 = targetPos;
 
-	#define WT1 weaponDef->visuals.texture1
-	#define WT2 weaponDef->visuals.texture2
-	#define WT3 weaponDef->visuals.texture3
+	const auto* WT1 = weaponDef->visuals.texture1;
+	const auto* WT2 = weaponDef->visuals.texture2;
+	const auto* WT3 = weaponDef->visuals.texture3;
 
 	if (playerCamDistSq < Square(1000.0f)) {
 		if (validTextures[2]) {
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<2>(
 				{ pos1 - xdir * beamEdgeSize,                       midtexx  , WT2->ystart, edgeColStart },
 				{ pos1 - xdir * beamEdgeSize - ydir * beamEdgeSize, WT2->xend, WT2->ystart, edgeColStart },
 				{ pos1 + xdir * beamEdgeSize - ydir * beamEdgeSize, WT2->xend, WT2->yend  , edgeColStart },
 				{ pos1 + xdir * beamEdgeSize,                       midtexx  , WT2->yend  , edgeColStart }
 			);
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<2>(
 				{ pos1 - xdir * beamCoreSize,                       midtexx  , WT2->ystart, coreColStart },
 				{ pos1 - xdir * beamCoreSize - ydir * beamCoreSize, WT2->xend, WT2->ystart, coreColStart },
 				{ pos1 + xdir * beamCoreSize - ydir * beamCoreSize, WT2->xend, WT2->yend  , coreColStart },
@@ -142,14 +144,14 @@ void CBeamLaserProjectile::Draw()
 
 		}
 		if (validTextures[1]) {
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - xdir * beamEdgeSize,                       WT1->xstart, WT1->ystart, edgeColStart },
 				{ pos2 - xdir * beamEdgeSize,                       WT1->xend  , WT1->ystart, edgeColEnd   },
 				{ pos2 + xdir * beamEdgeSize,                       WT1->xend  , WT1->yend  , edgeColEnd   },
 				{ pos1 + xdir * beamEdgeSize,                       WT1->xstart, WT1->yend  , edgeColStart }
 			);
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - xdir * beamCoreSize,                       WT1->xstart, WT1->ystart, coreColStart },
 				{ pos2 - xdir * beamCoreSize,                       WT1->xend  , WT1->ystart, coreColEnd   },
 				{ pos2 + xdir * beamCoreSize,                       WT1->xend  , WT1->yend  , coreColEnd   },
@@ -157,14 +159,14 @@ void CBeamLaserProjectile::Draw()
 			);
 		}
 		if (validTextures[2]) {
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<2>(
 				{ pos2 - xdir * beamEdgeSize,                       midtexx  , WT2->ystart, edgeColStart },
 				{ pos2 - xdir * beamEdgeSize + ydir * beamEdgeSize, WT2->xend, WT2->ystart, edgeColStart },
 				{ pos2 + xdir * beamEdgeSize + ydir * beamEdgeSize, WT2->xend, WT2->yend  , edgeColStart },
 				{ pos2 + xdir * beamEdgeSize,                       midtexx  , WT2->yend  , edgeColStart }
 			);
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<2>(
 				{ pos2 - xdir * beamCoreSize,                       midtexx  , WT2->ystart, coreColStart },
 				{ pos2 - xdir * beamCoreSize + ydir * beamCoreSize, WT2->xend, WT2->ystart, coreColStart },
 				{ pos2 + xdir * beamCoreSize + ydir * beamCoreSize, WT2->xend, WT2->yend  , coreColStart },
@@ -173,14 +175,14 @@ void CBeamLaserProjectile::Draw()
 		}
 	} else {
 		if (validTextures[1]) {
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - xdir * beamEdgeSize,                       WT1->xstart, WT1->ystart, edgeColStart },
 				{ pos2 - xdir * beamEdgeSize,                       WT1->xend  , WT1->ystart, edgeColEnd   },
 				{ pos2 + xdir * beamEdgeSize,                       WT1->xend  , WT1->yend  , edgeColEnd   },
 				{ pos1 + xdir * beamEdgeSize,                       WT1->xstart, WT1->yend  , edgeColStart }
 			);
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - xdir * beamCoreSize,                       WT1->xstart, WT1->ystart, coreColStart },
 				{ pos2 - xdir * beamCoreSize,                       WT1->xend  , WT1->ystart, coreColEnd   },
 				{ pos2 + xdir * beamCoreSize,                       WT1->xend  , WT1->yend  , coreColEnd   },
@@ -191,24 +193,20 @@ void CBeamLaserProjectile::Draw()
 
 	// draw flare
 	if (validTextures[3]) {
-		AddEffectsQuad(
+		AddWeaponEffectsQuad<3>(
 			{ pos1 - camera->GetRight() * flareEdgeSize - camera->GetUp() * flareEdgeSize, WT3->xstart, WT3->ystart, edgeColStart },
 			{ pos1 + camera->GetRight() * flareEdgeSize - camera->GetUp() * flareEdgeSize, WT3->xend,   WT3->ystart, edgeColStart },
 			{ pos1 + camera->GetRight() * flareEdgeSize + camera->GetUp() * flareEdgeSize, WT3->xend,   WT3->yend,   edgeColStart },
 			{ pos1 - camera->GetRight() * flareEdgeSize + camera->GetUp() * flareEdgeSize, WT3->xstart, WT3->yend,   edgeColStart }
 		);
 
-		AddEffectsQuad(
+		AddWeaponEffectsQuad<3>(
 			{ pos1 - camera->GetRight() * flareCoreSize - camera->GetUp() * flareCoreSize, WT3->xstart, WT3->ystart, coreColStart },
 			{ pos1 + camera->GetRight() * flareCoreSize - camera->GetUp() * flareCoreSize, WT3->xend,   WT3->ystart, coreColStart },
 			{ pos1 + camera->GetRight() * flareCoreSize + camera->GetUp() * flareCoreSize, WT3->xend,   WT3->yend,   coreColStart },
 			{ pos1 - camera->GetRight() * flareCoreSize + camera->GetUp() * flareCoreSize, WT3->xstart, WT3->yend,   coreColStart }
 		);
 	}
-
-	#undef WT3
-	#undef WT2
-	#undef WT1
 }
 
 void CBeamLaserProjectile::DrawOnMinimap() const

--- a/rts/Sim/Projectiles/WeaponProjectiles/EmgProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/EmgProjectile.cpp
@@ -70,6 +70,8 @@ void CEmgProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
+	UpdateWeaponAnimParams();
+
 	const uint8_t col[4] {
 		(uint8_t)(color.x * intensity * 255),
 		(uint8_t)(color.y * intensity * 255),
@@ -77,11 +79,13 @@ void CEmgProjectile::Draw()
 		(uint8_t)(          intensity * 255)
 	};
 
-	AddEffectsQuad(
-		{ drawPos - camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, weaponDef->visuals.texture1->xstart, weaponDef->visuals.texture1->ystart, col },
-		{ drawPos + camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, weaponDef->visuals.texture1->xend,   weaponDef->visuals.texture1->ystart, col },
-		{ drawPos + camera->GetRight() * drawRadius + camera->GetUp() * drawRadius, weaponDef->visuals.texture1->xend,   weaponDef->visuals.texture1->yend,   col },
-		{ drawPos - camera->GetRight() * drawRadius + camera->GetUp() * drawRadius, weaponDef->visuals.texture1->xstart, weaponDef->visuals.texture1->yend,   col }
+	const auto* tex = weaponDef->visuals.texture1;
+
+	AddWeaponEffectsQuad<1>(
+		{ drawPos - camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, tex->xstart, tex->ystart, col },
+		{ drawPos + camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, tex->xend,   tex->ystart, col },
+		{ drawPos + camera->GetRight() * drawRadius + camera->GetUp() * drawRadius, tex->xend,   tex->yend,   col },
+		{ drawPos - camera->GetRight() * drawRadius + camera->GetUp() * drawRadius, tex->xstart, tex->yend,   col }
 	);
 }
 

--- a/rts/Sim/Projectiles/WeaponProjectiles/ExplosiveProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/ExplosiveProjectile.cpp
@@ -79,10 +79,12 @@ void CExplosiveProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
+	UpdateWeaponAnimParams();
+
 	uint8_t col[4] = {0};
 
 	const WeaponDef::Visuals& wdVisuals = weaponDef->visuals;
-	const AtlasedTexture* tex = wdVisuals.texture1;
+	const auto* tex = wdVisuals.texture1;
 
 	if (wdVisuals.colorMap != nullptr) {
 		wdVisuals.colorMap->GetColor(col, curTime);
@@ -116,7 +118,7 @@ void CExplosiveProjectile::Draw()
 		col[2] = stageDecay * col[2];
 		col[3] = stageDecay * col[3];
 
-		AddEffectsQuad(
+		AddWeaponEffectsQuad<1>(
 			{ stagePos - xdirCam - ydirCam, tex->xstart, tex->ystart, col },
 			{ stagePos + xdirCam - ydirCam, tex->xend,   tex->ystart, col },
 			{ stagePos + xdirCam + ydirCam, tex->xend,   tex->yend,   col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/FireBallProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FireBallProjectile.cpp
@@ -54,6 +54,8 @@ void CFireBallProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
+	UpdateWeaponAnimParams();
+
 	unsigned char col[4] = {255, 150, 100, 1};
 
 	const float3 interPos = mix(pos, drawPos, checkCol);
@@ -68,14 +70,13 @@ void CFireBallProjectile::Draw()
 		col[1] = (numSparks - i) *  6;
 		col[2] = (numSparks - i) *  4;
 
-		#define ept projectileDrawer->explotex
-		AddEffectsQuad(
+		const auto* ept = projectileDrawer->explotex;
+		AddWeaponEffectsQuad<1>(
 			{ sparks[i].pos - camera->GetRight() * sparks[i].size - camera->GetUp() * sparks[i].size, ept->xstart, ept->ystart, col },
 			{ sparks[i].pos + camera->GetRight() * sparks[i].size - camera->GetUp() * sparks[i].size, ept->xend  , ept->ystart, col },
 			{ sparks[i].pos + camera->GetRight() * sparks[i].size + camera->GetUp() * sparks[i].size, ept->xend  , ept->yend  , col },
 			{ sparks[i].pos - camera->GetRight() * sparks[i].size + camera->GetUp() * sparks[i].size, ept->xstart, ept->yend  , col }
 		);
-		#undef ept
 	}
 
 	if (validTextures[2])
@@ -83,14 +84,13 @@ void CFireBallProjectile::Draw()
 		col[0] = (maxCol - i) * 25;
 		col[1] = (maxCol - i) * 15;
 		col[2] = (maxCol - i) * 10;
-		#define dgt projectileDrawer->dguntex
-		AddEffectsQuad(
+		const auto* dgt = projectileDrawer->dguntex;
+		AddWeaponEffectsQuad<2>(
 			{ interPos - (speed * 0.5f * i) - camera->GetRight() * size - camera->GetUp() * size, dgt->xstart, dgt->ystart, col },
 			{ interPos - (speed * 0.5f * i) + camera->GetRight() * size - camera->GetUp() * size, dgt->xend ,  dgt->ystart, col },
 			{ interPos - (speed * 0.5f * i) + camera->GetRight() * size + camera->GetUp() * size, dgt->xend ,  dgt->yend  , col },
 			{ interPos - (speed * 0.5f * i) - camera->GetRight() * size + camera->GetUp() * size, dgt->xstart, dgt->yend  , col }
 		);
-		#undef dgt
 	}
 }
 

--- a/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
@@ -80,10 +80,12 @@ void CFlameProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
+	UpdateWeaponAnimParams();
+
 	unsigned char col[4];
 	weaponDef->visuals.colorMap->GetColor(col, curTime);
 
-	AddEffectsQuad(
+	AddWeaponEffectsQuad<1>(
 		{ drawPos - camera->GetRight() * radius - camera->GetUp() * radius, weaponDef->visuals.texture1->xstart, weaponDef->visuals.texture1->ystart, col },
 		{ drawPos + camera->GetRight() * radius - camera->GetUp() * radius, weaponDef->visuals.texture1->xend,   weaponDef->visuals.texture1->ystart, col },
 		{ drawPos + camera->GetRight() * radius + camera->GetUp() * radius, weaponDef->visuals.texture1->xend,   weaponDef->visuals.texture1->yend,   col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/LargeBeamLaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LargeBeamLaserProjectile.cpp
@@ -25,9 +25,7 @@ CR_REG_METADATA(CLargeBeamLaserProjectile,(
 	CR_MEMBER(tilelength),
 	CR_MEMBER(scrollspeed),
 	CR_MEMBER(pulseSpeed),
-	CR_MEMBER(decay),
-	CR_MEMBER(beamtex),
-	CR_MEMBER(sidetex)
+	CR_MEMBER(decay)
 ))
 
 
@@ -52,9 +50,6 @@ CLargeBeamLaserProjectile::CLargeBeamLaserProjectile(const ProjectileParams& par
 		scrollspeed   = weaponDef->visuals.scrollspeed;
 		pulseSpeed    = weaponDef->visuals.pulseSpeed;
 		decay         = weaponDef->visuals.beamdecay;
-
-		beamtex       = *weaponDef->visuals.texture1;
-		sidetex       = *weaponDef->visuals.texture3;
 
 		coreColStart[0] = (weaponDef->visuals.color2.x * 255);
 		coreColStart[1] = (weaponDef->visuals.color2.y * 255);
@@ -96,6 +91,8 @@ void CLargeBeamLaserProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
+	UpdateWeaponAnimParams();
+
 	const float3 midPos = (targetPos + startPos) * 0.5f;
 	const float3 cameraDir = (midPos - camera->GetPos()).SafeANormalize();
 	// beam's coor-system; degenerate if targetPos == startPos
@@ -107,7 +104,7 @@ void CLargeBeamLaserProjectile::Draw()
 	float3 pos2 = targetPos;
 
 	const float startTex = 1.0f - ((gu->modGameTime * scrollspeed) - int(gu->modGameTime * scrollspeed));
-	const float texSizeX = beamtex.xend - beamtex.xstart;
+	const float texSizeX = weaponDef->visuals.texture1->xend - weaponDef->visuals.texture1->xstart;
 
 	const float beamEdgeSize = thickness;
 	const float beamCoreSize = beamEdgeSize * corethickness;
@@ -120,25 +117,27 @@ void CLargeBeamLaserProjectile::Draw()
 	// note: beamTileMaxDst can be negative, in which case we want numBeamTiles to equal zero
 	const float numBeamTiles = std::floor(((std::max(beamTileMinDst, beamTileMaxDst) - beamTileMinDst) / tilelength) + 0.5f);
 
-	#define WT2 weaponDef->visuals.texture2
-	#define WT4 weaponDef->visuals.texture4
+	const auto* WT1 = weaponDef->visuals.texture1;
+	const auto* WT2 = weaponDef->visuals.texture2;
+	const auto* WT3 = weaponDef->visuals.texture3;
+	const auto* WT4 = weaponDef->visuals.texture4;
 
 	if (validTextures[1]) {
-		AtlasedTexture tex = beamtex;
+		auto tex = *WT1;
 
 		if (beamTileMinDst > beamLength) {
 			// beam short enough to be drawn by one polygon
 			// draw laser start
-			tex.xstart = beamtex.xstart + startTex * texSizeX;
+			tex.xstart = WT1->xstart + startTex * texSizeX;
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 				{ pos2 - (xdir * beamEdgeSize), tex.xend  , tex.ystart, edgeColStart },
 				{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
 				{ pos1 + (xdir * beamEdgeSize), tex.xstart, tex.yend  , edgeColStart }
 			);
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 				{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 				{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -149,16 +148,16 @@ void CLargeBeamLaserProjectile::Draw()
 			pos2 = pos1 + zdir * beamTileMinDst;
 
 			// draw laser start
-			tex.xstart = beamtex.xstart + startTex * texSizeX;
+			tex.xstart = WT1->xstart + startTex * texSizeX;
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 				{ pos2 - (xdir * beamEdgeSize), tex.xend  , tex.ystart, edgeColStart },
 				{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
 				{ pos1 + (xdir * beamEdgeSize), tex.xstart, tex.yend  , edgeColStart }
 			);
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 				{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 				{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -166,20 +165,20 @@ void CLargeBeamLaserProjectile::Draw()
 			);
 
 			// draw continous beam
-			tex.xstart = beamtex.xstart;
+			tex.xstart = WT1->xstart;
 
 			for (float i = beamTileMinDst; i < beamTileMaxDst; i += tilelength) {
 				pos1 = startPos + zdir * i;
 				pos2 = startPos + zdir * (i + tilelength);
 
-				AddEffectsQuad(
+				AddWeaponEffectsQuad<1>(
 					{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 					{ pos2 - (xdir * beamEdgeSize), tex.xend  , tex.ystart, edgeColStart },
 					{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
 					{ pos1 + (xdir * beamEdgeSize), tex.xstart, tex.yend  , edgeColStart }
 				);
 
-				AddEffectsQuad(
+				AddWeaponEffectsQuad<1>(
 					{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 					{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 					{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -192,14 +191,14 @@ void CLargeBeamLaserProjectile::Draw()
 			pos2 = targetPos;
 			tex.xend = tex.xstart + (pos1.distance(pos2) / tilelength) * texSizeX;
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 				{ pos2 - (xdir * beamEdgeSize), tex.xend,   tex.ystart, edgeColStart },
 				{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
 				{ pos1 + (xdir * beamEdgeSize), tex.xstart, tex.yend  , edgeColStart }
 			);
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 				{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 				{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -209,14 +208,14 @@ void CLargeBeamLaserProjectile::Draw()
 	}
 
 	if (validTextures[2]) {
-		AddEffectsQuad(
+		AddWeaponEffectsQuad<2>(
 			{ pos2 - (xdir * beamEdgeSize),                         WT2->xstart, WT2->ystart, edgeColStart },
 			{ pos2 - (xdir * beamEdgeSize) + (ydir * beamEdgeSize), WT2->xend,   WT2->ystart, edgeColStart },
 			{ pos2 + (xdir * beamEdgeSize) + (ydir * beamEdgeSize), WT2->xend,   WT2->yend,   edgeColStart },
 			{ pos2 + (xdir * beamEdgeSize),                         WT2->xstart, WT2->yend,   edgeColStart }
 		);
 
-		AddEffectsQuad(
+		AddWeaponEffectsQuad<2>(
 			{ pos2 - (xdir * beamCoreSize),                         WT2->xstart, WT2->ystart, coreColStart },
 			{ pos2 - (xdir * beamCoreSize) + (ydir * beamCoreSize), WT2->xend,   WT2->ystart, coreColStart },
 			{ pos2 + (xdir * beamCoreSize) + (ydir * beamCoreSize), WT2->xend,   WT2->yend,   coreColStart },
@@ -240,18 +239,18 @@ void CLargeBeamLaserProjectile::Draw()
 		// draw muzzleflare
 		pos1 = startPos - zdir * (thickness * flaresize) * 0.02f;
 
-		AddEffectsQuad(
-			{ pos1 + (ydir * muzzleEdgeSize),                           sidetex.xstart, sidetex.ystart, edgeColor },
-			{ pos1 + (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), sidetex.xend,   sidetex.ystart, edgeColor },
-			{ pos1 - (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), sidetex.xend,   sidetex.yend,   edgeColor },
-			{ pos1 - (ydir * muzzleEdgeSize),                           sidetex.xstart, sidetex.yend,   edgeColor }
+		AddWeaponEffectsQuad<3>(
+			{ pos1 + (ydir * muzzleEdgeSize),                           WT3->xstart, WT3->ystart, edgeColor },
+			{ pos1 + (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->ystart, edgeColor },
+			{ pos1 - (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->yend,   edgeColor },
+			{ pos1 - (ydir * muzzleEdgeSize),                           WT3->xstart, WT3->yend,   edgeColor }
 		);
 
-		AddEffectsQuad(
-			{ pos1 + (ydir * muzzleCoreSize),                           sidetex.xstart, sidetex.ystart, coreColor },
-			{ pos1 + (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), sidetex.xend,   sidetex.ystart, coreColor },
-			{ pos1 - (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), sidetex.xend,   sidetex.yend,   coreColor },
-			{ pos1 - (ydir * muzzleCoreSize),                           sidetex.xstart, sidetex.yend,   coreColor }
+		AddWeaponEffectsQuad<3>(
+			{ pos1 + (ydir * muzzleCoreSize),                           WT3->xstart, WT3->ystart, coreColor },
+			{ pos1 + (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->ystart, coreColor },
+			{ pos1 - (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->yend,   coreColor },
+			{ pos1 - (ydir * muzzleCoreSize),                           WT3->xstart, WT3->yend,   coreColor }
 		);
 
 		pulseStartTime += 0.5f;
@@ -265,20 +264,20 @@ void CLargeBeamLaserProjectile::Draw()
 
 		muzzleEdgeSize = thickness * flaresize * pulseStartTime;
 
-		AddEffectsQuad(
-			{ pos1 + (ydir * muzzleEdgeSize),                           sidetex.xstart, sidetex.ystart, edgeColor },
-			{ pos1 + (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), sidetex.xend,   sidetex.ystart, edgeColor },
-			{ pos1 - (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), sidetex.xend,   sidetex.yend,   edgeColor },
-			{ pos1 - (ydir * muzzleEdgeSize),                           sidetex.xstart, sidetex.yend,   edgeColor }
+		AddWeaponEffectsQuad<3>(
+			{ pos1 + (ydir * muzzleEdgeSize),                           WT3->xstart, WT3->ystart, edgeColor },
+			{ pos1 + (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->ystart, edgeColor },
+			{ pos1 - (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->yend,   edgeColor },
+			{ pos1 - (ydir * muzzleEdgeSize),                           WT3->xstart, WT3->yend,   edgeColor }
 		);
 
 		muzzleCoreSize = muzzleEdgeSize * 0.6f;
 
-		AddEffectsQuad(
-			{ pos1 + (ydir * muzzleCoreSize),                           sidetex.xstart, sidetex.ystart, coreColor },
-			{ pos1 + (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), sidetex.xend,   sidetex.ystart, coreColor },
-			{ pos1 - (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), sidetex.xend,   sidetex.yend,   coreColor },
-			{ pos1 - (ydir * muzzleCoreSize),                           sidetex.xstart, sidetex.yend,   coreColor }
+		AddWeaponEffectsQuad<3>(
+			{ pos1 + (ydir * muzzleCoreSize),                           WT3->xstart, WT3->ystart, coreColor },
+			{ pos1 + (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->ystart, coreColor },
+			{ pos1 - (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->yend,   coreColor },
+			{ pos1 - (ydir * muzzleCoreSize),                           WT3->xstart, WT3->yend,   coreColor }
 		);
 	}
 
@@ -286,14 +285,14 @@ void CLargeBeamLaserProjectile::Draw()
 		// draw flare (moved slightly along the camera direction)
 		pos1 = startPos - (camera->GetDir() * 3.0f);
 
-		AddEffectsQuad(
+		AddWeaponEffectsQuad<4>(
 			{ pos1 - (camera->GetRight() * flareEdgeSize) - (camera->GetUp() * flareEdgeSize), WT4->xstart, WT4->ystart, edgeColStart },
 			{ pos1 + (camera->GetRight() * flareEdgeSize) - (camera->GetUp() * flareEdgeSize), WT4->xend  , WT4->ystart, edgeColStart },
 			{ pos1 + (camera->GetRight() * flareEdgeSize) + (camera->GetUp() * flareEdgeSize), WT4->xend  , WT4->yend  , edgeColStart },
 			{ pos1 - (camera->GetRight() * flareEdgeSize) + (camera->GetUp() * flareEdgeSize), WT4->xstart, WT4->yend  , edgeColStart }
 		);
 
-		AddEffectsQuad(
+		AddWeaponEffectsQuad<4>(
 			{ pos1 - (camera->GetRight() * flareCoreSize) - (camera->GetUp() * flareCoreSize), WT4->xstart, WT4->ystart, coreColStart },
 			{ pos1 + (camera->GetRight() * flareCoreSize) - (camera->GetUp() * flareCoreSize), WT4->xend  , WT4->ystart, coreColStart },
 			{ pos1 + (camera->GetRight() * flareCoreSize) + (camera->GetUp() * flareCoreSize), WT4->xend  , WT4->yend  , coreColStart },

--- a/rts/Sim/Projectiles/WeaponProjectiles/LargeBeamLaserProjectile.h
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LargeBeamLaserProjectile.h
@@ -33,9 +33,6 @@ private:
 	float scrollspeed;
 	float pulseSpeed;
 	float decay;
-
-	AtlasedTexture beamtex;
-	AtlasedTexture sidetex;
 };
 
 #endif // LARGE_BEAM_LASER_PROJECTILE_H

--- a/rts/Sim/Projectiles/WeaponProjectiles/LaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LaserProjectile.cpp
@@ -185,6 +185,8 @@ void CLaserProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
+	UpdateWeaponAnimParams();
+
 	float3 dif(pos - camera->GetPos());
 	const float camDist = dif.LengthNormalize();
 
@@ -222,14 +224,14 @@ void CLaserProjectile::Draw()
 		}
 
 		if (validTextures[2]) {
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<2>(
 				{ drawPos - (dir1 * size) - (dir2 * size),        weaponDef->visuals.texture2->xstart, weaponDef->visuals.texture2->ystart, col },
 				{ drawPos - (dir1 * size),                        midtexx,                             weaponDef->visuals.texture2->ystart, col },
 				{ drawPos + (dir1 * size),                        midtexx,                             weaponDef->visuals.texture2->yend  , col },
 				{ drawPos + (dir1 * size) - (dir2 * size),        weaponDef->visuals.texture2->xstart, weaponDef->visuals.texture2->yend  , col }
 			);
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<2>(
 				{ drawPos - (dir1 * coresize) - (dir2 * coresize), weaponDef->visuals.texture2->xstart, weaponDef->visuals.texture2->ystart, col2 },
 				{ drawPos - (dir1 * coresize),                     midtexx,                             weaponDef->visuals.texture2->ystart, col2 },
 				{ drawPos + (dir1 * coresize),                     midtexx,                             weaponDef->visuals.texture2->yend  , col2 },
@@ -237,14 +239,14 @@ void CLaserProjectile::Draw()
 			);
 		}
 		if (validTextures[1]) {
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ drawPos - (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col },
 				{ pos2    - (dir1 * size),     weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->ystart, col },
 				{ pos2    + (dir1 * size),     weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->yend  , col },
 				{ drawPos + (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->yend  , col }
 			);
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ drawPos - (dir1 * coresize), weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col2 },
 				{ pos2    - (dir1 * coresize), weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->ystart, col2 },
 				{ pos2    + (dir1 * coresize), weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->yend  , col2 },
@@ -252,14 +254,14 @@ void CLaserProjectile::Draw()
 			);
 		}
 		if (validTextures[2]) {
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<2>(
 				{ pos2 - (dir1 * size),                         midtexx,                           weaponDef->visuals.texture2->ystart, col },
 				{ pos2 - (dir1 * size) + (dir2 * size),         weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->ystart, col },
 				{ pos2 + (dir1 * size) + (dir2 * size),         weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->yend  , col },
 				{ pos2 + (dir1 * size),                         midtexx,                           weaponDef->visuals.texture2->yend  , col }
 			);
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<2>(
 				{ pos2 - (dir1 * coresize),                     midtexx,                           weaponDef->visuals.texture2->ystart, col2 },
 				{ pos2 - (dir1 * coresize) + (dir2 * coresize), weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->ystart, col2 },
 				{ pos2 + (dir1 * coresize) + (dir2 * coresize), weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->yend  , col2 },
@@ -280,14 +282,14 @@ void CLaserProjectile::Draw()
 			texEndOffset   = ((float)stayTime * (speedf / maxLength)) * (weaponDef->visuals.texture1->xstart - weaponDef->visuals.texture1->xend);
 		}
 		if (validTextures[1]) {
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col },
 				{ pos2 - (dir1 * size),     weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->ystart, col },
 				{ pos2 + (dir1 * size),     weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->yend  , col },
 				{ pos1 + (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->yend  , col }
 			);
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ pos1 - (dir1 * coresize), weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col2 },
 				{ pos2 - (dir1 * coresize), weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->ystart, col2 },
 				{ pos2 + (dir1 * coresize), weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->yend  , col2 },

--- a/rts/Sim/Projectiles/WeaponProjectiles/LightningProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LightningProjectile.cpp
@@ -64,6 +64,8 @@ void CLightningProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
+	UpdateWeaponAnimParams();
+
 	uint8_t col[4] {
 		(uint8_t)(color.x * 255),
 		(uint8_t)(color.y * 255),
@@ -85,7 +87,7 @@ void CLightningProjectile::Draw()
 			tempPos  = (startPos * (1.0f - f)) + (targetPos * f);
 
 			const auto& WDV = weaponDef->visuals;
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<1>(
 				{ tempPosO + (dir1 * (displacement[d    ] + WDV.thickness)), WDV.texture1->xstart, WDV.texture1->ystart, col },
 				{ tempPos  + (dir1 * (displacement[d + 1] + WDV.thickness)), WDV.texture1->xend,   WDV.texture1->ystart, col },
 				{ tempPos  + (dir1 * (displacement[d + 1] - WDV.thickness)), WDV.texture1->xend,   WDV.texture1->yend,   col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/MissileProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/MissileProjectile.cpp
@@ -380,15 +380,19 @@ void CMissileProjectile::Draw()
 	if (!validTextures[1])
 		return;
 
+	UpdateWeaponAnimParams();
+
 	// rocket flare
 	const SColor lightYellow(255, 210, 180, 1);
 	const float fsize = radius * 0.4f;
 
-	AddEffectsQuad(
-		{ drawPos - camera->GetRight() * fsize - camera->GetUp() * fsize, weaponDef->visuals.texture1->xstart, weaponDef->visuals.texture1->ystart, lightYellow },
-		{ drawPos + camera->GetRight() * fsize - camera->GetUp() * fsize, weaponDef->visuals.texture1->xend,   weaponDef->visuals.texture1->ystart, lightYellow },
-		{ drawPos + camera->GetRight() * fsize + camera->GetUp() * fsize, weaponDef->visuals.texture1->xend,   weaponDef->visuals.texture1->yend,   lightYellow },
-		{ drawPos - camera->GetRight() * fsize + camera->GetUp() * fsize, weaponDef->visuals.texture1->xstart, weaponDef->visuals.texture1->yend,   lightYellow }
+	const auto* WT1 = weaponDef->visuals.texture1;
+
+	AddWeaponEffectsQuad<1>(
+		{ drawPos - camera->GetRight() * fsize - camera->GetUp() * fsize, WT1->xstart, WT1->ystart, lightYellow },
+		{ drawPos + camera->GetRight() * fsize - camera->GetUp() * fsize, WT1->xend,   WT1->ystart, lightYellow },
+		{ drawPos + camera->GetRight() * fsize + camera->GetUp() * fsize, WT1->xend,   WT1->yend,   lightYellow },
+		{ drawPos - camera->GetRight() * fsize + camera->GetUp() * fsize, WT1->xstart, WT1->yend,   lightYellow }
 	);
 }
 

--- a/rts/Sim/Projectiles/WeaponProjectiles/StarburstProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/StarburstProjectile.cpp
@@ -349,6 +349,8 @@ void CStarburstProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
+	UpdateWeaponAnimParams();
+
 	const auto wt3 = weaponDef->visuals.texture3;
 	const auto wt1 = weaponDef->visuals.texture1;
 
@@ -377,7 +379,7 @@ void CStarburstProjectile::Draw()
 			SColor col = lightYellow * std::clamp(alpha, 0.0f, 1.0f);
 			col.a = 1;
 
-			AddEffectsQuad(
+			AddWeaponEffectsQuad<3>(
 				{ interPos - camera->GetRight() * drawsize - camera->GetUp() * drawsize, wt3->xstart, wt3->ystart, col },
 				{ interPos + camera->GetRight() * drawsize - camera->GetUp() * drawsize, wt3->xend,   wt3->ystart, col },
 				{ interPos + camera->GetRight() * drawsize + camera->GetUp() * drawsize, wt3->xend,   wt3->yend,   col },
@@ -393,7 +395,7 @@ void CStarburstProjectile::Draw()
 	constexpr float fsize = 25.0f;
 
 	if (validTextures[1]) {
-		AddEffectsQuad(
+		AddWeaponEffectsQuad<1>(
 			{ drawPos - camera->GetRight() * fsize - camera->GetUp() * fsize, wt1->xstart, wt1->ystart, lightRed },
 			{ drawPos + camera->GetRight() * fsize - camera->GetUp() * fsize, wt1->xend,   wt1->ystart, lightRed },
 			{ drawPos + camera->GetRight() * fsize + camera->GetUp() * fsize, wt1->xend,   wt1->yend,   lightRed },

--- a/rts/Sim/Projectiles/WeaponProjectiles/TorpedoProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/TorpedoProjectile.cpp
@@ -28,7 +28,9 @@ CR_REG_METADATA(CTorpedoProjectile,(
 	CR_MEMBER(ignoreError),
 	CR_MEMBER(tracking),
 	CR_MEMBER(maxSpeed),
-	CR_MEMBER(nextBubble)
+	CR_MEMBER(nextBubble),
+	CR_MEMBER(texx),
+	CR_MEMBER(texy)
 ))
 
 
@@ -39,6 +41,8 @@ CTorpedoProjectile::CTorpedoProjectile(const ProjectileParams& params): CWeaponP
 	, maxSpeed(0.0f)
 
 	, nextBubble(4)
+	, texx(0.0f)
+	, texy(0.0f)
 {
 	projectileType = WEAPON_TORPEDO_PROJECTILE;
 
@@ -48,6 +52,9 @@ CTorpedoProjectile::CTorpedoProjectile(const ProjectileParams& params): CWeaponP
 		maxSpeed = weaponDef->projectilespeed;
 
 	drawRadius = maxSpeed * 8.0f;
+
+	texx = projectileDrawer->torpedotex->xstart - (projectileDrawer->torpedotex->xend - projectileDrawer->torpedotex->xstart) * 0.5f;
+	texy = projectileDrawer->torpedotex->ystart - (projectileDrawer->torpedotex->yend - projectileDrawer->torpedotex->ystart) * 0.5f;
 }
 
 
@@ -166,9 +173,6 @@ void CTorpedoProjectile::Draw()
 		return;
 
 	//UpdateWeaponAnimParams();
-
-	const auto texx = projectileDrawer->torpedotex->xstart - (projectileDrawer->torpedotex->xend - projectileDrawer->torpedotex->xstart) * 0.5f;
-	const auto texy = projectileDrawer->torpedotex->ystart - (projectileDrawer->torpedotex->yend - projectileDrawer->torpedotex->ystart) * 0.5f;
 
 	float3 r = dir.cross(UpVector);
 

--- a/rts/Sim/Projectiles/WeaponProjectiles/TorpedoProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/TorpedoProjectile.cpp
@@ -28,9 +28,7 @@ CR_REG_METADATA(CTorpedoProjectile,(
 	CR_MEMBER(ignoreError),
 	CR_MEMBER(tracking),
 	CR_MEMBER(maxSpeed),
-	CR_MEMBER(nextBubble),
-	CR_MEMBER(texx),
-	CR_MEMBER(texy)
+	CR_MEMBER(nextBubble)
 ))
 
 
@@ -41,8 +39,6 @@ CTorpedoProjectile::CTorpedoProjectile(const ProjectileParams& params): CWeaponP
 	, maxSpeed(0.0f)
 
 	, nextBubble(4)
-	, texx(0.0f)
-	, texy(0.0f)
 {
 	projectileType = WEAPON_TORPEDO_PROJECTILE;
 
@@ -52,9 +48,6 @@ CTorpedoProjectile::CTorpedoProjectile(const ProjectileParams& params): CWeaponP
 		maxSpeed = weaponDef->projectilespeed;
 
 	drawRadius = maxSpeed * 8.0f;
-
-	texx = projectileDrawer->torpedotex->xstart - (projectileDrawer->torpedotex->xend - projectileDrawer->torpedotex->xstart) * 0.5f;
-	texy = projectileDrawer->torpedotex->ystart - (projectileDrawer->torpedotex->yend - projectileDrawer->torpedotex->ystart) * 0.5f;
 }
 
 
@@ -172,6 +165,11 @@ void CTorpedoProjectile::Draw()
 	if (model != nullptr)
 		return;
 
+	//UpdateWeaponAnimParams();
+
+	const auto texx = projectileDrawer->torpedotex->xstart - (projectileDrawer->torpedotex->xend - projectileDrawer->torpedotex->xstart) * 0.5f;
+	const auto texy = projectileDrawer->torpedotex->ystart - (projectileDrawer->torpedotex->yend - projectileDrawer->torpedotex->ystart) * 0.5f;
+
 	float3 r = dir.cross(UpVector);
 
 	if (r.SqLength() < 0.001f)
@@ -183,56 +181,56 @@ void CTorpedoProjectile::Draw()
 	const float w = 2;
 	const SColor col(60, 60, 100, 255);
 
-	AddEffectsQuad(
+	AddWeaponEffectsQuad<0>(
 		{ drawPos + (r * w),             texx, texy, col },
 		{ drawPos + (u * w),             texx, texy, col },
 		{ drawPos + (u * w) + (dir * h), texx, texy, col },
 		{ drawPos + (r * w) + (dir * h), texx, texy, col }
 	);
 
-	AddEffectsQuad(
+	AddWeaponEffectsQuad<0>(
 		{ drawPos + (u * w),             texx, texy, col },
 		{ drawPos - (r * w),             texx, texy, col },
 		{ drawPos - (r * w) + (dir * h), texx, texy, col },
 		{ drawPos + (u * w) + (dir * h), texx, texy, col }
 	);
 
-	AddEffectsQuad(
+	AddWeaponEffectsQuad<0>(
 		{ drawPos - (r * w),             texx, texy, col },
 		{ drawPos - (u * w),             texx, texy, col },
 		{ drawPos - (u * w) + (dir * h), texx, texy, col },
 		{ drawPos - (r * w) + (dir * h), texx, texy, col }
 	);
 
-	AddEffectsQuad(
+	AddWeaponEffectsQuad<0>(
 		{ drawPos - (u * w),             texx, texy, col },
 		{ drawPos + (r * w),             texx, texy, col },
 		{ drawPos + (r * w) + (dir * h), texx, texy, col },
 		{ drawPos - (u * w) + (dir * h), texx, texy, col }
 	);
 
-	AddEffectsQuad(
+	AddWeaponEffectsQuad<0>(
 		{ drawPos + (r * w) + (dir * h), texx, texy, col },
 		{ drawPos + (u * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col }
 	);
 
-	AddEffectsQuad(
+	AddWeaponEffectsQuad<0>(
 		{ drawPos + (u * w) + (dir * h), texx, texy, col },
 		{ drawPos - (r * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col }
 	);
 
-	AddEffectsQuad(
+	AddWeaponEffectsQuad<0>(
 		{ drawPos - (r * w) + (dir * h), texx, texy, col },
 		{ drawPos - (u * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col }
 	);
 
-	AddEffectsQuad(
+	AddWeaponEffectsQuad<0>(
 		{ drawPos - (u * w) + (dir * h), texx, texy, col },
 		{ drawPos + (r * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.cpp
@@ -284,10 +284,13 @@ void CWeaponProjectile::UpdateWeaponAnimParams()
 
 	if (validTextures[1])
 		UpdateAnimParamsImpl(weaponDef->visuals.animParams[0],      animProgress   );
+
 	if (validTextures[2])
 		UpdateAnimParamsImpl(weaponDef->visuals.animParams[1], extraAnimProgress[0]);
+
 	if (validTextures[3])
 		UpdateAnimParamsImpl(weaponDef->visuals.animParams[2], extraAnimProgress[1]);
+
 	if (validTextures[4])
 		UpdateAnimParamsImpl(weaponDef->visuals.animParams[3], extraAnimProgress[2]);
 }

--- a/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.cpp
@@ -285,11 +285,11 @@ void CWeaponProjectile::UpdateWeaponAnimParams()
 	if (validTextures[1])
 		UpdateAnimParamsImpl(weaponDef->visuals.animParams[0],      animProgress   );
 	if (validTextures[2])
-		UpdateAnimParamsImpl(weaponDef->visuals.animParams[0], extraAnimProgress[0]);
+		UpdateAnimParamsImpl(weaponDef->visuals.animParams[1], extraAnimProgress[0]);
 	if (validTextures[3])
-		UpdateAnimParamsImpl(weaponDef->visuals.animParams[1], extraAnimProgress[1]);
+		UpdateAnimParamsImpl(weaponDef->visuals.animParams[2], extraAnimProgress[1]);
 	if (validTextures[4])
-		UpdateAnimParamsImpl(weaponDef->visuals.animParams[2], extraAnimProgress[2]);
+		UpdateAnimParamsImpl(weaponDef->visuals.animParams[3], extraAnimProgress[2]);
 }
 
 

--- a/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.cpp
@@ -276,6 +276,22 @@ void CWeaponProjectile::Update()
 	UpdateInterception();
 }
 
+void CWeaponProjectile::UpdateWeaponAnimParams()
+{
+	assert(weaponDef);
+	if (!validTextures[0])
+		return;
+
+	if (validTextures[1])
+		UpdateAnimParamsImpl(weaponDef->visuals.animParams[0],      animProgress   );
+	if (validTextures[2])
+		UpdateAnimParamsImpl(weaponDef->visuals.animParams[0], extraAnimProgress[0]);
+	if (validTextures[3])
+		UpdateAnimParamsImpl(weaponDef->visuals.animParams[1], extraAnimProgress[1]);
+	if (validTextures[4])
+		UpdateAnimParamsImpl(weaponDef->visuals.animParams[2], extraAnimProgress[2]);
+}
+
 
 void CWeaponProjectile::UpdateInterception()
 {

--- a/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.h
+++ b/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.h
@@ -5,9 +5,9 @@
 
 #include "Sim/Projectiles/Projectile.h"
 #include "Sim/Projectiles/ProjectileParams.h" // easier to include this here
+#include "Sim/Weapons/WeaponDef.h"
 #include "WeaponProjectileTypes.h"
 
-struct WeaponDef;
 struct ProjectileParams;
 class CVertexArray;
 class DynDamageArray;
@@ -30,6 +30,12 @@ public:
 	void Collision(CFeature* feature) override;
 	void Collision(CUnit* unit) override;
 	void Update() override;
+
+	void UpdateWeaponAnimParams();
+
+	template <uint32_t texIdx>
+	void AddWeaponEffectsQuad(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const;
+
 	/// @return 0=unaffected, 1=instant repulse, 2=gradual repulse
 	virtual int ShieldRepulse(const float3& shieldPos, float shieldForce, float shieldMaxSpeed) { return 0; }
 
@@ -99,6 +105,39 @@ protected:
 
 	float3 bounceHitPos;
 	float3 bounceParams;
+
+	std::array<float, 3> extraAnimProgress;
 };
+
+template <>
+inline void CWeaponProjectile::AddWeaponEffectsQuad<0>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	assert(weaponDef);
+	AddEffectsQuadImpl(tl, tr, br, bl);
+}
+
+template <>
+inline void CWeaponProjectile::AddWeaponEffectsQuad<1>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	assert(weaponDef);
+	//reuse animProgress
+	AddEffectsQuadImpl(tl, tr, br, bl, weaponDef->visuals.animParams[0], animProgress);
+}
+
+template <>
+inline void CWeaponProjectile::AddWeaponEffectsQuad<2>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	assert(weaponDef);
+	AddEffectsQuadImpl(tl, tr, br, bl, weaponDef->visuals.animParams[1], extraAnimProgress[0]);
+}
+
+template <>
+inline void CWeaponProjectile::AddWeaponEffectsQuad<3>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	assert(weaponDef);
+	AddEffectsQuadImpl(tl, tr, br, bl, weaponDef->visuals.animParams[2], extraAnimProgress[1]);
+}
+
+template <>
+inline void CWeaponProjectile::AddWeaponEffectsQuad<4>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	assert(weaponDef);
+	AddEffectsQuadImpl(tl, tr, br, bl, weaponDef->visuals.animParams[3], extraAnimProgress[2]);
+}
 
 #endif /* WEAPON_PROJECTILE_H */

--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -235,6 +235,10 @@ WEAPONTAG(float4, scarProjVector, visuals.scarProjVector).defaultValue(float4{0.
 WEAPONTAG(float4, scarColorTint, visuals.scarColorTint).defaultValue(float4{0.5f, 0.5f, 0.5f, 0.5f }).description("Color tint for explosion scar decal. Scaled so that 0.5 is no change, 1.0 is twice as bright.");
 WEAPONTAG(bool, alwaysVisible, visuals.alwaysVisible).defaultValue(false).description("Is the projectile visible regardless of sight?");
 WEAPONTAG(float, cameraShake).fallbackName("damage.default").defaultValue(0.0f).minimumValue(0.0f).description("Passed to the wupget:ShockFront callin as the first argument, intended for shaking the camera on particularly strong hits. Same scale as damage.");
+WEAPONTAG(float3, animParams1, visuals.animParams[0]).fallbackName("animParams").defaultValue(float3{ 1.0f, 1.0f, 30.0f }).description("Used to do flipbook style animation of texture1");
+WEAPONTAG(float3, animParams2, visuals.animParams[1]).fallbackName("animParams").defaultValue(float3{ 1.0f, 1.0f, 30.0f }).description("Used to do flipbook style animation of texture2");
+WEAPONTAG(float3, animParams3, visuals.animParams[2]).fallbackName("animParams").defaultValue(float3{ 1.0f, 1.0f, 30.0f }).description("Used to do flipbook style animation of texture3");
+WEAPONTAG(float3, animParams4, visuals.animParams[3]).fallbackName("animParams").defaultValue(float3{ 1.0f, 1.0f, 30.0f }).description("Used to do flipbook style animation of texture4");
 
 // Missile
 WEAPONTAG(bool, smokeTrail, visuals.smokeTrail).defaultValue(false).description("MissileLauncher only. Does it leave a smoke trail ribbon?");

--- a/rts/Sim/Weapons/WeaponDef.h
+++ b/rts/Sim/Weapons/WeaponDef.h
@@ -274,6 +274,8 @@ public:
 
 		std::vector<int> scarIdcs;
 
+		std::array<float3, 4> animParams;
+
 		bool explosionScar = true;
 		bool smokeTrail = false;
 		bool smokeTrailCastShadow = true;


### PR DESCRIPTION
Use `animParams1`, `animParams2`, `animParams3`, `animParams4` in a weaponDef to animate `texture1`, `texture2`, `texture3`, `texture4` respectively or `animParams` to animate all of them the same way.

Implements https://github.com/beyond-all-reason/spring/issues/1565