### PR TITLE
Remove unused vector `GuiHandler::buildcolors`

### DIFF
--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -3798,14 +3798,10 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 					const float3 bPos = bp.camPos + bp.dir * bpDist;
 					const BuildInfo cInfo = BuildInfo(buildeeDef, cPos, buildFacing);
 					const BuildInfo bInfo = BuildInfo(buildeeDef, bPos, buildFacing);
-
-					buildColors.clear();
-					buildColors.reserve(GetBuildPositions(bInfo, cInfo, tracePos, traceDir));
+					GetBuildPositions(bInfo, cInfo, tracePos, traceDir);
 				} else {
 					const BuildInfo bi(buildeeDef, cPos, buildFacing);
-
-					buildColors.clear();
-					buildColors.reserve(GetBuildPositions(bi, bi, tracePos, traceDir));
+					GetBuildPositions(bi, bi, tracePos, traceDir);
 				}
 
 

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -263,7 +263,6 @@ private:
 	// DrawMapStuff caches
 	std::vector<BuildInfo> buildInfos;
 	std::vector<Command> buildCommands;
-	std::vector<float4> buildColors;
 
 public:
 	std::vector<SCommandDescription> commands;


### PR DESCRIPTION
My first PR. Just removes an unused variable I found while reading through engine code.

This field was added in b4bf567fa80b2afe87e8ce99391c230fd54a9351 but it is only ever modified, and never read. It's unclear how it was intended to be used.

