### PR TITLE
Out of map orders leniency

### DIFF
--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -2376,8 +2376,11 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 				const float3 camTraceDir = mouse->buttons[button].dir;
 
 				const float traceDist = camera->GetFarPlaneDist() * 1.4f;
-				const float innerDist = CGround::LineGroundCol(camTracePos, camTracePos + camTraceDir * traceDist, false);
-				      float outerDist = -1.0f;
+				float innerDist = CGround::LineGroundCol(camTracePos, camTracePos + camTraceDir * traceDist, false);
+				float outerDist = -1.0f;
+
+				if (innerDist < 0.0f)
+					innerDist = CGround::LinePlaneCol(camTracePos, camTraceDir, traceDist, CGround::GetWaterPlaneLevel());
 
 				if (innerDist < 0.0f)
 					return defaultRet;
@@ -3592,8 +3595,11 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 						const float3 camTraceDir = mouse->buttons[button].dir;
 
 						const float traceDist = camera->GetFarPlaneDist() * 1.4f;
-						const float innerDist = CGround::LineGroundCol(camTracePos, camTracePos + camTraceDir * traceDist, false);
-						      float outerDist = -1.0f;
+						float innerDist = CGround::LineGroundCol(camTracePos, camTracePos + camTraceDir * traceDist, false);
+						float outerDist = -1.0f;
+
+						if (innerDist < 0.0f)
+							innerDist = CGround::LinePlaneCol(camTracePos, camTraceDir, traceDist, CGround::GetWaterPlaneLevel());
 
 						if (innerDist < 0.0f)
 							break;

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -2379,7 +2379,7 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 				float innerDist = CGround::LineGroundCol(camTracePos, camTracePos + camTraceDir * traceDist, false);
 				float outerDist = -1.0f;
 
-				if (innerDist < 0.0f)
+				if (innerDist < 0.0f) // in case area center is out of map
 					innerDist = CGround::LinePlaneCol(camTracePos, camTraceDir, traceDist, CGround::GetWaterPlaneLevel());
 
 				if (innerDist < 0.0f)
@@ -3598,7 +3598,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 						float innerDist = CGround::LineGroundCol(camTracePos, camTracePos + camTraceDir * traceDist, false);
 						float outerDist = -1.0f;
 
-						if (innerDist < 0.0f)
+						if (innerDist < 0.0f) // in case area center is out of map
 							innerDist = CGround::LinePlaneCol(camTracePos, camTraceDir, traceDist, CGround::GetWaterPlaneLevel());
 
 						if (innerDist < 0.0f)

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -717,9 +717,8 @@ bool CCommandAI::AllowedCommand(const Command& c, bool fromSynced)
 
 			if (!ud->canGuard)
 				return false;
-			if (owner && !owner->pos.IsInBounds())
-				return false;
-			if (guardee && !guardee->pos.IsInBounds())
+			// Allow guarding out of map units only if both are builders to avoid plane hacks.
+			if (guardee && !(guardee->unitDef->IsBuilderUnit() && ud->IsBuilderUnit()) && !guardee->pos.IsInBounds())
 				return false;
 		} break;
 

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -701,6 +701,9 @@ bool CCommandAI::AllowedCommand(const Command& c, bool fromSynced)
 				if (attackee == nullptr)
 					return false;
 			} else {
+				if (c.GetNumParams() > 3 && c.GetParam(3) == 0 && !IsCommandInMap(c))
+					return false; // don't allow direct ground attack out of map
+
 				AdjustGroundAttackCommand(c, fromSynced, aiOrder);
 			}
 		} break;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -714,8 +714,6 @@ bool CCommandAI::AllowedCommand(const Command& c, bool fromSynced)
 				return false;
 		} break;
 		case CMD_GUARD: {
-			const CUnit* guardee = GetCommandUnit(c, 0);
-
 			if (!ud->canGuard)
 				return false;
 		} break;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -701,7 +701,9 @@ bool CCommandAI::AllowedCommand(const Command& c, bool fromSynced)
 				if (attackee == nullptr)
 					return false;
 			} else {
-				if (c.GetNumParams() > 3 && c.GetParam(3) == 0 && !IsCommandInMap(c))
+				const bool isGroundTargeted = (c.GetNumParams() > 3 && c.GetParam(3) == 0)
+							      || c.GetNumParams() == 3;
+				if (isGroundTargeted && !IsCommandInMap(c))
 					return false; // don't allow direct ground attack out of map
 
 				AdjustGroundAttackCommand(c, fromSynced, aiOrder);

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -718,9 +718,6 @@ bool CCommandAI::AllowedCommand(const Command& c, bool fromSynced)
 
 			if (!ud->canGuard)
 				return false;
-			// Allow guarding out of map units only if both are builders to avoid plane hacks.
-			if (guardee && !(guardee->unitDef->IsBuilderUnit() && ud->IsBuilderUnit()) && !guardee->pos.IsInBounds())
-				return false;
 		} break;
 
 		case CMD_PATROL: {

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -640,8 +640,6 @@ bool CCommandAI::AllowedCommand(const Command& c, bool fromSynced)
 	// TODO check if the command is in the map first, for more commands
 	switch (cmdID) {
 		case CMD_MOVE:
-		case CMD_ATTACK:
-		case CMD_AREA_ATTACK:
 		case CMD_RECLAIM:
 		case CMD_REPAIR:
 		case CMD_RESURRECT:
@@ -700,8 +698,6 @@ bool CCommandAI::AllowedCommand(const Command& c, bool fromSynced)
 				const CUnit* attackee = GetCommandUnit(c, 0);
 
 				if (attackee == nullptr)
-					return false;
-				if (!attackee->pos.IsInBounds())
 					return false;
 			} else {
 				AdjustGroundAttackCommand(c, fromSynced, aiOrder);

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -640,6 +640,7 @@ bool CCommandAI::AllowedCommand(const Command& c, bool fromSynced)
 	// TODO check if the command is in the map first, for more commands
 	switch (cmdID) {
 		case CMD_MOVE:
+		case CMD_AREA_ATTACK:
 		case CMD_RECLAIM:
 		case CMD_REPAIR:
 		case CMD_RESURRECT:


### PR DESCRIPTION
### Work Done

* Allow centering area commands out of map.
* Allow attacking out of map units.
* Allow guarding out of map units when both the actor and guardee are builders.

### Related issues

* https://github.com/beyond-all-reason/Beyond-All-Reason/issues/763

### Remarks

* I think these actions are safe and wanted, since not being easy to target out of map units with attacks incentivises out of map attack hacks. Regarding the guard issue it's in the above referenced issue.
* Could have maybe touched some more orders but for now these seem the most pressing.
* Still doesn't allow attack ground out of map (in case someone is wondering).
* Also allowing any out of map unit to issue guard orders, don't see why we shouldn't allow this.