### PR TITLE
Drop library directories from install

### DIFF
--- a/docker-build/scripts/04_install.sh
+++ b/docker-build/scripts/04_install.sh
@@ -1,3 +1,10 @@
 cd "${BUILD_DIR}"
 
 make install
+
+# Manually remove the lib, include and share directories coming
+# from the GNUInstallDirs. Unfortunately it's not possible to
+# easily disable in CMake all installation targets exported when
+# using add_subdirectory so we drop them from installation manually.
+cd "${INSTALL_DIR}"
+rm -rf lib include share

--- a/docker-build/scripts/04_install.sh
+++ b/docker-build/scripts/04_install.sh
@@ -6,5 +6,6 @@ make install
 # from the GNUInstallDirs. Unfortunately it's not possible to
 # easily disable in CMake all installation targets exported when
 # using add_subdirectory so we drop them from installation manually.
+# This is done to heavily reduce the resulting install size.
 cd "${INSTALL_DIR}"
 rm -rf lib include share


### PR DESCRIPTION
The libraries are added when we include deps via add_subdirectory. There isn't a simple way to ask CMake to not install them. A clean way would be to use components, but our cmake is not there at the moment.