### PR TITLE
Restore missing `Spring.GetFeatureSelectionVolumeData`

### DIFF
--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -148,8 +148,8 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetFeatureNoDraw);
 	REGISTER_LUA_CFUNC(GetFeatureEngineDrawMask);
 	REGISTER_LUA_CFUNC(GetFeatureAlwaysUpdateMatrix);
-	REGISTER_LUA_CFUNC(GetFeatureAlwaysUpdateMatrix);
 	REGISTER_LUA_CFUNC(GetFeatureDrawFlag);
+	REGISTER_LUA_CFUNC(GetFeatureSelectionVolumeData);
 
 	REGISTER_LUA_CFUNC(GetUnitTransformMatrix);
 	REGISTER_LUA_CFUNC(GetFeatureTransformMatrix);


### PR DESCRIPTION
Looks like an accident in 7af79e4c5e330049bb3855b5ba734f3da1138be3