### PR TITLE
Should not GuiTraceRay for quads beyond the floor until the far plane.

### DIFF
--- a/rts/Game/TraceRay.cpp
+++ b/rts/Game/TraceRay.cpp
@@ -18,15 +18,13 @@
 #include "Sim/Units/UnitTypes/Factory.h"
 #include "Sim/Weapons/PlasmaRepulser.h"
 #include "Sim/Weapons/WeaponDef.h"
-#include "System/Config/ConfigHandler.h"
+#include "System/GlobalConfig.h"
 #include "System/SpringMath.h"
 
 #include <algorithm>
 #include <vector>
 
 #include "System/Misc/TracyDefs.h"
-
-CONFIG(float, SelectThroughGround).defaultValue(200.0f).minimumValue(0.0f).description("Sets how far beyond the ground to allow selecting objects.");
 
 //////////////////////////////////////////////////////////////////////
 // Local/Helper functions
@@ -418,8 +416,7 @@ float GuiTraceRay(
 		// pointing upwards
 		maxRayLength = length;
 	}
-	const float lenienceBuffer = configHandler->GetFloat("SelectThroughGround");
-	maxRayLength = std::min(maxRayLength + lenienceBuffer, length);
+	maxRayLength = std::min(maxRayLength + globalConfig.selectThroughGround, length);
 
 	CollisionQuery cq;
 

--- a/rts/Game/TraceRay.cpp
+++ b/rts/Game/TraceRay.cpp
@@ -403,10 +403,12 @@ float GuiTraceRay(
 	if (groundOnly)
 		return minRayLength;
 
+	const float maxRayLength = minRayLength < 0.0 ? length : minRayLength;
+
 	CollisionQuery cq;
 
 	QuadFieldQuery qfQuery;
-	quadField.GetQuadsOnRay(qfQuery, start, dir, minRayLength);
+	quadField.GetQuadsOnRay(qfQuery, start, dir, maxRayLength);
 
 	for (const int quadIdx: *qfQuery.quads) {
 		const CQuadField::Quad& quad = quadField.GetQuad(quadIdx);

--- a/rts/Game/TraceRay.cpp
+++ b/rts/Game/TraceRay.cpp
@@ -406,7 +406,7 @@ float GuiTraceRay(
 	CollisionQuery cq;
 
 	QuadFieldQuery qfQuery;
-	quadField.GetQuadsOnRay(qfQuery, start, dir, length);
+	quadField.GetQuadsOnRay(qfQuery, start, dir, minRayLength);
 
 	for (const int quadIdx: *qfQuery.quads) {
 		const CQuadField::Quad& quad = quadField.GetQuad(quadIdx);

--- a/rts/System/GlobalConfig.cpp
+++ b/rts/System/GlobalConfig.cpp
@@ -65,6 +65,8 @@ CONFIG(bool, DumpGameStateOnDesync).defaultValue(true).description("Enable writi
 CONFIG(float, MinSimDrawBalance).defaultValue(0.15f).description("Percent of the time for simulation is minimum spend for drawing. E.g. if set to 0.15 then 15% of the total cpu time is exclusively reserved for drawing.");
 CONFIG(int, MinDrawFPS).defaultValue(2).description("Defines how many frames per second should minimally be rendered. To reach this number we will delay simframes.");
 
+CONFIG(float, SelectThroughGround).defaultValue(200.0f).minimumValue(0.0f).description("How far beyond the ground to allow selecting objects.");
+
 void GlobalConfig::Init()
 {
 	// Recommended semantics for "expert" type config values:
@@ -98,6 +100,8 @@ void GlobalConfig::Init()
 	minDrawFPS = configHandler->GetInt("MinDrawFPS");
 
 	teamHighlight = configHandler->GetInt("TeamHighlight");
+
+	selectThroughGround = configHandler->GetFloat("SelectThroughGround");
 }
 #endif
 

--- a/rts/System/GlobalConfig.h
+++ b/rts/System/GlobalConfig.h
@@ -141,6 +141,13 @@ public:
 	 * rendered. To reach this number we will delay simframes.
 	 */
 	int minDrawFPS;
+
+	/**
+	 * @brief selection ground penetration
+	 *
+	 * Defines how far beyond the ground to allow selecting objects.
+	 */
+	float selectThroughGround;
 };
 
 extern GlobalConfig globalConfig;


### PR DESCRIPTION
### Work done

* Pass minRayLength into GetQuadsOnRay instead of length.

### Details

Length is the length til camera far plane, but minRayLength is actually the length until the ground/water (not sure why it's called minRayLength the name seems a bit misleading).

I believe this to be an error, resulting in querying the quadField for every quad until the end of the map, even when tracing relatively perpendicular. I was testing something else and wondering why TraceRay was tracing so far.

A typical ray trace around the screen will return around 10 quads with this, 50 or more without. It also depends where you are in the map since the more map in front of you more quads will be returned. With the fix the number of quads stays constant as you move around the map since it only depends on where the mouse cursor is, and where the ground is intersected.

This needs to be looked into closely for sure. On initial testing I didn't find a difference when applying the fix, but will have to look at all users of GuiTraceRay to see nothing funny is going on.

Also this means it wouldn't be respecting looking for units or features above the water, but probably that isn't a thing.

### Before

see how the search area extends beyond the mouse pointer and even into the map side when there's no more map

![wideray-nolimits](https://github.com/user-attachments/assets/edbf8274-6cb3-4a6d-89a6-6e379f40729e)

### After

![wideray-before](https://github.com/user-attachments/assets/5e45a22d-143c-4b33-ae00-4c234143e435)
