### PR TITLE
Save and restore metalMap.

### DIFF
--- a/rts/Map/MetalMap.cpp
+++ b/rts/Map/MetalMap.cpp
@@ -12,9 +12,9 @@
 CR_BIND(CMetalMap, )
 
 CR_REG_METADATA(CMetalMap,(
-	CR_MEMBER(metalScale),
-	CR_MEMBER(sizeX),
-	CR_MEMBER(sizeZ),
+	CR_IGNORED(metalScale),
+	CR_IGNORED(sizeX),
+	CR_IGNORED(sizeZ),
 
 	CR_IGNORED(texturePalette),
 	CR_MEMBER(distributionMap),

--- a/rts/Map/ReadMap.cpp
+++ b/rts/Map/ReadMap.cpp
@@ -191,6 +191,7 @@ void CReadMap::Serialize(creg::ISerializer* s)
 	SerializeMapChangesBeforeMatch(s);
 	SerializeMapChangesDuringMatch(s);
 	SerializeTypeMap(s);
+	s->SerializeObjectInstance(&metalMap, metalMap.GetClass());
 }
 
 void CReadMap::SerializeMapChangesBeforeMatch(creg::ISerializer* s)


### PR DESCRIPTION
### Work done

* Serialize metalMap
* Saves distributionMap and extractionMap, setting other members to ignored since they don't need to be stored the map loader will [set those](https://github.com/beyond-all-reason/spring/blob/1cc2b11f7c777bbe6634b3a53eb2241baabab5f0/rts/Map/ReadMap.cpp#L169).

### Considerations

* Alternative PR to #1744 (see there for more information about related issue and how to test).
* Seems this is a better way.
* Just hope setting those CR_IGNORED members has no side effects, for what I understand @sprunk [said](https://github.com/beyond-all-reason/spring/pull/1744#issuecomment-2450920710) should just make the serializer ignore those. Otherwise it's not a big deal to include them in the serialization.
* Could be done in CregLoadSaveHandler.cpp instead of ReadMap.cpp, I thought it's better to leave it in ReadMap since there's some other metalMap related stuff there on Loading the map, but can be moved.
* Maybe saving the distributionMap is overkill, since nobody modifies it atm, but at least in bar there's one widget prepared to do that.