### PR TITLE
Add DEBUG_DRAW_QUADFIELD to draw some quadfield related helpers.

### DIFF
--- a/rts/Game/SelectedUnitsHandler.cpp
+++ b/rts/Game/SelectedUnitsHandler.cpp
@@ -712,7 +712,7 @@ void CSelectedUnitsHandler::Draw()
 	glDepthMask(true);
 	glEnable(GL_TEXTURE_2D);
 
-	#ifdef DEBUG_QUADFIELD
+	#ifdef DEBUG_DRAW_QUADFIELD
 	const float4 quadColor = {0.4, 1.0, 0.4, 1.0};
 	for (const int unitID: selectedUnits) {
 		const CUnit* su = unitHandler.GetUnit(unitID);
@@ -720,7 +720,7 @@ void CSelectedUnitsHandler::Draw()
 			quadField.DrawQuad(qIdx, quadColor);
 		}
 	}
-	#endif
+	#endif // DEBUG_DRAW_QUADFIELD
 }
 
 

--- a/rts/Game/SelectedUnitsHandler.cpp
+++ b/rts/Game/SelectedUnitsHandler.cpp
@@ -711,6 +711,16 @@ void CSelectedUnitsHandler::Draw()
 	glEnable(GL_DEPTH_TEST);
 	glDepthMask(true);
 	glEnable(GL_TEXTURE_2D);
+
+	#ifdef DEBUG_QUADFIELD
+	const float4 quadColor = {0.4, 1.0, 0.4, 1.0};
+	for (const int unitID: selectedUnits) {
+		const CUnit* su = unitHandler.GetUnit(unitID);
+		for(const int qIdx: su->quads) {
+			quadField.DrawQuad(qIdx, quadColor);
+		}
+	}
+	#endif
 }
 
 

--- a/rts/Game/TraceRay.cpp
+++ b/rts/Game/TraceRay.cpp
@@ -411,6 +411,10 @@ float GuiTraceRay(
 	for (const int quadIdx: *qfQuery.quads) {
 		const CQuadField::Quad& quad = quadField.GetQuad(quadIdx);
 
+		#ifdef DEBUG_QUADFIELD
+		quadField.DrawQuad(quadIdx, {1.0, 1.0, 1.0, 1.0});
+		#endif
+
 		// Unit Intersection
 		for (const CUnit* u: quad.units) {
 			const bool unitIsEnemy = !teamHandler.Ally(u->allyteam, gu->myAllyTeam);

--- a/rts/Game/TraceRay.cpp
+++ b/rts/Game/TraceRay.cpp
@@ -411,7 +411,7 @@ float GuiTraceRay(
 	for (const int quadIdx: *qfQuery.quads) {
 		const CQuadField::Quad& quad = quadField.GetQuad(quadIdx);
 
-		#ifdef DEBUG_QUADFIELD
+		#ifdef DEBUG_DRAW_QUADFIELD
 		quadField.DrawQuad(quadIdx, {1.0, 1.0, 1.0, 1.0});
 		#endif
 

--- a/rts/Sim/Misc/QuadField.cpp
+++ b/rts/Sim/Misc/QuadField.cpp
@@ -20,6 +20,11 @@
 
 #include "System/Misc/TracyDefs.h"
 
+#ifdef DEBUG_QUADFIELD
+	#include "Rendering/LineDrawer.h"
+	#include "Map/Ground.h"
+#endif
+
 CR_BIND(CQuadField, )
 CR_REG_METADATA(CQuadField, (
 	CR_MEMBER(baseQuads),
@@ -943,4 +948,26 @@ void CQuadField::GetUnitsAndFeaturesColVol(
 		}
 	}
 }
+
+#ifdef DEBUG_QUADFIELD
+void QuadField::DrawQuad(unsigned i, const float4 color) {
+	const int qx = i % numQuadsX;
+	const int qz = i / numQuadsX;
+
+	const float x_0 = qx * quadSizeX;
+	const float y_0 = qz * quadSizeZ;
+	const float x_1 = x_0 + quadSizeX;
+	const float y_1 = y_0 + quadSizeZ;
+
+	const float h = CGround::GetHeightReal((x_0 + x_1) / 2.0, (y_0 + y_1) / 2.0, false);
+
+	lineDrawer.StartPath({x0, h, y0}, color);
+	lineDrawer.DrawLine({x1, h, y0}, color);
+	lineDrawer.DrawLine({x1, h, y1}, color);
+	lineDrawer.DrawLine({x0, h, y1}, color);
+	lineDrawer.DrawLine({x0, h, y0}, color);
+	lineDrawer.FinishPath();
+}
+#endif // DEBUG_QUADFIELD
+
 #endif // UNIT_TEST

--- a/rts/Sim/Misc/QuadField.cpp
+++ b/rts/Sim/Misc/QuadField.cpp
@@ -20,7 +20,7 @@
 
 #include "System/Misc/TracyDefs.h"
 
-#ifdef DEBUG_QUADFIELD
+#ifdef DEBUG_DRAW_QUADFIELD
 	#include "Rendering/LineDrawer.h"
 	#include "Map/Ground.h"
 #endif
@@ -949,7 +949,7 @@ void CQuadField::GetUnitsAndFeaturesColVol(
 	}
 }
 
-#ifdef DEBUG_QUADFIELD
+#ifdef DEBUG_DRAW_QUADFIELD
 void QuadField::DrawQuad(unsigned i, const float4 color) {
 	const int qx = i % numQuadsX;
 	const int qz = i / numQuadsX;
@@ -968,6 +968,6 @@ void QuadField::DrawQuad(unsigned i, const float4 color) {
 	lineDrawer.DrawLine({x0, h, y0}, color);
 	lineDrawer.FinishPath();
 }
-#endif // DEBUG_QUADFIELD
+#endif // DEBUG_DRAW_QUADFIELD
 
 #endif // UNIT_TEST

--- a/rts/Sim/Misc/QuadField.h
+++ b/rts/Sim/Misc/QuadField.h
@@ -234,9 +234,9 @@ public:
 
 	constexpr static unsigned int BASE_QUAD_SIZE = 128;
 
-#ifdef DEBUG_QUADFIELD
+#ifdef DEBUG_DRAW_QUADFIELD
 	void DrawQuad(unsigned i, const float4 color);
-#endif
+#endif // DEBUG_DRAW_QUADFIELD
 
 private:
 	int2 WorldPosToQuadField(const float3 p) const;

--- a/rts/Sim/Misc/QuadField.h
+++ b/rts/Sim/Misc/QuadField.h
@@ -234,6 +234,10 @@ public:
 
 	constexpr static unsigned int BASE_QUAD_SIZE = 128;
 
+#ifdef DEBUG_QUADFIELD
+	void DrawQuad(unsigned i, const float4 color);
+#endif
+
 private:
 	int2 WorldPosToQuadField(const float3 p) const;
 	int WorldPosToQuadFieldIdx(const float3 p) const;


### PR DESCRIPTION
### Work done

* Draw quads related to selected unit and GuiTraceRay.
* Add DEBUG_DRAW_QUADFIELD to control aforementioned drawing.

### Remarks

* Helps in debugging https://github.com/beyond-all-reason/spring/pull/1764 and https://github.com/beyond-all-reason/spring/pull/1754.
* I preferred doing a compile option since this way we can draw directly inside the loop GuiTraceRay without (normal use) overhead, with config option it would be too many tests imo.
* Could all be moved to use a separate module and use /debug_quads command or similar. The drawback is then we need to replicate some GuiTraceRay code in order to replicate and draw quads in use there.
* Not really needed but thought you might want this, otherwise it can serve as reference here.

I'm also myself using the following snippet inside the quad+units loop in GuiTraceRay to draw line from unit midpos to it's radar dot, but not sure it fits here:

```LUA
float4 errColor = {8.0, 0.2, 0.2, 0.2};
lineDrawer.StartPath(u->GetErrorPos(gu->myAllyTeam), errColor);
lineDrawer.DrawLine(u->midPos, errColor);
lineDrawer.FinishPath();
```
