### PR TITLE
Add sample shading for MSAA (better quality)

### DIFF
--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -46,6 +46,7 @@ CONFIG(bool, DebugGLStacktraces).defaultValue(false).description("Create a stack
 CONFIG(int, GLContextMajorVersion).defaultValue(3).minimumValue(3).maximumValue(4);
 CONFIG(int, GLContextMinorVersion).defaultValue(0).minimumValue(0).maximumValue(5);
 CONFIG(int, MSAALevel).defaultValue(0).minimumValue(0).maximumValue(32).description("Enables multisample anti-aliasing; 'level' is the number of samples used.");
+CONFIG(float, MinSampleShadingRate).defaultValue(1.0f).minimumValue(0.0f).maximumValue(1.0f).description("A value of 1.0 indicates that each sample in the framebuffer should be independently shaded. A value of 0.0 effectively allows the GL to ignore sample rate shading. Any value between 0.0 and 1.0 allows the GL to shade only a subset of the total samples within each covered fragment.");
 
 CONFIG(int, ForceDisablePersistentMapping).defaultValue(0).minimumValue(0).maximumValue(1);
 CONFIG(int, ForceDisableExplicitAttribLocs).defaultValue(0).minimumValue(0).maximumValue(1);
@@ -162,6 +163,7 @@ CR_REG_METADATA(CGlobalRendering, (
 	CR_IGNORED(forceSwapBuffers),
 
 	CR_IGNORED(msaaLevel),
+	CR_IGNORED(minSampleShadingRate),
 	CR_IGNORED(maxTextureSize),
 	CR_IGNORED(maxFragShSlots),
 	CR_IGNORED(maxCombShSlots),
@@ -274,6 +276,7 @@ CGlobalRendering::CGlobalRendering()
 
 	// fallback
 	, msaaLevel(configHandler->GetInt("MSAALevel"))
+	, minSampleShadingRate(configHandler->GetFloat("MinSampleShadingRate"))
 	, maxTextureSize(2048)
 	, maxFragShSlots(8)
 	, maxCombShSlots(8)
@@ -1659,6 +1662,14 @@ void CGlobalRendering::InitGLState()
 	// MSAA rasterization
 	msaaLevel *= CheckGLMultiSampling();
 	ToggleMultisampling();
+
+	if(msaaLevel > 0 && minSampleShadingRate > 0.0f) {
+		// Enable sample shading
+		glEnable(GL_SAMPLE_SHADING_ARB);
+		if (GLEW_VERSION_4_0) {
+			glMinSampleShading(minSampleShadingRate); 
+		}
+	}
 
 	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);

--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -46,7 +46,7 @@ CONFIG(bool, DebugGLStacktraces).defaultValue(false).description("Create a stack
 CONFIG(int, GLContextMajorVersion).defaultValue(3).minimumValue(3).maximumValue(4);
 CONFIG(int, GLContextMinorVersion).defaultValue(0).minimumValue(0).maximumValue(5);
 CONFIG(int, MSAALevel).defaultValue(0).minimumValue(0).maximumValue(32).description("Enables multisample anti-aliasing; 'level' is the number of samples used.");
-CONFIG(float, MinSampleShadingRate).defaultValue(1.0f).minimumValue(0.0f).maximumValue(1.0f).description("A value of 1.0 indicates that each sample in the framebuffer should be independently shaded. A value of 0.0 effectively allows the GL to ignore sample rate shading. Any value between 0.0 and 1.0 allows the GL to shade only a subset of the total samples within each covered fragment.");
+CONFIG(float, MinSampleShadingRate).defaultValue(0.0f).minimumValue(0.0f).maximumValue(1.0f).description("A value of 1.0 indicates that each sample in the framebuffer should be independently shaded. A value of 0.0 effectively allows the GL to ignore sample rate shading. Any value between 0.0 and 1.0 allows the GL to shade only a subset of the total samples within each covered fragment.");
 
 CONFIG(int, ForceDisablePersistentMapping).defaultValue(0).minimumValue(0).maximumValue(1);
 CONFIG(int, ForceDisableExplicitAttribLocs).defaultValue(0).minimumValue(0).maximumValue(1);

--- a/rts/Rendering/GlobalRendering.h
+++ b/rts/Rendering/GlobalRendering.h
@@ -222,6 +222,7 @@ public:
 	 * Level of multisample anti-aliasing
 	 */
 	int msaaLevel;
+	float minSampleShadingRate;
 
 	/**
 	 * @brief maxTextureSize


### PR DESCRIPTION
Adds sample shading (needs MSAA to be enabled).

https://registry.khronos.org/OpenGL/extensions/ARB/ARB_sample_shading.txt
https://registry.khronos.org/OpenGL-Refpages/gl4/html/glMinSampleShading.xhtml

Add this to your springsettings.cfg
```
MSAA = 1
MSAALevel = 4
MinSampleShadingRate = 1.0
```

You should immediately notice a lot smoother AA, particularly visible on UI elements. 

Best quality observed with MSAA x4 and minSampleShadingRate to 1.0
MSAA x8 is ridiculously expensive for no perceived added value on my rig.