### PR TITLE
Add linux dockerfile for ubuntu 20.04.

### DIFF
--- a/docker-build-v2/amd64-linux/Dockerfile.20.04
+++ b/docker-build-v2/amd64-linux/Dockerfile.20.04
@@ -1,6 +1,6 @@
-# We pick ubuntu 18 instead of newer one because we are dynamically linking
-# to glibc and a few other libraries and we want to keep compatibility for as
-# many users as possible.
+# Ubuntu 20.04 docker environment for building spring.
+# Not used for distribution atm, but can be used in case the 18.04 gives you problems
+# with newer distros or want to experiment.
 FROM docker.io/ubuntu:20.04
 ENV ENGINE_PLATFORM=amd64-linux
 

--- a/docker-build-v2/amd64-linux/Dockerfile.20.04
+++ b/docker-build-v2/amd64-linux/Dockerfile.20.04
@@ -1,0 +1,61 @@
+# We pick ubuntu 18 instead of newer one because we are dynamically linking
+# to glibc and a few other libraries and we want to keep compatibility for as
+# many users as possible.
+FROM docker.io/ubuntu:20.04
+ENV ENGINE_PLATFORM=amd64-linux
+
+RUN apt-get update \
+ && apt-get install --no-install-recommends --yes software-properties-common \
+ && add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
+ && apt-get update \
+ && apt-get install --no-install-recommends --yes \
+    curl gcc-13 g++-13 git ninja-build curl p7zip-full python3-pip python3-setuptools \
+    libsdl2-dev libopenal-dev libfreetype6-dev libfontconfig1-dev xz-utils make uuid-dev \
+ && apt-get remove --purge --yes software-properties-common \
+ && apt-get autoremove --purge --yes \
+ && apt-get upgrade --yes \
+ && rm -rf /var/lib/apt/lists/*
+
+
+
+# We need a newer ccache for compression support
+ARG CCACHE_VERSION="4.10.2"
+RUN curl -L -O https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-linux-x86_64.tar.xz \
+ && tar -xf ccache-${CCACHE_VERSION}-linux-x86_64.tar.xz \
+ && mv ccache-${CCACHE_VERSION}-linux-x86_64/ccache /usr/bin \
+ && rm -rf ccache-${CCACHE_VERSION}-linux-x86_64*
+
+# And need newer zstd :(, fortunatelly it's quick build
+RUN git clone --depth 1 --branch v1.5.6 https://github.com/facebook/zstd.git \
+ && cd zstd \
+ && CC=g++-13 make -j$(nproc) \
+ && mv programs/zstd /usr/local/bin \
+ && cd .. \
+ && rm -rf zstd
+
+RUN pip3 install --upgrade pip \
+ && pip3 install scikit-build \
+ && pip3 install cmake==3.27.*
+
+WORKDIR /build
+RUN mkdir src cache out artifacts && chmod a+rwx cache out artifacts
+
+# Fetch library dependencies and configure resolution
+RUN git clone --depth=1 https://github.com/beyond-all-reason/spring-static-libs.git -b 20.04 spring-static-libs
+ENV PKG_CONFIG_LIBDIR=/build/spring-static-libs/lib/pkgconfig
+ENV PKG_CONFIG="pkg-config --define-prefix --static"
+ENV CMAKE_PREFIX_PATH=/build/spring-static-libs/
+ENV PREFER_STATIC_LIBS=TRUE
+
+# Fontconfig cmake doesn't seem to be properly setup
+RUN sed -i 's/ IMPORTED_LOCATION "\${Fontconfig_LIBRARY}"/&\n   INTERFACE_LINK_LIBRARIES "\/usr\/lib\/x86_64-linux-gnu\/libuuid\.a"/' /usr/local/lib/python3.8/dist-packages/cmake/data/share/cmake-3.27/Modules/FindFontconfig.cmake
+
+# Set up default cmake toolchain
+COPY toolchain.cmake .
+ENV CMAKE_TOOLCHAIN_FILE=/build/toolchain.cmake
+
+# Configure ccache caching
+COPY ccache.conf .
+ENV CCACHE_CONFIGPATH=/build/ccache.conf
+ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
+ENV CMAKE_C_COMPILER_LAUNCHER=ccache


### PR DESCRIPTION
### Work done

- Update docker docker-build-v2/amd64-linux/Dockerfile to ubuntu 20.04
  - The 18.04 dockerfile is too old and starts to have compatibility issues with recent linux distros.

### Related issues

- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3884

I have checked, and building with the old dockerfile leads to issues (freeze on engine start), after updating seems to work fine both running with the launcher flatpak, and directly from the host os with ./spring.

After building with the new dockerfile the above issue should be fixed, but since I'm not running zorin specifically would have to double check with op. Zorin 17 is based on 24.04 though, the same I'm testing.

### Remarks

- I guess this needs good **testing** and have no idea how to check if this can lead to desyncs. windows docker file seems to be at ubuntu 24.04 already though.
- There is an issue when linking, in that fontconfig doesn't seem to be properly configured either by the distro or the build system and doesn't link libuuid resulting in link errors at the end.
  - The linking problem only affects PreferStatic builds, like the docker one.
  - I modify the cmake FindFontconfig file inside the dockerfile, maybe there is a better way to fix this but this way I avoid having to add hack rules to make it work inside CMakeLists. Other libraries have similar stances so what I'm adding is nothing out of the ordinary.
  - I'm linking libuuid.a (static), but libuuid.so (dynamic) would also work.
