### PR TITLE
dollycam should respect the los when tracking units

### DIFF
--- a/rts/Game/Camera/DollyController.cpp
+++ b/rts/Game/Camera/DollyController.cpp
@@ -7,6 +7,7 @@
 #include "Game/Camera.h"
 #include "Game/Camera/CameraController.h"
 #include "Game/CameraHandler.h"
+#include "Game/GlobalUnsynced.h"
 #include "Game/UI/MouseHandler.h"
 #include "Map/ReadMap.h"
 #include "Sim/Units/Unit.h"
@@ -109,7 +110,7 @@ void CDollyController::Update()
 		dir = (lookT - pos).Normalize();
 	} else if (lookMode == DOLLY_LOOKMODE_UNIT) {
 		CUnit* unit = unitHandler.GetUnit(lookUnit);
-		if (unit != nullptr) {
+		if (unit != nullptr && unit->IsInLosForAllyTeam(gu->myAllyTeam)) {
 			pos += unit->drawPos * relative;
 			dir = (unit->drawPos - pos).Normalize();
 		}

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -1310,7 +1310,7 @@ int LuaUnsyncedCtrl::SetDollyCameraPosition(lua_State* L)
  *
  * @function Spring.SetDollyCameraCurve
  * @number degree
- * @tparam table cpoints
+ * @tparam table cpoints NURBS control point positions {{x,y,z,weight}, ...}
  * @tparam table knots
  * @treturn nil
  */

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -1263,7 +1263,7 @@ int LuaUnsyncedCtrl::RunDollyCamera(lua_State* L)
 /*** Pause Dolly Camera
  *
  * @function Spring.PauseDollyCamera
- * @number fraction fraction of the total runtime to pause at, 0 to 1 inclusive
+ * @number fraction fraction of the total runtime to pause at, 0 to 1 inclusive. A null value pauses at current percent
  * @treturn nil
  */
 int LuaUnsyncedCtrl::PauseDollyCamera(lua_State* L)
@@ -1364,7 +1364,7 @@ int LuaUnsyncedCtrl::SetDollyCameraRelativeMode(lua_State* L)
  *
  * @function Spring.SetDollyCameraLookCurve
  * @number degree
- * @tparam table cpoints
+ * @tparam table cpoints NURBS control point positions {{x,y,z,weight}, ...}
  * @tparam table knots
  * @treturn nil
  */
@@ -1394,9 +1394,9 @@ int LuaUnsyncedCtrl::SetDollyCameraLookCurve(lua_State* L)
  */
 int LuaUnsyncedCtrl::SetDollyCameraLookPosition(lua_State* L)
 {
-	int x = luaL_checkint(L, 1);
-	int y = luaL_checkint(L, 2);
-	int z = luaL_checkint(L, 3);
+	float x = luaL_checkfloat(L, 1);
+	float y = luaL_checkfloat(L, 2);
+	float z = luaL_checkfloat(L, 3);
 
 	camHandler->GetDollyController().SetLookMode(CDollyController::DOLLY_LOOKMODE_POSITION);
 	camHandler->GetDollyController().SetLookPosition(float3(x, y, z));


### PR DESCRIPTION
dollycam stops tracking enemy units that go out of los, and a couple of other items from #1758