### PR TITLE
Add `Engine.FeatureSupport` table

### DIFF
--- a/rts/Lua/LuaConstEngine.cpp
+++ b/rts/Lua/LuaConstEngine.cpp
@@ -19,6 +19,7 @@
  * @string versionFull 
  * @string versionPatchSet 
  * @string buildFlags (unsynced only) Gets additional engine buildflags, e.g. "OMP" or "MT-Sim DEBUG"
+ * @string FeatureSupport table containing various engine features as keys; use for cross-version compat
  * @number wordSize indicates the build type and is either 32 or 64 (or 0 in synced code)
  */
 
@@ -35,6 +36,14 @@ bool LuaConstEngine::PushEntries(lua_State* L)
 	#else
 	LuaPushNamedNumber(L, "wordSize", (!CLuaHandle::GetHandleSynced(L))? Platform::NativeWordSize() * 8: 0);
 	#endif
+
+
+	lua_pushliteral(L, "FeatureSupport");
+	lua_createtable(L, 0, 2);
+		LuaPushNamedBool(L, "hasExitOnlyYardmaps", true);
+		LuaPushNamedNumber(L, "rmlUiApiVersion", 1);
+	lua_rawset(L, -3);
+
 	return true;
 }
 


### PR DESCRIPTION
With an example for a feature added in the latest release.

 * `if Engine.FeatureSupport.hasXYZ then` is both more self-documenting and convenient than `if Script.IsEngineMinVersion(123) then`
 * development is not necessarily linear so there may not even be any specific version a feature was added in. A feature can be available at commit 1 on feature branch X, on commit 234 after being merged to the common development branch Y, and on version 1.5.67 on release branch Z. Having a direct bool to rely on is better than trying to account for all of the above combinations via version checks.
 * could be used for internal versioning of features as well. For example maybe the initial version of rmlUI sets `Engine.FeatureSupport.rmluiApiVersion = 1` and then when it finally gets livetested and the API changes based on that feedback, it would set `Engine.FeatureSupport.rmluiApiVersion = 2`.
 * something to discuss: whether to have a subtable or just put it directly in the `Engine` table. Flattening is nice, but I also like the expressive name.