### PR TITLE
Fix leaks inside ProfileDrawer and TimeProfiler.

### DIFF
--- a/rts/Game/UI/ProfileDrawer.cpp
+++ b/rts/Game/UI/ProfileDrawer.cpp
@@ -660,12 +660,14 @@ void ProfileDrawer::Update()
 	const spring_time curTime = spring_now();
 	const spring_time maxTime = spring_secs(MAX_THREAD_HIST_TIME);
 
+	// cleanup old frame records
 	DiscardOldTimeSlices(lgcFrames, curTime, maxTime);
 	DiscardOldTimeSlices(uusFrames, curTime, maxTime);
 	DiscardOldTimeSlices(swpFrames, curTime, maxTime);
 	DiscardOldTimeSlices(vidFrames, curTime, maxTime);
 	DiscardOldTimeSlices(simFrames, curTime, maxTime);
 
+	// cleanup old records from the ThreadProfiles
 	auto& profiler = CTimeProfiler::GetInstance();
 	const size_t numThreads = std::min(profiler.GetNumThreadProfiles(), (size_t)ThreadPool::GetNumThreads());
 	size_t i = 0;

--- a/rts/Game/UI/ProfileDrawer.cpp
+++ b/rts/Game/UI/ProfileDrawer.cpp
@@ -215,7 +215,6 @@ static void DrawThreadBarcode(TypedRenderBuffer<VA_TYPE_C   >& rb)
 	{
 		// Need to lock; CleanupOldThreadProfiles pop_front()'s old entries
 		// from threadProf while ~ScopedMtTimer can modify it concurrently.
-		// Also, TimeProfiler could cleanup too while we're doing this.
 		profiler.ToggleLock(true);
 		profiler.CleanupOldThreadProfiles();
 

--- a/rts/Game/UI/ProfileDrawer.h
+++ b/rts/Game/UI/ProfileDrawer.h
@@ -20,6 +20,7 @@ public:
 	virtual bool MousePress(int x, int y, int button) override;
 	virtual bool IsAbove(int x, int y) override;
 	virtual void DbgTimingInfo(DbgTimingInfoType type, const spring_time start, const spring_time end) override;
+	virtual void Update() override;
 
 private:
 	ProfileDrawer();

--- a/rts/System/TimeProfiler.cpp
+++ b/rts/System/TimeProfiler.cpp
@@ -333,6 +333,7 @@ void CTimeProfiler::RefreshProfilesRaw()
 
 void CTimeProfiler::CleanupOldThreadProfiles()
 {
+	#ifdef THREADPOOL
 	const spring_time curTime = spring_gettime();
 	const spring_time maxTime = spring_secs(MAX_THREAD_HIST_TIME);
 	const size_t numThreads = std::min(threadProfiles.size(), (size_t)ThreadPool::GetNumThreads());
@@ -344,6 +345,7 @@ void CTimeProfiler::CleanupOldThreadProfiles()
 			threadProf.pop_front();
 		}
 	}
+	#endif
 }
 
 const CTimeProfiler::TimeRecord& CTimeProfiler::GetTimeRecord(const char* name) const

--- a/rts/System/TimeProfiler.h
+++ b/rts/System/TimeProfiler.h
@@ -30,6 +30,8 @@
 
 #define SCOPED_ONCE_TIMER(name) ZoneScopedNC(name, tracy::Color::Purple); ScopedOnceTimer __timer(name);
 
+static constexpr float MAX_THREAD_HIST_TIME = 0.5f; // secs
+
 class BasicTimer : public spring::noncopyable
 {
 public:
@@ -183,6 +185,7 @@ public:
 	void ResortProfilesRaw();
 	void RefreshProfiles();
 	void RefreshProfilesRaw();
+	void CleanupOldThreadProfiles();
 
 	void SetEnabled(bool b) { enabled = b; }
 	void PrintProfilingInfo() const;


### PR DESCRIPTION
### Work done

* Made ProfileDrawer clean up old frame records on Update() instead of Draw()
  * this way it's memory usage should in no case go beyond storage of 0.5 seconds of records.
  * Before the fix it's up to 30 seconds when minimized if Game.cpp doesnt botch it (see #1741), and **unlimited** otherwise.
* Made TimeProfiler cleanup its own records on Update (run every second)
  * Also ProfileDrawer will clean them before drawing to make sure it has the right amount of records since it wants 0.5 sec data.
  * Before the fix TimeProfiler can accept threadProfile records even with Drawer disabled when in `/debug on off` mode. In that case records **wouldn't ever be cleaned**.

### Considerations

See https://github.com/beyond-all-reason/spring/issues/1661 for a discussion of the underlying issue and investigation.

Feel free to discard this solution and do something different. Note even if ProfileDrawer can depend on two frames per second even when minimized, TimeProfiler can't.

Behaviour will be a bit different than currently but I think it should be ok (some records could be old by a factor of DrawTime-UpdateTime, but the difference should be negligible).

Another solution can be simply denying all incoming data when minimized, although this might fail if drawing is not called because of some other condition, just check for globalRendering->active at the top of [DbgTimingInfo](https://github.com/beyond-all-reason/spring/blob/master/rts/Game/UI/ProfileDrawer.cpp#L630) and also at [TimeProfiler](https://github.com/beyond-all-reason/spring/blob/master/rts/System/TimeProfiler.cpp#L381), but I think TimeProfiler is supposed to accept records even if ProfileDrawer is disabled or minimized.
