### PR TITLE
Save and restore metal extraction map.

### DIFF
--- a/rts/Map/ReadMap.cpp
+++ b/rts/Map/ReadMap.cpp
@@ -191,6 +191,7 @@ void CReadMap::Serialize(creg::ISerializer* s)
 	SerializeMapChangesBeforeMatch(s);
 	SerializeMapChangesDuringMatch(s);
 	SerializeTypeMap(s);
+	SerializeMetalMap(s);
 }
 
 void CReadMap::SerializeMapChangesBeforeMatch(creg::ISerializer* s)
@@ -260,6 +261,19 @@ void CReadMap::SerializeTypeMap(creg::ISerializer* s)
 	FreeInfoMap("type", iotm);
 }
 
+void CReadMap::SerializeMetalMap(creg::ISerializer* s)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	// Metal extraction map is updated by ExtractorBuildings.
+	assert(metalMap.GetSizeX()*metalMap.GetSizeZ() == (tbi.width * tbi.height));
+
+	float *const extractionMap = const_cast<float *const>(metalMap.GetExtractionMap());
+
+	const int width = metalMap.GetSizeX();
+	const int height = metalMap.GetSizeZ();
+
+	s->Serialize(extractionMap, width*height*sizeof(float));
+}
 
 void CReadMap::PostLoad()
 {

--- a/rts/Map/ReadMap.h
+++ b/rts/Map/ReadMap.h
@@ -91,6 +91,7 @@ private:
 	void SerializeMapChangesDuringMatch(creg::ISerializer* s);
 	void SerializeMapChanges(creg::ISerializer* s, const float* refHeightMap, float* modifiedHeightMap);
 	void SerializeTypeMap(creg::ISerializer* s);
+	void SerializeMetalMap(creg::ISerializer* s);
 
 public:
 	void PostLoad();


### PR DESCRIPTION
### Work done

* Added serialization for MetalMap.extractionMap inside ReadMap.

### Considerations

* Alternative (probably better) implementation at #1745
* Not sure if this is the best way to save the data.
* This will break compatibility with older saves, any way to avoid that?
* I thought to do PostLoad on Extractors instead, thus re-initializing the extraction map without saving additional data, but dont' think that works because several extractors can be in the same spot, thus loading them in different order could result in different initialization. If unit load ordering is guaranteed to be the same of unit ~~creation order~~ activation order (activated as in started extracting metal), then I think that can work, but might be more fragile not sure.
* Also initially thought to save just the edited points instead of the whole buffer, but the code gets longer, and since the file is compressed, in the end I don't think it pays off (whole buffer is less than 1MB for a 500x500 map uncompressed and 15kB when compressed, more as the game progresses of course). When saving individual points each point requires 2 ints + 1 float, instead of just 1 float, and even basic mexes are like 300 points in the extractionMap.

### How to test

* Open game of spring
* Create a metal extractor
* Save game and close
* Open spring and load game
* Observe the metal view, below the extractor should show red, but shows green.
* Destroy the metal extractor with self-d or whatever
* Create the metal extractor again
* Observe how now it creates double metal as expected

With fix none of that should happen, and game should work as expected.

### Related issues

See https://github.com/beyond-all-reason/Beyond-All-Reason/issues/1489

Extraction map didn't get saved, thus metal visualization is wrong and also on load game this will cause accounting errors for the metal extractors (experienced as extractors with multiples of expected income production). Above issue has several screenshots.

### Why

Initially the extraction map is set to all 0s.

When a metal extractor is built, updates the map to it's extraction value. This way when another extractor comes later they can share the metal if the latter one is t2. Later one will overwrite values, but deduct the original value from its available income.

Not loading the extractionMap means it will be initialized to 0, but metal extractors will be present in the map, so when one of them is destroyed, it will call [CMetalMap::RemoveExtraction](https://github.com/beyond-all-reason/spring/blob/1cc2b11f7c777bbe6634b3a53eb2241baabab5f0/rts/Map/MetalMap.cpp#L123) deducting its value to below 0. That way when another extractor comes afterwards in the same place, it will request X extraction, but [obtain more](https://github.com/beyond-all-reason/spring/blob/1cc2b11f7c777bbe6634b3a53eb2241baabab5f0/rts/Map/MetalMap.cpp#L109).

Note metal extractors seem to be saving and loading all of the relevant data they need, so the extractionMap seems to be the only missing part to keep accounting and spot visualization right.



