### PR TITLE
Upstream fix for OpenBSD cpuid stats

### DIFF
--- a/rts/lib/libcpuid/libcpuid/cpuid_main.c
+++ b/rts/lib/libcpuid/libcpuid/cpuid_main.c
@@ -290,7 +290,12 @@ static bool set_cpu_affinity(logical_cpu_t logical_cpu)
 
 static int get_total_cpus(void)
 {
+#ifdef __OpenBSD__
+	// HW_NCPUONLINE accounts for hyperthreading off/on
+	int mib[2] = { CTL_HW, HW_NCPUONLINE };
+#else
 	int mib[2] = { CTL_HW, HW_NCPU };
+#endif
 	int ncpus;
 	size_t len = sizeof(ncpus);
 	if (sysctl(mib, 2, &ncpus, &len, (void *) 0, 0) != 0) return 1;

--- a/rts/lib/libcpuid/libcpuid/rdtsc.c
+++ b/rts/lib/libcpuid/libcpuid/rdtsc.c
@@ -30,6 +30,11 @@
 #include "asm-bits.h"
 #include "rdtsc.h"
 
+#ifdef __OpenBSD__
+	#include <sys/types.h>
+	#include <sys/sysctl.h>
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 void sys_precise_clock(uint64_t *result)
@@ -121,6 +126,15 @@ int cpu_clock_by_os(void)
 	if (sysctlbyname("hw.cpufrequency", &result, &size, NULL, 0))
 		return -1;
 	return (int) (result / (long long) 1000000);
+}
+#elif defined(__OpenBSD__)
+int cpu_clock_by_os(void)
+{
+    int result = -1;
+    size_t size = sizeof(result);
+    int mib[2] = { CTL_HW, HW_CPUSPEED };
+    sysctl(mib, 2, &result, &size, NULL, 0);
+    return result;
 }
 #else
 /* Assuming Linux with /proc/cpuinfo */


### PR DESCRIPTION
Use `HW_NCPUONLINE` for OpenBSD CPU count and implement `cpu_clock_by_os`. `HW_NCPUONLINE` is the preferred count on OpenBSD; `HW_NCPU` would count virtual hyperthreading cores that might be deactivated.