### PR TITLE
allocate table

### DIFF
--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -228,6 +228,7 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetConfigString);
 
 	REGISTER_LUA_CFUNC(CreateDir);
+	REGISTER_LUA_CFUNC(AllocateTable);
 
 	REGISTER_LUA_CFUNC(SendCommands);
 	REGISTER_LUA_CFUNC(GiveOrder);
@@ -2440,6 +2441,29 @@ int LuaUnsyncedCtrl::CreateDir(lua_State* L)
 	return 1;
 }
 
+/***
+ *
+ * @function Spring.AllocateTable
+ * @number narr hint for count of array elements
+ * @number nrec hint for count of record elements
+ * @treturn table
+ */
+int LuaUnsyncedCtrl::AllocateTable(lua_State* L)
+{
+	int narr = luaL_optinteger(L, 1, 0);
+	int nrec = luaL_optinteger(L, 2, 0);
+
+	if (narr < 0) {
+		narr = 0;
+	}
+	if (nrec < 0) {
+		nrec = 0;
+	}
+
+	lua_createtable(L, narr, nrec);
+
+	return 1;
+}
 
 
 

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -107,6 +107,7 @@ class LuaUnsyncedCtrl {
 		static int SetConfigString(lua_State* L);
 
 		static int CreateDir(lua_State* L);
+		static int AllocateTable(lua_State* L);
 
 		static int Reload(lua_State* L);
 		static int Restart(lua_State* L);


### PR DESCRIPTION
https://github.com/beyond-all-reason/spring/issues/1632

1.5 microseconds saved for an array of 30 items:
![image](https://github.com/user-attachments/assets/96f26b69-3734-44d6-b5ea-279cab093ef2)

```lua
function widget:Update()
	local table = Spring.AllocateTable(30) -- vs {}
	for i = 1, 30, 1 do
		table[i] = i
	end
	Spring.Echo(table[25])
end

```