### PR TITLE
Bump cmake version to 3.27 and fix headless linking to GLEW

### DIFF
--- a/AI/Wrappers/LegacyCpp/CMakeLists.txt
+++ b/AI/Wrappers/LegacyCpp/CMakeLists.txt
@@ -44,16 +44,16 @@ if    (BUILD_${myName}_AIWRAPPER)
 
 	# Assemble the Legacy C++ AI sources
 	set(mySources
-		"${mySourceDir}/AIAI"
-		"${mySourceDir}/AIAICallback"
-		"${mySourceDir}/AIAICheats"
-		"${mySourceDir}/AIGlobalAICallback"
-		"${mySourceDir}/DamageArray"
-		"${mySourceDir}/MoveData"
-		"${mySourceDir}/UnitDef"
-		"${rts}/ExternalAI/AISCommands"
-		"${rts}/Sim/Units/CommandAI/Command"
-		"${rts}/System/float3"
+		"${mySourceDir}/AIAI.cpp"
+		"${mySourceDir}/AIAICallback.cpp"
+		"${mySourceDir}/AIAICheats.cpp"
+		"${mySourceDir}/AIGlobalAICallback.cpp"
+		"${mySourceDir}/DamageArray.cpp"
+		"${mySourceDir}/MoveData.cpp"
+		"${mySourceDir}/UnitDef.cpp"
+		"${rts}/ExternalAI/AISCommands.cpp"
+		"${rts}/Sim/Units/CommandAI/Command.cpp"
+		"${rts}/System/float3.cpp"
 		${ai_common_SRC}
 		)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.27)
 cmake_policy(SET CMP0060 OLD) #causes link errors on Linux otherwise
 cmake_policy(SET CMP0065 OLD) #we need binaries compiled with -rdynamic for BARb to work (cause unknown https://github.com/beyond-all-reason/spring/issues/405)
 

--- a/rts/build/cmake/ConfigureVersion.cmake
+++ b/rts/build/cmake/ConfigureVersion.cmake
@@ -16,7 +16,7 @@
 #	)
 #
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.27)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_MODULES_SPRING}")
 

--- a/rts/lib/lua/CMakeLists.txt
+++ b/rts/lib/lua/CMakeLists.txt
@@ -48,7 +48,7 @@ else ()
 TARGET_LINK_LIBRARIES(lua)
 endif ()
 
-target_link_libraries(lua GLEW::GLEW)
+target_link_libraries(lua $<COMPILE_ONLY:GLEW::GLEW>)
 target_include_directories(lua PUBLIC include)
 
 if (UNIX)

--- a/rts/lib/minizip/CMakeLists.txt
+++ b/rts/lib/minizip/CMakeLists.txt
@@ -13,9 +13,9 @@ else   (MINIZIP_FOUND)
 	# Build our own minizip library
 	
 	set(miniZipSources
-			"unzip"
-			"zip"
-			"ioapi"
+			"unzip.c"
+			"zip.c"
+			"ioapi.c"
 		)
 
 	add_definitions(-DNOCRYPT -DNOUNCRYPT)

--- a/tools/dirchange/CMakeLists.txt
+++ b/tools/dirchange/CMakeLists.txt
@@ -7,5 +7,5 @@
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
-add_executable(dirchange EXCLUDE_FROM_ALL dirchange)
+add_executable(dirchange EXCLUDE_FROM_ALL dirchange.cpp)
 set_target_properties(dirchange PROPERTIES OUTPUT_NAME "dch")


### PR DESCRIPTION
https://github.com/beyond-all-reason/spring/commit/5e604820512b9677a627210ec12537b42b2f47de caused the headless libs to link to the GLEW libraries

While we should use imported targets, for the headless stuff we just want to use the library includes. This PR bumps the cmake version to 3.27 so that we have access to the `COMPILE_ONLY` [generator expression](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#compile-context).

Finally, this PR fixes the issue of linking to GLEW libraries by using this generator expression.