### PR TITLE
Fix linux fontconfig

### DIFF
--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -188,8 +188,7 @@ public:
 		{
 			auto dirs = FcConfigGetCacheDirs(GetFCConfig());
 			FcStrListFirst(dirs);
-			for (FcChar8* dir = FcStrListNext(dirs), *prevDir = nullptr; dir != nullptr && dir != prevDir; ) {
-				prevDir = dir;
+			for (FcChar8* dir = FcStrListNext(dirs); dir != nullptr; dir = FcStrListNext(dirs)) {
 				LOG_MSG("[%s] Using Fontconfig cache dir \"%s\"", false, __func__, dir);
 			}
 			FcStrListDone(dirs);

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -460,7 +460,7 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 
 		if (family)
 			FcPatternAddString(pattern, FC_FAMILY, family);
-		if (foundry && strcmp("UKWN", reinterpret_cast<char*>(foundry)) != 0 && !strcmp("ukwn", reinterpret_cast<char*>(foundry)) != 0)
+		if (foundry && strcmp("UKWN", reinterpret_cast<char*>(foundry)) != 0 && strcmp("ukwn", reinterpret_cast<char*>(foundry)) != 0)
 			FcPatternAddString(pattern, FC_FOUNDRY, foundry);
 	}
 

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -460,7 +460,7 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 
 		if (family)
 			FcPatternAddString(pattern, FC_FAMILY, family);
-		if (foundry)
+		if (foundry && strcmp("UKWN", reinterpret_cast<char*>(foundry)) != 0 && !strcmp("ukwn", reinterpret_cast<char*>(foundry)) != 0)
 			FcPatternAddString(pattern, FC_FOUNDRY, foundry);
 	}
 

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -120,6 +120,7 @@ public:
 				return;
 			}
 
+			FcConfigEnableHome(FcFalse);
 			config = FcInitLoadConfigAndFonts();
 			if (!config)
 				return;

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -292,6 +292,16 @@ bool FtLibraryHandlerProxy::CheckGenFontConfigFull(bool console)
 /*******************************************************************************/
 
 #ifndef HEADLESS
+static bool IsFoundryOkay(std::string_view foundry)
+{
+        /* These foundry codes are defaults from some editors and can make pattern
+	 * search fail to provide proper results on the first items.
+         */
+        if (foundry.starts_with(std::string_view{"UKWN"}) || foundry.starts_with(std::string_view{"ukwn"}))
+                return false;
+        return true;
+}
+
 static inline uint64_t GetKerningHash(char32_t lchar, char32_t rchar)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
@@ -460,7 +470,7 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 
 		if (family)
 			FcPatternAddString(pattern, FC_FAMILY, family);
-		if (foundry && strcmp("UKWN", reinterpret_cast<char*>(foundry)) != 0 && strcmp("ukwn", reinterpret_cast<char*>(foundry)) != 0)
+		if (foundry && IsFoundryOkay(reinterpret_cast<const char*>(foundry)))
 			FcPatternAddString(pattern, FC_FOUNDRY, foundry);
 	}
 

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -182,14 +182,6 @@ public:
 			return false;
 		}
 
-		char osFontsDir[8192];
-
-		#ifdef _WIN32
-			ExpandEnvironmentStrings("%WINDIR%\\fonts", osFontsDir, sizeof(osFontsDir)); // expands %HOME% etc.
-		#else
-			strncpy(osFontsDir, "/etc/fonts/", sizeof(osFontsDir));
-		#endif
-
 		FcConfigAppFontClear(GetFCConfig());
 		FcConfigAppFontAddDir(GetFCConfig(), reinterpret_cast<const FcChar8*>("fonts"));
 
@@ -204,11 +196,11 @@ public:
 		}
 
 		if (FtLibraryHandler::CheckFontConfig()) {
-			LOG_MSG("[%s] fontconfig for directory \"%s\" up to date", false, __func__, osFontsDir);
+			LOG_MSG("[%s] fontconfig up to date", false, __func__);
 			return true;
 		}
 
-		LOG_MSG("[%s] creating fontconfig for directory \"%s\"", false, __func__, osFontsDir);
+		LOG_MSG("[%s] creating fontconfig", false, __func__);
 
 		return FcConfigBuildFonts(GetFCConfig());
 	#endif

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -292,16 +292,6 @@ bool FtLibraryHandlerProxy::CheckGenFontConfigFull(bool console)
 /*******************************************************************************/
 
 #ifndef HEADLESS
-static bool IsFoundryOkay(std::string_view foundry)
-{
-        /* These foundry codes are defaults from some editors and can make pattern
-	 * search fail to provide proper results on the first items.
-         */
-        if (foundry.starts_with(std::string_view{"UKWN"}) || foundry.starts_with(std::string_view{"ukwn"}))
-                return false;
-        return true;
-}
-
 static inline uint64_t GetKerningHash(char32_t lchar, char32_t rchar)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
@@ -436,7 +426,6 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 		FcBool outline = FcFalse;
 
 		FcChar8* family = nullptr;
-		FcChar8* foundry = nullptr;
 
 		const FcChar8* ftname = reinterpret_cast<const FcChar8*>("not used");
 
@@ -457,7 +446,6 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 			FcPatternGetDouble( origPattern, FC_PIXEL_SIZE, 0, &pixelSize);
 
 			FcPatternGetString( origPattern, FC_FAMILY , 0, &family );
-			FcPatternGetString( origPattern, FC_FOUNDRY, 0, &foundry);
 
 		}
 
@@ -470,8 +458,6 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 
 		if (family)
 			FcPatternAddString(pattern, FC_FAMILY, family);
-		if (foundry && IsFoundryOkay(reinterpret_cast<const char*>(foundry)))
-			FcPatternAddString(pattern, FC_FOUNDRY, foundry);
 	}
 
 	FcDefaultSubstitute(pattern);

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -120,7 +120,7 @@ public:
 				return;
 			}
 
-			config = FcConfigCreate();
+			config = FcInitLoadConfigAndFonts();
 			if (!config)
 				return;
 
@@ -192,7 +192,6 @@ public:
 
 		FcConfigAppFontClear(GetFCConfig());
 		FcConfigAppFontAddDir(GetFCConfig(), reinterpret_cast<const FcChar8*>("fonts"));
-		FcConfigAppFontAddDir(GetFCConfig(), reinterpret_cast<const FcChar8*>(osFontsDir));
 
 		{
 			auto dirs = FcConfigGetCacheDirs(GetFCConfig());


### PR DESCRIPTION
### Work done

* Fix linux fontconfig initialization and fallback mechanisms.
* Initialize config with FcConfigEnableHome(false) and FcInitLoadConfigAndFonts. This way system configuration is automatically loaded both on linux and windows and we won't write in user folders out of the spring dir.
* Don't load osFontsDir with FcConfigAppFontAddDir.
* Remove foundry from search pattern since that confuses the search.
* ~~Filter out UKWN and ukwn foundries.~~

### Remarks

* The way to init config I believe should be more robust on windows too, but someone will have to test it to see if it actually works.
  * Loading system config can be done later on at CheckGenFontConfigFull, but that requires more changes like loading /etc/fonts/fonts.conf with FtConfigParseAndLoad and removing the CheckFontConfig there as otherwise FcConfigBuildFonts won't get called.
  * The proposed method works on windows too, and looks much cleaner.
* Regarding the foundry filter, at least here, it's not finding requested glyphs (at least in first matches) when that is set. We could just filter out "UKWN" and "ukwn" and make it work but removing it was deemed better here. I know fontconfig should be returning matching fonts in order of priority filters, but somehow that's breaking it completely. Those foundries are defaults from some programs and totally not recommended to have inside font files.

### Related issues

* https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3088
* https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3884
* https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3925

All these issues are somehow related, at least they are badly affecting linux since it's not loading system fonts at all atm, although just the fixes here may not fix them for everyone as that depends on system fonts. With the proposed changes now emojis and glyphs from 3925 work here (i had to install noto font in ubuntu 24 though).

Looks like on windows also #3925 is solved with this PR, otherwise fontconfig wouldn't find the glyphs even when present in the system. Not sure if this is because of the new initialization method or because of removing the foundry though, this would have to be checked by someone on windows.

The ZorinOS bug is a bit weird but might be related to trying to load /etc/fonts using FcConfigAppFontAddDir on an old distro, since that's not the intended way to use the method. Looks like the method is for loading actual font files from a directory, but /etc/fonts holds config files.

Imo fixing missing emojis can be fixed by distributing NotoEmoji-VariableFont_wght.ttf, glyphs, for https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3925 I found at NotoSansSymbols2-Regular.ttf (1f81a) and DejaVuSerif.ttf (1F525). All our provided fonts inside fonts/ should be loaded and used if the user misses glyphs. I know this is maybe more of a game issue and I can propose including and loading them there to bar. Then how to prioritize app provided fonts can be looked into but imo it should be feasible (there's some talks about this at https://github.com/beyond-all-reason/spring/issues/537).

