### PR TITLE
GuiTraceRay from theater ray intersection instead of camera position.

### DIFF
--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -796,7 +796,7 @@ float3 CCamera::NearTheaterIntersection(const float3& dir, const float rayLength
 	// vertical plane from frustum intersection to max height
 	const float3 p = fv1;
 	const float3 norm = midFv-pos;
-	const float d = -(norm.x*p.x+norm.y*p.y+norm.z*p.z);
+	const auto d = -norm.dot(p);
 	const float4 nearTheaterPlane = float4(norm.x, norm.y, norm.z, d);
 
 	// intersection

--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -13,6 +13,7 @@
 #include "System/float3.h"
 #include "System/Matrix44f.h"
 #include "System/Config/ConfigHandler.h"
+#include "Sim/Features/FeatureHandler.h"
 #include "Sim/Units/UnitHandler.h"
 
 #include "System/Misc/TracyDefs.h"
@@ -787,7 +788,8 @@ bool CCamera::TracePointToMaxAltitude(const float3& point, const float rayLength
 
 float3 CCamera::NearTheaterIntersection(const float3& dir, const float rayLength) const
 {
-	const float maxAltitude = std::max(unitHandler.MaxUnitAltitude(), readMap->GetCurrMaxHeight());
+	float maxAltitude = std::max(unitHandler.MaxUnitAltitude(), readMap->GetCurrMaxHeight());
+	maxAltitude = std::max(maxAltitude, featureHandler.MaxFeatureAltitude());
 	if (pos.y < maxAltitude)
 		return pos;
 

--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -800,7 +800,7 @@ float3 CCamera::NearTheaterIntersection(const float3& dir, const float rayLength
 	const auto ftl = GetFrustumVert(CCamera::FRUSTUM_POINT_FTL);
 
 	// check the bottom frustum is parallel to ground and lower than the top frustum
-	if ((std::abs(fbl.y-fbr.y) > std::numeric_limits<float>::epsilon()) || (fbl.y >= ftl.y))
+	if ((std::abs(fbl.y-fbr.y) > std::abs(fbl.y/100000.0)) || (fbl.y >= ftl.y))
 		return pos;
 
 	const auto fv1 = TracePointToMaxAltitude(fbl, rayLength, maxAltitude);

--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -774,7 +774,7 @@ float3 CCamera::GetMoveVectorFromState(bool fromKeyState) const
 	return v;
 }
 
-float3 CCamera::PointToMaxUnitAltitude(const float3& point, const float rayLength, const float maxAltitude)
+float3 CCamera::PointToMaxUnitAltitude(const float3& point, const float rayLength, const float maxAltitude) const
 {
 	const float3 dir = (point-pos).Normalize();
 	float dist = CGround::LinePlaneCol(pos, dir, rayLength, maxAltitude);
@@ -783,7 +783,7 @@ float3 CCamera::PointToMaxUnitAltitude(const float3& point, const float rayLengt
 	return point;
 }
 
-float3 CCamera::NearTheaterIntersection(const float3& dir, const float rayLength)
+float3 CCamera::NearTheaterIntersection(const float3& dir, const float rayLength) const
 {
 	const float maxAltitude = std::max(unitHandler.MaxUnitAltitude(), readMap->GetCurrMaxHeight());
 	if (pos.y < maxAltitude)
@@ -800,10 +800,10 @@ float3 CCamera::NearTheaterIntersection(const float3& dir, const float rayLength
 	const float4 nearTheaterPlane = float4(norm.x, norm.y, norm.z, d);
 
 	// intersection
-	float3 xpos;
-	const bool res = RayAndPlaneIntersection(pos, pos+dir*rayLength, nearTheaterPlane, false, xpos);
+	float3 intersection;
+	const bool res = RayAndPlaneIntersection(pos, pos+dir*rayLength, nearTheaterPlane, false, intersection);
 	if (res)
-		return xpos;
+		return intersection;
 	return pos;
 }
 

--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -793,7 +793,7 @@ float3 CCamera::NearTheaterIntersection(const float3& dir, const float rayLength
 	// vertical plane from frustum intersection to max height
 	const float3 p = fv1;
 	const float3 norm = midFv-pos;
-	const float d = -(norm.x+p.x+norm.y*p.y+norm.z*p.z);
+	const float d = -(norm.x*p.x+norm.y*p.y+norm.z*p.z);
 	const float4 nearTheaterPlane = float4(norm.x, norm.y, norm.z, d);
 
 	// intersection

--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -795,8 +795,16 @@ float3 CCamera::NearTheaterIntersection(const float3& dir, const float rayLength
 	if (pos.y < maxAltitude)
 		return pos;
 
-	const auto fv1 = TracePointToMaxAltitude(GetFrustumVert(CCamera::FRUSTUM_POINT_FBL), rayLength, maxAltitude);
-	const auto fv2 = TracePointToMaxAltitude(GetFrustumVert(CCamera::FRUSTUM_POINT_FBR), rayLength, maxAltitude);
+	const auto fbl = GetFrustumVert(CCamera::FRUSTUM_POINT_FBL);
+	const auto fbr = GetFrustumVert(CCamera::FRUSTUM_POINT_FBR);
+	const auto ftl = GetFrustumVert(CCamera::FRUSTUM_POINT_FTL);
+
+	// check the bottom frustum is parallel to ground and lower than the top frustum
+	if ((std::abs(fbl.y-fbr.y) > std::numeric_limits<float>::epsilon()) || (fbl.y >= ftl.y))
+		return pos;
+
+	const auto fv1 = TracePointToMaxAltitude(fbl, rayLength, maxAltitude);
+	const auto fv2 = TracePointToMaxAltitude(fbr, rayLength, maxAltitude);
 	if (!fv1 || !fv2)
 		return pos;
 

--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -818,10 +818,16 @@ float3 CCamera::NearTheaterIntersection(const float3& dir, const float rayLength
 	const float4 nearTheaterPlane = float4(norm.x, norm.y, norm.z, d);
 
 	// intersection
-	float3 intersection;
-	const bool res = RayAndPlaneIntersection(pos, pos+dir*rayLength, nearTheaterPlane, false, intersection);
-	if (res)
-		return intersection;
+	float3 rayIntersection;
+	float3 topFrustumIntersection;
+
+	// both the ray and cam to ftl need to intersect the plane to make sure we're not looking down, in that
+	// case results wouldn't be correct and also we wouldn't gain anything.
+	const bool rayRes = RayAndPlaneIntersection(pos, pos+dir*rayLength, nearTheaterPlane, false, rayIntersection);
+	const bool tfRes = RayAndPlaneIntersection(pos, ftl, nearTheaterPlane, false, topFrustumIntersection);
+	if (rayRes && tfRes) {
+		return rayIntersection;
+	}
 	return pos;
 }
 

--- a/rts/Game/Camera.h
+++ b/rts/Game/Camera.h
@@ -221,7 +221,7 @@ public:
 		return (forward.dot(objPos - pos));
 	}
 
-	float3 PointToMaxUnitAltitude(const float3& point, const float rayLength, const float maxAltitude) const;
+	bool TracePointToMaxAltitude(const float3& point, const float rayLength, const float maxAltitude, float3& result) const;
 	float3 NearTheaterIntersection(const float3& dir, const float rayLength) const;
 
 	/*

--- a/rts/Game/Camera.h
+++ b/rts/Game/Camera.h
@@ -221,7 +221,7 @@ public:
 		return (forward.dot(objPos - pos));
 	}
 
-	bool TracePointToMaxAltitude(const float3& point, const float rayLength, const float maxAltitude, float3& result) const;
+	std::optional<float3> TracePointToMaxAltitude(const float3& point, const float rayLength, const float maxAltitude) const;
 	float3 NearTheaterIntersection(const float3& dir, const float rayLength) const;
 
 	/*

--- a/rts/Game/Camera.h
+++ b/rts/Game/Camera.h
@@ -221,6 +221,9 @@ public:
 		return (forward.dot(objPos - pos));
 	}
 
+	float3 PointToMaxUnitAltitude(const float3& point), const float rayLength;
+	float3 NearTheaterIntersection(const float3& dir, const float rayLength);
+
 	/*
 	float ProjectedDistanceShadow(const float3& objPos, const float3& sunDir) const {
 		// FIXME: fix it, cap it for shallow shadows?

--- a/rts/Game/Camera.h
+++ b/rts/Game/Camera.h
@@ -221,7 +221,7 @@ public:
 		return (forward.dot(objPos - pos));
 	}
 
-	float3 PointToMaxUnitAltitude(const float3& point, const float rayLength);
+	float3 PointToMaxUnitAltitude(const float3& point, const float rayLength, const float maxAltitude);
 	float3 NearTheaterIntersection(const float3& dir, const float rayLength);
 
 	/*

--- a/rts/Game/Camera.h
+++ b/rts/Game/Camera.h
@@ -221,8 +221,8 @@ public:
 		return (forward.dot(objPos - pos));
 	}
 
-	float3 PointToMaxUnitAltitude(const float3& point, const float rayLength, const float maxAltitude);
-	float3 NearTheaterIntersection(const float3& dir, const float rayLength);
+	float3 PointToMaxUnitAltitude(const float3& point, const float rayLength, const float maxAltitude) const;
+	float3 NearTheaterIntersection(const float3& dir, const float rayLength) const;
 
 	/*
 	float ProjectedDistanceShadow(const float3& objPos, const float3& sunDir) const {

--- a/rts/Game/Camera.h
+++ b/rts/Game/Camera.h
@@ -221,7 +221,7 @@ public:
 		return (forward.dot(objPos - pos));
 	}
 
-	float3 PointToMaxUnitAltitude(const float3& point), const float rayLength;
+	float3 PointToMaxUnitAltitude(const float3& point, const float rayLength);
 	float3 NearTheaterIntersection(const float3& dir, const float rayLength);
 
 	/*

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -1156,7 +1156,7 @@ bool CGuiHandler::TryTarget(const SCommandDescription& cmdDesc) const
 
 	const float viewRange = camera->GetFarPlaneDist() * 1.4f;
 	const float3 rayOrigin = camera->NearTheaterIntersection(mouse->dir, viewRange);
-	const float dist = TraceRay::GuiTraceRay(rayOrigin, mouse->dir, viewRange, NULL, targetUnit, targetFeature, true);
+	const float dist = TraceRay::GuiTraceRay(rayOrigin, mouse->dir, viewRange, nullptr, targetUnit, targetFeature, true);
 	const float3 groundPos = rayOrigin + mouse->dir * dist;
 
 	if (dist <= 0.0f)
@@ -2354,7 +2354,7 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 				const CFeature* feature = nullptr;
 				const float viewRange = camera->GetFarPlaneDist() * 1.4f;
 				const float3 rayOrigin = camera->NearTheaterIntersection(mouseDir, viewRange);
-				const float dist2 = TraceRay::GuiTraceRay(rayOrigin, mouseDir, viewRange, NULL, unit, feature, true);
+				const float dist2 = TraceRay::GuiTraceRay(rayOrigin, mouseDir, viewRange, nullptr, unit, feature, true);
 
 				if (dist2 > (camera->GetFarPlaneDist() * 1.4f - 300) && (commands[tempInCommand].type != CMDTYPE_ICON_UNIT_FEATURE_OR_AREA))
 					return defaultRet;

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -569,7 +569,9 @@ void CMouseHandler::MouseRelease(int x, int y, int button)
 			const CUnit* unit = nullptr;
 			const CFeature* feature = nullptr;
 
-			TraceRay::GuiTraceRay(camera->GetPos(), dir, camera->GetFarPlaneDist() * 1.4f, nullptr, unit, feature, false);
+			const float viewRange = camera->GetFarPlaneDist() * 1.4f;
+			const float3 rayOrigin = camera->NearTheaterIntersection(dir, viewRange);
+			TraceRay::GuiTraceRay(rayOrigin, dir, viewRange, nullptr, unit, feature, false);
 			lastClicked = unit;
 
 			const bool selectType = (bp.lastRelease >= (gu->gameTime - doubleClickTime) && unit == _lastClicked);
@@ -701,8 +703,9 @@ std::string CMouseHandler::GetCurrentTooltip() const
 	const CUnit* unit = nullptr;
 	const CFeature* feature = nullptr;
 
+	const float3 rayOrigin = camera->NearTheaterIntersection(dir, range);
 	{
-		dist = TraceRay::GuiTraceRay(camera->GetPos(), dir, range, nullptr, unit, feature, true, false, true);
+		dist = TraceRay::GuiTraceRay(rayOrigin, dir, range, nullptr, unit, feature, true, false, true);
 
 		if (unit    != nullptr) return CTooltipConsole::MakeUnitString(unit);
 		if (feature != nullptr) return CTooltipConsole::MakeFeatureString(feature);
@@ -714,7 +717,7 @@ std::string CMouseHandler::GetCurrentTooltip() const
 		return selTip;
 
 	if (dist <= range)
-		return CTooltipConsole::MakeGroundString(camera->GetPos() + (dir * dist));
+		return CTooltipConsole::MakeGroundString(rayOrigin + (dir * dist));
 
 	return "";
 }

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -3261,6 +3261,7 @@ int LuaSyncedCtrl::SetUnitMidAndAimPos(lua_State* L)
 
 	if (updateQuads) {
 		quadField.MovedUnit(unit);
+		unitHandler.MovedUnit(unit);
 	}
 
 	lua_pushboolean(L, true);
@@ -3296,6 +3297,7 @@ int LuaSyncedCtrl::SetUnitRadiusAndHeight(lua_State* L)
 
 	if (updateQuads) {
 		quadField.MovedUnit(unit);
+		unitHandler.MovedUnit(unit);
 	}
 
 	lua_pushboolean(L, true);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -2952,10 +2952,15 @@ int LuaUnsyncedRead::TraceScreenRay(lua_State* L)
 	const float3 pxlDir = camera->CalcPixelDir(wx, wy);
 
 	// trace for player's allyteam
-	const float traceDist = TraceRay::GuiTraceRay(camPos, pxlDir, rawRange, nullptr, unit, feature, true, onlyCoords, ignoreWater);
+	float3 rayOrigin;
+	if (onlyCoords)
+		rayOrigin = camPos;
+	else
+		rayOrigin = camera->NearTheaterIntersection(pxlDir, rawRange);
+	const float traceDist = TraceRay::GuiTraceRay(rayOrigin, pxlDir, rawRange, nullptr, unit, feature, true, onlyCoords, ignoreWater);
 	const float planeDist = CGround::LinePlaneCol(camPos, pxlDir, rawRange, luaL_optnumber(L, newArgIdx, 0.0f));
 
-	const float3 tracePos = camPos + (pxlDir * traceDist);
+	const float3 tracePos = rayOrigin + (pxlDir * traceDist);
 	const float3 planePos = camPos + (pxlDir * planeDist); // backup (for includeSky and onlyCoords)
 
 	if ((traceDist < 0.0f || traceDist > badRange) && unit == nullptr && feature == nullptr) {

--- a/rts/Rendering/UniformConstants.cpp
+++ b/rts/Rendering/UniformConstants.cpp
@@ -275,9 +275,10 @@ void UniformConstants::UpdateParamsImpl(UniformParamsBuffer* updateBuffer)
 		const float3 pxlDir = camPlayer->CalcPixelDir(wx, wy);
 
 		// trace for player's allyteam
-		const float traceDist = TraceRay::GuiTraceRay(camPos, pxlDir, rawRange, nullptr, unit, feature, true, false, true);
+		const float3 rayOrigin = camPlayer->NearTheaterIntersection(pxlDir, rawRange);
+		const float traceDist = TraceRay::GuiTraceRay(rayOrigin, pxlDir, rawRange, nullptr, unit, feature, true, false, true);
 
-		const float3 tracePos = camPos + (pxlDir * traceDist);
+		const float3 tracePos = rayOrigin + (pxlDir * traceDist);
 
 		if (unit)
 			updateBuffer->mouseWorldPos = float4{ unit->drawPos, 1.0f };

--- a/rts/Sim/Features/Feature.cpp
+++ b/rts/Sim/Features/Feature.cpp
@@ -481,6 +481,7 @@ void CFeature::ForcedMove(const float3& newPos)
 	UpdateTransformAndPhysState();
 
 	eventHandler.FeatureMoved(this, oldPos);
+	featureHandler.MovedFeature(this);
 
 	// insert into managers
 	quadField.AddFeature(this);
@@ -596,6 +597,7 @@ bool CFeature::UpdatePosition()
 	// use an exact comparison for the y-component (gravity is small)
 	if (!pos.equals(oldPos, float3(float3::cmp_eps(), 0.0f, float3::cmp_eps()))) {
 		eventHandler.FeatureMoved(this, oldPos);
+		featureHandler.MovedFeature(this);
 		return true;
 	}
 

--- a/rts/Sim/Features/FeatureHandler.cpp
+++ b/rts/Sim/Features/FeatureHandler.cpp
@@ -192,7 +192,7 @@ CFeature* CFeatureHandler::CreateWreckage(const FeatureLoadParams& cparams)
 
 void CFeatureHandler::RecalculateMaxAltitude()
 {
-	if (maxFeatureAltitude < std::max(readMap->GetCurrMaxHeight, unitHandler.MaxUnitAltitude()))
+	if (maxFeatureAltitude < std::max(readMap->GetCurrMaxHeight(), unitHandler.MaxUnitAltitude()))
 		return;
 
 	maxFeatureAltitude = readMap->GetCurrMaxHeight();

--- a/rts/Sim/Features/FeatureHandler.cpp
+++ b/rts/Sim/Features/FeatureHandler.cpp
@@ -220,7 +220,7 @@ void CFeatureHandler::Update()
 
 		updateFeatures.erase(iter, updateFeatures.end());
 	}
-	if ((gs->frameNum & 62) == 0) {
+	if ((gs->frameNum & 63) == 0) {
 		RecalculateMaxAltitude();
 	}
 }

--- a/rts/Sim/Features/FeatureHandler.h
+++ b/rts/Sim/Features/FeatureHandler.h
@@ -59,11 +59,14 @@ public:
 	bool TryFreeFeatureID(int id);
 	bool AddFeature(CFeature* feature);
 	void DeleteFeature(CFeature* feature);
+	void MovedFeature(const CFeature* feature);
 
 	void LoadFeaturesFromMap();
 
 	void SetFeatureUpdateable(CFeature* feature);
 	void TerrainChanged(int x1, int y1, int x2, int y2);
+
+	float MaxFeatureAltitude() const { return maxFeatureAltitude; }
 
 	const spring::unordered_set<int>& GetActiveFeatureIDs() const { return activeFeatureIDs; }
 
@@ -88,6 +91,12 @@ private:
 	std::vector<int> deletedFeatureIDs;
 	std::vector<CFeature*> features;
 	std::vector<CFeature*> updateFeatures;
+
+	///< highest altitude of any feature added so far
+	///< (ray tracing uses this in some cases)
+	float maxFeatureAltitude = 0.0f;
+
+	void RecalculateMaxAltitude();
 };
 
 extern CFeatureHandler featureHandler;

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -531,6 +531,7 @@ void CUnit::ForcedMove(const float3& newPos)
 
 	eventHandler.UnitMoved(this);
 	quadField.MovedUnit(this);
+	unitHandler.MovedUnit(this);
 }
 
 
@@ -741,6 +742,7 @@ void CUnit::UpdateTransportees()
 		// see ::AttachUnit
 		if (transportee->IsStunned()) {
 			quadField.MovedUnit(transportee);
+			unitHandler.MovedUnit(transportee);
 		}
 	}
 }

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -55,6 +55,7 @@ CR_REG_METADATA(CUnitHandler, (
 
 	CR_MEMBER(maxUnits),
 	CR_MEMBER(maxUnitRadius),
+	CR_MEMBER_UN(maxUnitAltitude),
 
 	CR_MEMBER(inUpdateCall)
 ))
@@ -115,6 +116,7 @@ void CUnitHandler::Init() {
 		// other team in the respective allyteam
 		maxUnits = CalcMaxUnits();
 		maxUnitRadius = 0.0f;
+		maxUnitAltitude = 0.0f;
 	}
 	{
 		activeSlowUpdateUnit = 0;
@@ -170,6 +172,7 @@ void CUnitHandler::Kill()
 	{
 		maxUnits = 0;
 		maxUnitRadius = 0.0f;
+		maxUnitAltitude = 0.0f;
 	}
 }
 
@@ -236,6 +239,7 @@ bool CUnitHandler::AddUnit(CUnit* unit)
 	spring::VectorInsertUnique(GetUnitsByTeamAndDef(unit->team, unit->unitDef->id), unit, false);
 
 	maxUnitRadius = std::max(unit->radius, maxUnitRadius);
+	MovedUnit(unit);
 	return true;
 }
 
@@ -408,6 +412,7 @@ void CUnitHandler::UpdateUnits()
 {
 	SCOPED_TIMER("Sim::Unit::Update");
 
+	maxUnitAltitude = 0.0f;
 	size_t activeUnitCount = activeUnits.size();
 	for (size_t i = 0; i < activeUnitCount; ++i) {
 		CUnit* unit = activeUnits[i];
@@ -415,6 +420,7 @@ void CUnitHandler::UpdateUnits()
 		unit->SanityCheck();
 		unit->Update();
 		unit->moveType->UpdateCollisionMap();
+		MovedUnit(unit);
 		// unsynced; done on-demand when drawing unit
 		// unit->UpdateLocalModel();
 		unit->SanityCheck();
@@ -514,3 +520,7 @@ unsigned int CUnitHandler::CalcMaxUnits() const
 	return n;
 }
 
+void CUnitHandler::MovedUnit(CUnit* unit)
+{
+	maxUnitAltitude = std::max(unit->pos.y + unit->radius, maxUnitAltitude);
+}

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -11,6 +11,7 @@
 #include "UnitTypes/Factory.h"
 
 #include "CommandAI/BuilderCAI.h"
+#include "Map/ReadMap.h"
 #include "Sim/Ecs/Registry.h"
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/Misc/ModInfo.h"
@@ -116,7 +117,7 @@ void CUnitHandler::Init() {
 		// other team in the respective allyteam
 		maxUnits = CalcMaxUnits();
 		maxUnitRadius = 0.0f;
-		maxUnitAltitude = 0.0f;
+		maxUnitAltitude = readMap->GetCurrMaxHeight();
 	}
 	{
 		activeSlowUpdateUnit = 0;
@@ -172,7 +173,7 @@ void CUnitHandler::Kill()
 	{
 		maxUnits = 0;
 		maxUnitRadius = 0.0f;
-		maxUnitAltitude = 0.0f;
+		maxUnitAltitude = std::numeric_limits<float>::lowest();
 	}
 }
 
@@ -412,7 +413,7 @@ void CUnitHandler::UpdateUnits()
 {
 	SCOPED_TIMER("Sim::Unit::Update");
 
-	maxUnitAltitude = 0.0f;
+	maxUnitAltitude = readMap->GetCurrMaxHeight();
 	size_t activeUnitCount = activeUnits.size();
 	for (size_t i = 0; i < activeUnitCount; ++i) {
 		CUnit* unit = activeUnits[i];
@@ -520,7 +521,9 @@ unsigned int CUnitHandler::CalcMaxUnits() const
 	return n;
 }
 
-void CUnitHandler::MovedUnit(CUnit* unit)
+void CUnitHandler::MovedUnit(const CUnit* unit)
 {
-	maxUnitAltitude = std::max(unit->pos.y + unit->radius, maxUnitAltitude);
+	const CollisionVolume& cv = unit->selectionVolume;
+	const float top = cv.GetWorldSpacePos(unit).y + cv.GetBoundingRadius();
+	maxUnitAltitude = std::max(top, maxUnitAltitude);
 }

--- a/rts/Sim/Units/UnitHandler.h
+++ b/rts/Sim/Units/UnitHandler.h
@@ -28,6 +28,7 @@ public:
 
 	void Update();
 	bool AddUnit(CUnit* unit);
+	void MovedUnit(CUnit* unit);
 
 	bool CanAddUnit(int id) const {
 		// do we want to be assigned a random ID and are any left in pool?
@@ -46,6 +47,7 @@ public:
 	unsigned int CalcMaxUnits() const;
 
 	float MaxUnitRadius() const { return maxUnitRadius; }
+	float MaxUnitAltitude() const { return maxUnitAltitude; }
 
 	/// Returns true if a unit of type unitID can be built, false otherwise
 	bool CanBuildUnit(const UnitDef* unitdef, int team) const;
@@ -114,6 +116,10 @@ private:
 	///< largest radius of any unit added so far (some
 	///< spatial query filters in GameHelper use this)
 	float maxUnitRadius = 0.0f;
+
+	///< highest altitude of any unit added so far
+	///< (ray tracing uses this in some cases)
+	float maxUnitAltitude = 0.0f;
 
 	bool inUpdateCall = false;
 };

--- a/rts/Sim/Units/UnitHandler.h
+++ b/rts/Sim/Units/UnitHandler.h
@@ -28,7 +28,7 @@ public:
 
 	void Update();
 	bool AddUnit(CUnit* unit);
-	void MovedUnit(CUnit* unit);
+	void MovedUnit(const CUnit* unit);
 
 	bool CanAddUnit(int id) const {
 		// do we want to be assigned a random ID and are any left in pool?


### PR DESCRIPTION
### Work done

* Calculate optimal position to GuiTraceRay from and apply to all GuiTraceRay (the ones with groundOnly=false).

### Explanation

#### Background

* Only applies when using FOV zoom
* Discovered this while testing https://github.com/beyond-all-reason/spring/pull/1774 and https://github.com/beyond-all-reason/spring/pull/1764
* Very similar problem to https://github.com/beyond-all-reason/spring/pull/1754
* The ray origin is too pessimistic, and while this is not a problem when looking down, as the perspective increases it quickly becomes a ray until the other side of the map going back.
* I think this is important since every quad scanned potentially has lots of units in late game, and https://github.com/beyond-all-reason/spring/pull/1764 will multiply scanned quads by (approximately) 3.

#### Implementation

* I define theater as the vertical plane defined by the intersection of camera to far bottom frustum corners with the map maxheight+maxunitaltitude.
*  The theater window is basically the bottom of the frustum intersected with the maximum height + the maximum altitude from airplanes. This defines the closest units we can actually see, even if the camera position is far back.
* Then calculate the theater ray intersection as the intersection of the theater plane with the ray.
* **Note:** For now I don't use the real maxunitaltitude but a hardcoded number, this needs to actually get the maxunitaltitude from somewhere. This comes from unitdefs+some additional logic, and I think can be maintained by the engine, or maybe already does not sure about this. I did check and 500.0 is good for bar atm, but ofc this needs to be improved before merging.
* We could optimize a bit by not doing if camera direction is just looking down with some threshold, but I think the calculations are not too expensive anyways.

#### Remarks

* I think this is the proper logic but of course needs some thought, the idea is tracing from as close as possible to scan less quads.
* Might be I'm reimplementing some functionality already present in engine, please let me know if this is the case. Specially I couldn't find a way to get a plane equation from norm+point.
* Also maybe the "theater" terminology is not the best.

### Before and after

* Top images are from current master, bottom are with the PR applied.
* The white squares are actual quads scanned by GuiTraceRay.
* Note how the top images quickly become a search from the other side of the map going back.
* Note how the corners (represented by squares) I'm drawing go further back than the frustum drawn at minimap, this is because they intersect with ground, but I'm intersecting with max altitude basically.
* Blue square is the camera position, red square the intersection of the ray with the near frustum plane (iirc, I tried this first, but it's also not best).

![rayorigin](https://github.com/user-attachments/assets/07eff63d-82b4-4cf6-b8c1-9985a6549cdd)

### Diagram

![theater](https://github.com/user-attachments/assets/035bf546-b1b9-4ed7-8039-5d73f2d3166c)

