### PR TITLE
Mechanism to define priority fallback fonts

### DIFF
--- a/rts/Lua/LuaFonts.cpp
+++ b/rts/Lua/LuaFonts.cpp
@@ -221,8 +221,8 @@ int LuaFonts::AddFallbackFont(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 
-	const bool f = CFontTexture::AddFallbackFont(luaL_checkstring(L, 1));
-	lua_pushboolean(L, f);
+	const bool res = CFontTexture::AddFallbackFont(luaL_checkstring(L, 1));
+	lua_pushboolean(L, res);
 	return 1;
 }
 

--- a/rts/Lua/LuaFonts.cpp
+++ b/rts/Lua/LuaFonts.cpp
@@ -25,6 +25,8 @@ bool LuaFonts::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(LoadFont);
 	REGISTER_LUA_CFUNC(DeleteFont);
+	REGISTER_LUA_CFUNC(AddFallbackFont);
+	REGISTER_LUA_CFUNC(ClearFallbackFonts);
 
 	return true;
 }
@@ -205,6 +207,22 @@ int LuaFonts::DeleteFont(lua_State* L)
 	return meta_gc(L);
 }
 
+int LuaFonts::AddFallbackFont(lua_State* L)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+
+	const bool f = CFontTexture::AddFallbackFont(luaL_checkstring(L, 1));
+	lua_pushboolean(L, f);
+	return 1;
+}
+
+int LuaFonts::ClearFallbackFonts(lua_State* L)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+
+	CFontTexture::ClearFallbackFonts();
+	return 0;
+}
 
 /******************************************************************************/
 /******************************************************************************/

--- a/rts/Lua/LuaFonts.cpp
+++ b/rts/Lua/LuaFonts.cpp
@@ -207,6 +207,16 @@ int LuaFonts::DeleteFont(lua_State* L)
 	return meta_gc(L);
 }
 
+/*** Adds a fallback font for the font rendering engine.
+ *
+ * Fonts added first will have higher priority.
+ * When a glyph isn't found when rendering a font, the fallback fonts
+ * will be searched first, otherwise os fonts will be used.
+ *
+ * @function gl.AddFallbackFont
+ * @string filePath VFS path to the file, for example "fonts/myfont.ttf"
+ * @treturn bool success
+ */
 int LuaFonts::AddFallbackFont(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
@@ -216,6 +226,11 @@ int LuaFonts::AddFallbackFont(lua_State* L)
 	return 1;
 }
 
+/*** Clears all fallback fonts.
+ *
+ * @function gl.ClearFallbackFonts
+ * @treturn nil
+ */
 int LuaFonts::ClearFallbackFonts(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Lua/LuaFonts.h
+++ b/rts/Lua/LuaFonts.h
@@ -22,6 +22,8 @@ class LuaFonts {
 	private: // call-outs
 		static int LoadFont(lua_State* L);
 		static int DeleteFont(lua_State* L);
+		static int AddFallbackFont(lua_State* L);
+		static int ClearFallbackFonts(lua_State* L);
 
 	private: // userdata call-outs
 		static int Print(lua_State* L);

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -747,7 +747,7 @@ void CFontTexture::ClearFallbackFonts()
 {
 #if defined(USE_FONTCONFIG) && !defined(HEADLESS)
 	if (!FtLibraryHandler::UseFontConfig())
-		return false;
+		return;
 
 	FtLibraryHandler::ClearFallbackPattern();
 	FtLibraryHandler::ClearGameFontSet();

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -149,8 +149,12 @@ public:
 			return;
 
 		FcConfigDestroy(config);
-		FcFontSetDestroy(gameFontSet);
-		FcPatternDestroy(fallbackPattern);
+		if (gameFontSet) {
+			FcFontSetDestroy(gameFontSet);
+		}
+		if (fallbackPattern) {
+			FcPatternDestroy(fallbackPattern);
+		}
 		FcFini();
 		config = nullptr;
 		#endif

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -690,6 +690,9 @@ CFontTexture::~CFontTexture()
 bool CFontTexture::AddFallbackFont(const std::string& fontfile)
 {
 #if defined(USE_FONTCONFIG) && !defined(HEADLESS)
+	if (!FtLibraryHandler::UseFontConfig())
+		return false;
+
 	FcFontSet *set = FtLibraryHandler::GetGameFontSet();
 
 	// Check if font already loaded
@@ -743,6 +746,9 @@ bool CFontTexture::AddFallbackFont(const std::string& fontfile)
 void CFontTexture::ClearFallbackFonts()
 {
 #if defined(USE_FONTCONFIG) && !defined(HEADLESS)
+	if (!FtLibraryHandler::UseFontConfig())
+		return false;
+
 	FtLibraryHandler::ClearFallbackPattern();
 	FtLibraryHandler::ClearGameFontSet();
 #endif

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -681,7 +681,7 @@ CFontTexture::~CFontTexture()
 bool CFontTexture::AddFallbackFont(const std::string& fontfile)
 {
 #if defined(USE_FONTCONFIG) && !defined(HEADLESS)
-	if (!FtLibraryHandler::UseFontConfig())
+	if (!FtLibraryHandler::CanUseFontConfig())
 		return false;
 
 	FcFontSet *set = FtLibraryHandler::GetGameFontSet();
@@ -737,7 +737,7 @@ bool CFontTexture::AddFallbackFont(const std::string& fontfile)
 void CFontTexture::ClearFallbackFonts()
 {
 #if defined(USE_FONTCONFIG) && !defined(HEADLESS)
-	if (!FtLibraryHandler::UseFontConfig())
+	if (!FtLibraryHandler::CanUseFontConfig())
 		return;
 
 	FtLibraryHandler::ClearFallbackPattern();

--- a/rts/Rendering/Fonts/CFontTexture.h
+++ b/rts/Rendering/Fonts/CFontTexture.h
@@ -113,6 +113,8 @@ public:
 	static void InitFonts();
 	static void KillFonts();
 	static void Update();
+	static bool AddFallbackFont(const std::string& fontfile);
+	static void ClearFallbackFonts();
 
 	inline static spring::WrappedSyncRecursiveMutex sync = {};
 protected:


### PR DESCRIPTION
This PR is for reference only, I think it's better to merge https://github.com/beyond-all-reason/spring/pull/1790 directly (this PR also contained there).

### Work done

* Introduce lua AddFallbackFont(vfspath) and ClearFallbackFonts().
* Backend at CFontTexture::AddFallbackFont and CFontTexture::ClearFallbackFonts.

### Related issues

* https://github.com/beyond-all-reason/spring/issues/537
* https://github.com/beyond-all-reason/spring/issues/381
* https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3088
* https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3925
* https://github.com/beyond-all-reason/Beyond-All-Reason/issues/974

While this PR won't directly fix all of the above, the proposed mechanism will allow fixing all those easily by having games providing priority fallback fonts for languages and emojis, and using the proposed api.

### Testing

* Get this bar branch [test-fallback-fonts](https://github.com/saurtron/Beyond-All-Reason/tree/test-fallback-fonts) into your BAR.sdd
   * This branch has functionality for enabling/disabling one fallback through mouse left click, and also runs an automatic procedure to write into chat and enable/disable fallbacks.
* Open skirmish
* Once it starts, the test widget will automatically run the following procedure:
  * Write something into chat, like: "blah🔥" (at frame 3)
    * it will use your os fallback
  * Enable fallbacks and write into chat (at frame 150)
    * should say "Fallback fonts, true"
    * The fire glyph should change to the provided font
  * Disable fallbacks and write into chat (at frame 450)
    * should say "Fallback fonts, false" 
    * The fire glyph should change to the os font again

You will notice disabling doesn't really work well, for the branch where fallbacks are enabled and disabled, use this branch instead: https://github.com/beyond-all-reason/spring/pull/1790

You can further play with it by using left mouse button to enable/disable fallback, and writing your own characters into chat.

### Discussion

* I added the lua methods inside Lua/LuaFonts.cpp as that seems to be the best place, only drawback is it results in methods being under `gl.` namespace which is a bit awkward maybe.
* While the mechanism is simple I think this will suffice for application needs.
  * Applications can use the api like gl.AddFallbackFont("font/NotoEmoji-VariableFont_wght.ttf") to add fallbacks, priority will be the same as order of fallback addition.
  * Allow to ClearFallbackFonts just in case.
  * Note gl.LoadFont doesn't currently add fonts to gameFonts, this is on purpose as right now we don't need those included in fontconfig listings, at least not for this PR. The idea is the game will be using a specific font for render in different places, and having all the fallbacks "for free" with every font.
* Can be made more sophisticated on top of this implementation:
  * For example could allow declaring priority fallback fonts just for certain families or languages, but I believe this isn't really needed atm.
  * Can be expanded later by including more parameters to AddFallbackFont.
* I strive to use safe fontconfig mechanisms that work well with the library:
  * While it's possible to add font definition patterns to the fontconfig application list through [FcConfigGetFonts](https://fontconfig.pages.freedesktop.org/fontconfig/fontconfig-devel/#FCCONFIGGETFONTS), this is not recommended: "This font set is owned by the library and must not be modified or freed."
    * We need this since the allowed methods FcConfigAppFontAddDir and FcConfigAppFontAddFile work with actual fs paths, but we need to load from VFS.
    * I'm using our own set `gameFontSet`, first searching on it with FcFontSetSort, and then falling back to FcFontSort to search system fonts, this allows having our own set in addition to the fontconfig ones with minimal changes.
    * The documentation is not very clear here, and "must not be modified" may not mean we can't add patterns to the set, but it might so safest to have our own separate set imo.
  * We could use xml priority matches as described [here](https://github.com/beyond-all-reason/spring/issues/537#issuecomment-2480494965), but that doesn't allow us to clear the prioritization, and also according to documentation for [FcConfigBuildFonts](https://fontconfig.pages.freedesktop.org/fontconfig/fontconfig-devel/#FCCONFIGBUILDFONTS): "Note that any changes to the configuration after this call (through FcConfigParseAndLoad or FcConfigParseAndLoadFromMemory) have indeterminate effects"
    * I'm using a default pattern with priority font families prepended instead `fallbackPattern`, this seems to work fine.
  * There's one thing I'm not sure about, you may have noticed the commented method: `FcConfigSubstitute(FtLibraryHandler::GetFCConfig(), pattern, FcMatchScan)` after adding the font to our set. I see the library doing this when it adds fonts through FcConfigAppFontAddFile, but tbh have no idea if it's actually needed in this case, on my tests it doesn't seem to help or hurt.
* I have respected USE_FONTCONFIG #ifdefs and added my own to maintain compatibility, but I think that's broken atm since FcConfig *config pointer isn't protected by an #ifdef. I believe we might actually want to remove the USE_FONTCONFIG ifdefs.
* ~~Not sure where the documentation for the lua methods should go, I don't see it for LoadFonts or DeleteFont, I'll take a look.~~ Added ldoc, will keep an eye for https://github.com/beyond-all-reason/spring/pull/1775
* This should avoid needing Luaui reload when changing fallbacks, but ClearFallbackFonts might want to do some atlas cleaning after being called.
* We might also want to add system priority fonts by family name for fonts everyone should have in order to avoid distribution by games. This is possible but not sure really needed atm since it's always going to be more fragile due to users not actually having the fonts. If wanted a new method AddSystemFallbackFont(familyname) could be added.

### More notes on testing

(for a direct procedure see "Testing" above)

The general procedure is finding a few characters you know render different on your os and some other font. Try without the fallback, then try with fallbacks.

- Make sure you have this branch.
- Add the font to BAR.sdd/fonts/.
- Call  gl.AddFallbackFont("fonts/XXXXX") in some widget you know will be loaded, like advplayerslist.
- I'm using font/NotoEmoji-VariableFont_wght.ttf and FreeSerif.otf with the "🔥" character.
- Also DejaVuSerif.ttf and NotoSansMono-Bold.ttf with "⟵".

fc-list or some similar program can be used to list fonts your os has with some character, like: `fc-list :charset=27f5`, `fc-list :charset=1f81a` or `fc-list :charset=1F525`.