### PR TITLE
Fix saving state after /iconshidewithui

### DIFF
--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -3165,7 +3165,7 @@ public:
 
 	bool Execute(const UnsyncedAction& action) const final {
 		InverseOrSetBool(CUnitDrawer::IconHideWithUI(), action.GetArgs());
-		configHandler->Set("IconsHideWithUI", CUnitDrawer::IconHideWithUI() ? 1 : 0);
+		configHandler->Set("UnitIconsHideWithUI", CUnitDrawer::IconHideWithUI() ? 1 : 0);
 		LogSystemStatus("Hide unit icons with UI: ", CUnitDrawer::IconHideWithUI());
 		return true;
 	}


### PR DESCRIPTION
### Work Done

* Fixes wrong variable name when saving config on /iconshidewithui command

### Related Issues

* Possibly related to https://github.com/beyond-all-reason/Beyond-All-Reason/issues/969

### How to test

* Check here: https://github.com/beyond-all-reason/spring/blob/master/rts/Rendering/Units/UnitDrawer.cpp#L63
