### PR TITLE
RmlUI Context handling improvements

### DIFF
--- a/rts/Game/Camera/SpringController.cpp
+++ b/rts/Game/Camera/SpringController.cpp
@@ -31,7 +31,7 @@ namespace {
 CONFIG(bool,  CamSpringEnabled).defaultValue(true).headlessValue(false);
 CONFIG(int,   CamSpringScrollSpeed).defaultValue(10);
 CONFIG(float, CamSpringFOV).defaultValue(45.0f);
-CONFIG(float, CamSpringMinZoomDistance).defaultValue(20.0f).description("Minimum camera zoom distance");
+CONFIG(float, CamSpringMinZoomDistance).defaultValue(20.0f).description("Minimum camera zoom distance, note this is the distance from frustrum location to the ground in the direction of view");
 CONFIG(bool,  CamSpringLockCardinalDirections).defaultValue(true).description("Whether cardinal directions should be `locked` for a short time when rotating.");
 CONFIG(bool,  CamSpringZoomInToMousePos).defaultValue(true);
 CONFIG(bool,  CamSpringZoomOutFromMousePos).defaultValue(false);

--- a/rts/Rml/Backends/RmlUi_Backend.cpp
+++ b/rts/Rml/Backends/RmlUi_Backend.cpp
@@ -317,7 +317,7 @@ Rml::Context* RmlGui::GetOrCreateContext(const std::string& name)
 	Rml::Context* context = Rml::GetContext(name);
 	if (context == nullptr) {
 		context = Rml::CreateContext(name, {0, 0});
-	} else if (state->contexts_to_remove.contains(context)) {
+	} else {
 		state->contexts_to_remove.erase(context);
 	}
 	

--- a/rts/Rml/Backends/RmlUi_Backend.cpp
+++ b/rts/Rml/Backends/RmlUi_Backend.cpp
@@ -308,6 +308,34 @@ void RmlGui::OnContextDestroy(Rml::Context* context)
 	state->contexts.erase(std::ranges::find(state->contexts, context));
 }
 
+Rml::Context* RmlGui::GetOrCreateContext(const std::string& name)
+{
+	if (!RmlInitialized()) {
+		return nullptr;
+	}
+	
+	Rml::Context* context = Rml::GetContext(name);
+	if (context == nullptr) {
+		context = Rml::CreateContext(name, {0, 0});
+	} else if (state->contexts_to_remove.contains(context)) {
+		state->contexts_to_remove.erase(context);
+	}
+	
+	return context;
+}
+
+Rml::Context* RmlGui::GetContext(const std::string& name) {
+	if (!RmlInitialized()) {
+		return nullptr;
+	}
+
+	Rml::Context* context = Rml::GetContext(name);
+	if (context != nullptr && !state->contexts_to_remove.contains(context)) {
+		return context;
+	}
+	return nullptr;
+}
+
 void RmlGui::MarkContextForRemoval(Rml::Context *context) {
 	if (!RmlInitialized() || context == nullptr) {
 		return;

--- a/rts/Rml/Backends/RmlUi_Backend.cpp
+++ b/rts/Rml/Backends/RmlUi_Backend.cpp
@@ -317,7 +317,7 @@ Rml::Context* RmlGui::GetOrCreateContext(const std::string& name)
 	Rml::Context* context = Rml::GetContext(name);
 	if (context == nullptr) {
 		context = Rml::CreateContext(name, {0, 0});
-	} else if (state->contexts_to_remove.contains(context)) {
+	} else {
 		// can happen if name reused on the same frame
 		state->contexts_to_remove.erase(context);
 	}

--- a/rts/Rml/Backends/RmlUi_Backend.cpp
+++ b/rts/Rml/Backends/RmlUi_Backend.cpp
@@ -354,16 +354,14 @@ void RmlGui::Update()
 	for (const auto& context : state->contexts) {
 		context->Update();
 	}
-
+	
+	// move clicked context to top
 	if (state->clicked_context) {
-		auto context_pos = std::ranges::find(state->contexts, state->clicked_context);
-		if (context_pos != state->contexts.end()) {
-			// debug context is always to be on top
-			auto start = state->contexts.begin() + (state->debug_host_context ? 1 : 0);
-			if (context_pos != start) {
-				state->contexts.erase(context_pos);
-				state->contexts.insert(start, state->clicked_context);
-			}
+		// debug context is always to be at index 0 so it renders on top
+		auto start = state->contexts.begin() + (state->debug_host_context ? 1 : 0);
+		auto context_pos = std::ranges::find(start, state->contexts.end(), state->clicked_context);
+		if (context_pos != start && context_pos != state->contexts.end()) {
+			std::ranges::rotate(start, context_pos, context_pos + 1);
 		}
 		state->clicked_context = nullptr;
 	}

--- a/rts/Rml/Backends/RmlUi_Backend.h
+++ b/rts/Rml/Backends/RmlUi_Backend.h
@@ -73,6 +73,9 @@ namespace RmlGui
 
 	void OnContextCreate(Rml::Context* context);
 	void OnContextDestroy(Rml::Context* context);
+	
+	Rml::Context* GetOrCreateContext(const std::string& name);
+	Rml::Context* GetContext(const std::string& name);
 	void MarkContextForRemoval(Rml::Context* context);
 
 	void BeginFrame();

--- a/rts/Rml/SolLua/bind/Global.cpp
+++ b/rts/Rml/SolLua/bind/Global.cpp
@@ -75,7 +75,7 @@ namespace Rml::SolLua
 		{
 			return Rml::RegisterEventType(type, interruptible, bubbles, Rml::DefaultActionPhase::None);
 		}
-
+		
 		auto removeContext(Rml::Context* context) {
 			RmlGui::MarkContextForRemoval(context);
 		}
@@ -107,7 +107,7 @@ namespace Rml::SolLua
 			"CreateContext", [slp](const Rml::String& name) {
 				// context will be resized right away by other code
 				// send {0, 0} in to avoid triggering a pointless resize event in the Rml code
-				auto context = Rml::CreateContext(name, {0, 0});
+				auto context = RmlGui::GetOrCreateContext(name);
 				if (context != nullptr) {
 					slp->AddContextTracking(context);
 				}
@@ -124,7 +124,7 @@ namespace Rml::SolLua
 			),
 			//"RegisterTag",
 			//--
-			"GetContext", sol::resolve<Rml::Context* (const Rml::String&)>(&Rml::GetContext),
+			"GetContext", sol::resolve<Rml::Context* (const Rml::String&)>(&RmlGui::GetContext),
 			"RegisterEventType", sol::overload(&functions::registerEventType4, &functions::registerEventType3),
 			"AddTranslationString", [translationTable](const Rml::String& key, const Rml::String& translation, sol::this_state s) {
 				return translationTable->addTranslation(key, translation);


### PR DESCRIPTION
context handling improvements

* manage contexts in the "contexts_to_remove" hashset more carefully to prevent use-after-free crash.
* Remove context from removal hashset if it is "recreated" in the same frame.

use ranges::rotate to reorder clicked context

fixes #1832