### PR TITLE
Fix Game.cpp two draws per minute when minimized.

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1263,12 +1263,10 @@ bool CGame::UpdateUnsynced(const spring_time currentTime)
 	SCOPED_TIMER("Update");
 
 	// timings and frame interpolation
-	const spring_time deltaDrawFrameTime = currentTime - lastDrawFrameTime;
+	const spring_time deltaDrawFrameTime = currentTime - globalRendering->lastFrameStart;
 
 	const float modGameDeltaTimeSecs = mix(deltaDrawFrameTime.toMilliSecsf() * 0.001f, 0.01f, skipping);
 	const float unsyncedUpdateDeltaTime = (currentTime - lastUnsyncedUpdateTime).toSecsf();
-
-	lastDrawFrameTime = currentTime;
 
 	{
 		// update game timings
@@ -1599,6 +1597,8 @@ bool CGame::Draw() {
 
 	eventHandler.DbgTimingInfo(TIMING_VIDEO, currentTimePreDraw, currentTimePostDraw);
 	globalRendering->SetGLTimeStamp(CGlobalRendering::FRAME_END_TIME_QUERY_IDX);
+
+	lastDrawFrameTime = currentTimePostDraw;
 
 	return true;
 }


### PR DESCRIPTION
### Work done

- Fixes the test for drawing two frames per minute when minimized.

### Considerations

See https://github.com/beyond-all-reason/spring/issues/1661 for a discussion of the underlying issue and investigation.

This is just a simple proposal, but I don't know much about the engine so please review carefully.

Also, feel free to discard this solution and do something different, it's just a good faith effort.

The change is simple, and I think using the value from globalRendering->lastFrameStart that we set in the same module is going to yield the same results as using lastDrawFrameTime to store it. It does look like a duplicate value stored in both modules.

There might be something going on I'm not aware of though.

Could be safer to just add a new variable so we can keep storing lastDrawFrameTime and just use a new one to store lastDrawTime or whatever. Anyways since afaics it's safe to do it like this, I didn't want to overcomplicate the solution.



