### PR TITLE
add stringify functions to vector and matrix

### DIFF
--- a/rts/System/Matrix44f.h
+++ b/rts/System/Matrix44f.h
@@ -157,6 +157,12 @@ public:
 		float md[4][4]; // WARNING: it still is column-major, means md[j][i]!!!
 		float4 col[4];
 	};
+
+	std::string str() const {
+		return std::format(
+			"m44(\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f})",
+			m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7], m[11], m[15]);
+	}
 };
 
 

--- a/rts/System/float3.h
+++ b/rts/System/float3.h
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <array>
 #include <utility>
+#include <format>
 
 #include "System/BranchPrediction.h"
 #include "lib/streflop/streflop_cond.h"
@@ -803,6 +804,10 @@ public:
 
 	static constexpr float cmp_eps() { return 1e-04f; }
 	static constexpr float nrm_eps() { return 1e-12f; }
+
+	std::string str() const {
+		return std::format("float3({:.3f}, {:.3f}, {:.3f})", x, y, z);
+	}
 
 	/**
 	 * @brief max x pos

--- a/rts/System/float4.h
+++ b/rts/System/float4.h
@@ -103,6 +103,11 @@ struct float4 : public float3
 		return (x * f.x) + (y * f.y) + (z * f.z) + (w * f.w);
 	}
 
+	std::string str() const {
+		return std::format("float4({:.3f}, {:.3f}, {:.3f}, {:.3f})", x, y, z, w);
+	}
+
+
 	/// Allows implicit conversion to float* (for passing to gl functions)
 	operator const float* () const { return reinterpret_cast<const float*>(&x); }
 	operator       float* ()       { return reinterpret_cast<      float*>(&x); }


### PR DESCRIPTION
for easy logging of vector values
for example `LOG_L(L_ERROR, "%s", unit->pos.str().c_str());`