### PR TITLE
Port fix to sol's optional::emplace for clang++ 19

### DIFF
--- a/rts/lib/sol2/sol.hpp
+++ b/rts/lib/sol2/sol.hpp
@@ -6375,7 +6375,8 @@ namespace sol {
 			static_assert(std::is_constructible<T, Args&&...>::value, "T must be constructible with Args");
 
 			*this = nullopt;
-			this->construct(std::forward<Args>(args)...);
+			new (static_cast<void*>(this)) optional(std::in_place, std::forward<Args>(args)...);
+			return **this;
 		}
 
 		/// Swaps this optional with the other.


### PR DESCRIPTION
This is just a straight copy of https://github.com/ThePhD/sol2/pull/1606 from sol2 to fix compilation under clang++ 19 as it's more restrictive in veryfying code under templates.