### PR TITLE
Add misc.windChangeReportPeriod (in seconds) modrule...

### DIFF
--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -127,7 +127,7 @@ void CModInfo::ResetState()
 		allowEnginePlayerlist = true;
 	}
 	{
-		windChangeReportPeriod = 0;
+		windChangeReportPeriod = 15 * GAME_SPEED;
 	}
 }
 
@@ -336,7 +336,7 @@ void CModInfo::Init(const std::string& modFileName)
 		//misc
 		const LuaTable& misc = root.SubTable("misc");
 
-		windChangeReportPeriod = static_cast<int>(math::roundf(misc.GetFloat("windChangeReportPeriod", 0.0f) * GAME_SPEED));
+		windChangeReportPeriod = static_cast<int>(math::roundf(misc.GetFloat("windChangeReportPeriod", static_cast<float>(windChangeReportPeriod) / GAME_SPEED) * GAME_SPEED));
 	}
 
 	if (!std::has_single_bit <unsigned> (quadFieldQuadSizeInElmos))

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -127,6 +127,7 @@ void CModInfo::ResetState()
 		allowEnginePlayerlist = true;
 	}
 	{
+		// make windChangeReportPeriod equal to EnvResourceHandler::WIND_UPDATE_RATE = 15 * GAME_SPEED;
 		windChangeReportPeriod = 15 * GAME_SPEED;
 	}
 }

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -126,6 +126,9 @@ void CModInfo::ResetState()
 
 		allowEnginePlayerlist = true;
 	}
+	{
+		windChangeReportPeriod = 0;
+	}
 }
 
 void CModInfo::Init(const std::string& modFileName)
@@ -328,6 +331,12 @@ void CModInfo::Init(const std::string& modFileName)
 
 		if ((airMipLevel < 0) || (airMipLevel > 30))
 			throw content_error("Sensors\\Los\\AirLosMipLevel out of bounds. The minimum value is 0. The maximum value is 30.");
+	}
+	{
+		//misc
+		const LuaTable& misc = root.SubTable("misc");
+
+		windChangeReportPeriod = static_cast<int>(math::roundf(misc.GetFloat("windChangeReportPeriod", 0.0f) * GAME_SPEED));
 	}
 
 	if (!std::has_single_bit <unsigned> (quadFieldQuadSizeInElmos))

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -232,6 +232,9 @@ public:
 
 	bool allowTake;
 	bool allowEnginePlayerlist;
+
+	// how often to report wind speed/direction to wind gens
+	int windChangeReportPeriod;
 };
 
 extern CModInfo modInfo;

--- a/rts/Sim/Misc/Wind.cpp
+++ b/rts/Sim/Misc/Wind.cpp
@@ -62,7 +62,16 @@ void EnvResourceHandler::LoadWind(float minStrength, float maxStrength)
 	minWindStrength = std::min(minStrength, maxStrength);
 	maxWindStrength = std::max(minStrength, maxStrength);
 
-	curWindVec = mix(curWindDir * GetAverageWindStrength(), RgtVector * GetAverageWindStrength(), curWindDir == RgtVector);
+	// generate initial wind direction
+	float strength = 0.0f;
+
+	do {
+		curWindDir.x = gsRNG.NextFloat();
+		curWindDir.z = gsRNG.NextFloat();
+		strength = curWindDir.LengthNormalize2D();
+	} while (strength == 0.0f);
+
+	curWindVec = curWindDir * GetAverageWindStrength();
 	oldWindVec = curWindVec;
 }
 
@@ -88,7 +97,7 @@ void EnvResourceHandler::Update()
 	if (maxWindStrength <= 0.0f)
 		return;
 
-	if (windDirTimer == 0 ) {
+	if (windDirTimer == 0) {
 		oldWindVec = curWindVec;
 		newWindVec = oldWindVec;
 
@@ -103,39 +112,33 @@ void EnvResourceHandler::Update()
 
 		// normalize and clamp s.t. minWindStrength <= strength <= maxWindStrength
 		newWindVec /= newStrength;
-		newWindVec *= (newStrength = std::clamp(newStrength, minWindStrength, maxWindStrength));
-
-		// update generators
-		for (auto unitID: allGeneratorIDs) {
-			(unitHandler.GetUnit(unitID))->UpdateWind(newWindVec.x, newWindVec.z, newStrength);
-		}
-	} else {
-		const float mod = smoothstep(0.0f, 1.0f, windDirTimer / float(WIND_UPDATE_RATE));
-
-		// blend between old & new wind directions
-		// note: generators added on simframes when timer is 0
-		// do not receive a snapshot of the blended direction
-		curWindVec = mix(oldWindVec, newWindVec, mod);
-		curWindStrength = curWindVec.LengthNormalize();
-
-		curWindDir = curWindVec;
-		curWindVec = curWindDir * (curWindStrength = std::clamp(curWindStrength, minWindStrength, maxWindStrength));
-
-		if (const auto& wcrp = modInfo.windChangeReportPeriod; wcrp > 0 && gs->frameNum % wcrp == 0) {
-			// update generators every modInfo.windChangeReportPeriod frames
-			for (auto unitID : allGeneratorIDs) {
-				(unitHandler.GetUnit(unitID))->UpdateWind(curWindDir.x, curWindDir.z, curWindStrength);
-			}
-		}
-
-		for (auto unitID: newGeneratorIDs) {
-			// make newly added generators point in direction of wind
-			(unitHandler.GetUnit(unitID))->UpdateWind(curWindDir.x, curWindDir.z, curWindStrength);
-			allGeneratorIDs.push_back(unitID);
-		}
-
-		newGeneratorIDs.clear();
+		newStrength = std::clamp(newStrength, minWindStrength, maxWindStrength);
+		newWindVec *= newStrength;
 	}
+
+	const float mod = smoothstep(0.0f, 1.0f, windDirTimer / float(WIND_UPDATE_RATE));
+
+	// blend between old & new wind directions
+	curWindVec = mix(oldWindVec, newWindVec, mod);
+	curWindStrength = std::clamp(curWindVec.LengthNormalize(), minWindStrength, maxWindStrength);
+
+	curWindDir = curWindVec;
+	curWindVec = curWindDir * curWindStrength;
+
+	if (const auto& wcrp = modInfo.windChangeReportPeriod; wcrp > 0 && gs->frameNum % wcrp == 0) {
+		// update generators every modInfo.windChangeReportPeriod frames
+		for (auto unitID : allGeneratorIDs) {
+			unitHandler.GetUnit(unitID)->UpdateWind(curWindDir.x, curWindDir.z, curWindStrength);
+		}
+	}
+
+	// needs to be done immediately to rotate the generator according to the wind direction correctly
+	for (auto unitID : newGeneratorIDs) {
+		// make newly added generators point in direction of wind
+		unitHandler.GetUnit(unitID)->UpdateWind(curWindDir.x, curWindDir.z, curWindStrength);
+		allGeneratorIDs.push_back(unitID);
+	}
+	newGeneratorIDs.clear();
 
 	windDirTimer = (windDirTimer + 1) % (WIND_UPDATE_RATE + 1);
 }

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -337,8 +337,9 @@ void CUnit::PostInit(const CUnit* builder)
 	UpdateCollidableStateBit(CSolidObject::CSTATE_BIT_SOLIDOBJECTS, unitDef->collidable && (!immobile || !unitDef->canKamikaze));
 	Block();
 
-	if (unitDef->windGenerator > 0.0f)
-		envResHandler.AddGenerator(this);
+	// done in UnitFinished() instead
+	//if (unitDef->windGenerator > 0.0f)
+	//	envResHandler.AddGenerator(this);
 
 	UpdateTerrainType();
 	UpdatePhysicalState(0.1f);
@@ -430,6 +431,9 @@ void CUnit::FinishedBuilding(bool postInit)
 
 	// Sets the frontdir in sync with heading.
 	UpdateDirVectors(!upright && IsOnGround(), false, 0.0f);
+
+	if (unitDef->windGenerator > 0.0f)
+		envResHandler.AddGenerator(this);
 
 	eventHandler.UnitFinished(this);
 	eoh->UnitFinished(*this);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -337,9 +337,10 @@ void CUnit::PostInit(const CUnit* builder)
 	UpdateCollidableStateBit(CSolidObject::CSTATE_BIT_SOLIDOBJECTS, unitDef->collidable && (!immobile || !unitDef->canKamikaze));
 	Block();
 
-	// done in UnitFinished() instead
-	//if (unitDef->windGenerator > 0.0f)
-	//	envResHandler.AddGenerator(this);
+	// done once again in UnitFinished() too
+	// but keep the old behavior for compatibility purposes
+	if (unitDef->windGenerator > 0.0f)
+		envResHandler.AddGenerator(this);
 
 	UpdateTerrainType();
 	UpdatePhysicalState(0.1f);
@@ -432,8 +433,12 @@ void CUnit::FinishedBuilding(bool postInit)
 	// Sets the frontdir in sync with heading.
 	UpdateDirVectors(!upright && IsOnGround(), false, 0.0f);
 
-	if (unitDef->windGenerator > 0.0f)
+	if (unitDef->windGenerator > 0.0f) {
+		// trigger sending the wind update by removing
+		envResHandler.DelGenerator(this);
+		//  and adding back this windgen
 		envResHandler.AddGenerator(this);
+	}
 
 	eventHandler.UnitFinished(this);
 	eoh->UnitFinished(*this);


### PR DESCRIPTION
to report changs to the wind speed/strength as frequent as defined by misc.windChangeReportPeriod.

If misc.windChangeReportPeriod is not defined or defined to be <= 0.0, the previous behavior of reporting the wind change once in 15 seconds is kept for compatibility reasons.

Fixes https://github.com/beyond-all-reason/spring/issues/1711