### PR TITLE
Support line and grid bulk build commands without holding shift

### DIFF
--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -1253,6 +1253,9 @@ float CGameHelper::GetBuildHeight(const float3& pos, const UnitDef* unitdef, boo
 }
 
 
+/**
+ * @param feature Deprecated, just pass nullptr.
+ */
 CGameHelper::BuildSquareStatus CGameHelper::TestUnitBuildSquare(
 	const BuildInfo& buildInfo,
 	CFeature*& feature,

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -2223,18 +2223,18 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 			if (unitdef == nullptr)
 				return Command(CMD_STOP);
 
-			const BuildInfo bi(unitdef, cameraPos + mouseDir * dist, buildFacing);
-
-			if (button == SDL_BUTTON_LEFT) {
+			// Update buildInfos.
+			{
 				const float3 camTracePos = mouse->buttons[SDL_BUTTON_LEFT].camPos;
 				const float3 camTraceDir = mouse->buttons[SDL_BUTTON_LEFT].dir;
 
 				const float traceDist = camera->GetFarPlaneDist() * 1.4f;
 				const float isectDist = CGround::LineGroundWaterCol(camTracePos, camTraceDir, traceDist, unitdef->floatOnWater, false);
 
-				GetBuildPositions(BuildInfo(unitdef, camTracePos + camTraceDir * isectDist, buildFacing), bi, cameraPos, mouseDir);
-			} else {
-				GetBuildPositions(bi, bi, cameraPos, mouseDir);
+				const BuildInfo startInfo(unitdef, camTracePos + camTraceDir * isectDist, buildFacing);
+				const BuildInfo endInfo(unitdef, cameraPos + mouseDir * dist, buildFacing);
+
+				GetBuildPositions(startInfo, endInfo, cameraPos, mouseDir);
 			}
 
 			if (buildInfos.empty())

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -2267,7 +2267,6 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 				}
 			}
 
-			buildCommands.clear();
 			return CheckCommand((buildInfos.back()).CreateCommand(options));
 		}
 
@@ -3838,7 +3837,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 						glSurfaceCircle(buildPos, wd->coverageRange, { cmdColors.rangeInterceptorOn }, 40);
 					}
 
-					if (GetQueueKeystate()) {
+					{
 						buildCommands.clear();
 
 						const Command c = bi.CreateCommand();

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -83,6 +83,7 @@ public:
 	bool GetInvertQueueKey() const { return invertQueueKey; }
 	void SetInvertQueueKey(bool value) { invertQueueKey = value; }
 	bool GetQueueKeystate() const;
+	bool IsBatchBuildEnabled() const;
 
 	bool GetGatherMode() const { return gatherMode; }
 	void SetGatherMode(bool value) { gatherMode = value; }
@@ -220,9 +221,11 @@ private:
 	bool needShift = false;
 	bool showingMetal = false;
 	bool autoShowMetal = false;
-	bool invertQueueKey = false;
 	bool activeMousePress = false;
 	bool forceLayoutUpdate = false;
+
+	bool invertQueueKey = false;
+	bool holdQueueKeyToBatchBuild = true;
 
 	bool dropShadows = true;
 	bool useOptionLEDs = true;

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -59,6 +59,8 @@ public:
 		return GetCommand(mouseX, mouseY, buttonHint, preview, camera->GetPos(), mouse->dir);
 	}
 	Command GetCommand(int mouseX, int mouseY, int buttonHint, bool preview, const float3& cameraPos, const float3& mouseDir);
+
+	size_t GetBuildPositions(const UnitDef* unitDef, float3 endCamPos, float3 endMouseDir, bool isMultiBuild);
 	/// startInfo.def has to be endInfo.def
 	size_t GetBuildPositions(const BuildInfo& startInfo, const BuildInfo& endInfo, const float3& cameraPos, const float3& mouseDir);
 


### PR DESCRIPTION
## Overview

Divorces the concept of queue from building row/grid of buildings by removing the requirement to hold shift from build line and build grid commands. Permits building a row/grid without queuing it.

The result is some new input options following an intuitive logic without changing anything in the game.

__single__
- <kbd>LMB</kbd> build single *(unchanged)*
- <kbd>LMB</kbd>+<kbd>shift</kbd> queue single *(unchanged)*
- <kbd>LMB</kbd>+<kbd>space</kbd> queue single front *(unchanged)*
- <kbd>LMB</kbd>+<kbd>space</kbd>+<kbd>alt</kbd> insert single *(unchanged)*
 
__row__
- drag build row **NEW**
- drag+<kbd>shift</kbd> queue row *(unchanged)*
- drag+<kbd>space</kbd> queue row front **NEW**
- drag+<kbd>shift</kbd>+<kbd>space</kbd>+<kbd>alt</kbd> insert row  *(unchanged)*

__grid__
- drag+<kbd>alt</kbd> build grid **NEW**
- drag+<kbd>shift</kbd>+<kbd>alt</kbd> queue grid *(unchanged)*
- drag+<kbd>space</kbd>+<kbd>alt</kbd> queue grid front **NEW**
- drag+<kbd>shift</kbd>+<kbd>space</kbd>+<kbd>alt</kbd> insert grid *(unchanged)*

The "insert" logic seems quite buggy in current build, but it's a separate issue.

Discord discussion [here](https://discord.com/channels/549281623154229250/724924957074915358/1292524203291054191).

## List of changes

- Support dragging to draw a row without holding queue (<kbd>shift</kbd>).
- Support dragging to draw a grid without holding queue (<kbd>shift</kbd>), just <kbd>alt</kbd>.
- **Fix** Play error sound when no build in a row/grid is valid.
- Add new config option `HoldQueueKeyToBatchBuild` which is defaulted to true for back compatibility.
- Add new console command `/queuetobatch` to toggle the feature on in build. _Doesn't appear in autocomplete._

## Concerns
_To be reported or fixed_
- WIth alt+space grid input, it only queues front if I press space _before_ alt. If I hold alt and then _then_ hold space it ignores the space and clears the queue instead of queuing first. This is reproducible on latest release.
- Extreme lag when dragging massive grid over the entire map. This is reproducible on latest release.
- There is a limit to how many buildings will build when dragging a large build order, but this is not reflected in the preview indicator. Reflecting this limit would be both clearer and potentially alleviate lag issues.
- Units do not convert to naval/land when hovering minimap (as they do when hovering regular map). e.g. converter <-> naval converter.
- Similarly, a batch build will pick its naval/land type based on the first position you click, rather than checking each build position.