### PR TITLE
Fix crash with not found glyphs.

### DIFF
--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -858,9 +858,7 @@ void CFontTexture::LoadGlyph(std::shared_ptr<FontFace>& f, char32_t ch, unsigned
 	const auto iter = std::find_if(glyphs.begin(), glyphs.end(), pred);
 
 	if (iter != glyphs.end()) {
-		auto& glyph = glyphs[ch];
-		glyph = iter->second;
-		glyph.letter = ch;
+		glyphs[ch] = iter->second;
 		return;
 	}
 


### PR DESCRIPTION
### Work done

- Fix a crash when several not found glyphs are used.
- Debugged but not 100% sure what's going on.

### Remarks

Note this all happens with current standard engine, also with custom compiled without any of the recent fontconfig changes, also fontconfig here doesn't take part since I'm using `UseFontConfigLib = 0` anyways.

- found this while testing the engine with bar and option `UseFontConfigLib = 0` and some font that doesn't have alphabet  glyphs inside BAR/fonts.
  - that makes the engine load loads of unknown glyphs since it will try to preload the alphabet but its not there (also not the best).
  - not sure if it also happens on windows
  - also noticed here having games provide their fonts inside fonts/ and loading fontconfig/engine fonts from fonts/ is not very good since then we will preload all of them even if not used due to VFS.
- also removed assigning chr to the GlyphInfo (`glyph.letter = ch`) since it already has a previous character so no reason to overwrite it here. We look it up in the std::pair->first anyways, and changing the font here can make it not share some other caches (rn the kerninginfo).

- Was trying `UseFontConfigLib = 0` as a possible workaround for the [Zorin Os player](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3884), and decided to investigate the crash since it might be affecting other players too. Funnily the workaround pbbly can't be used by the player since afaik when playing with launcher it will overwrite the springsettings.cfg config all the time.



### Crash debug

The affected code:

https://github.com/beyond-all-reason/spring/blob/07dd4bc464a23445163b574df9e3df3e77aa7ad8/rts/Rendering/Fonts/CFontTexture.cpp#L860-L864

Tbh not entirely sure why it crashes XD. I know but don't know the ultimate reasons.

I investigated, and seems like sometimes (it's only after a few times entering the loop, not sure why, maybe 20) the assignment operator will get an empty GlyphInfo for some reason when calling `glyph = iter->second;`.

A **dirtier workaround** seems to be doing some `glyphs[ch]` access before the ``return`, in that case it all works!! Might be something with the compiler? Corruption before this?

Sorry that I don't have a more final analysis :-P

### Logs

These are custom logs, interpret like:

[glyph-dupe-ok.txt](https://github.com/user-attachments/files/17959440/glyph-dupe-ok.txt)

[glyph-dupe-crash.txt](https://github.com/user-attachments/files/17959441/glyph-dupe-crash.txt) (just printing the chain that lead to the crash, there were more dupe glyphs before this)

The crash happens after `[t=00:00:12.223282][f=-000001] [Font] DUPE GLYPH Noto Sans Symbols2 ['] 0 0x5b0d599a93c0 / 0 [~] 0x5b0dae3dcea0 21 0.588235
`.

That means the iter->second.face has 21 count on the smart counter there so not the first time entering the loop.

They logs are printed roughly with this code:

```cpp
        if (iter != glyphs.end()) {
                LOG("DUPE GLYPH %s [%lc] %d %p / %d [%lc] %p %ld %f", f->face->family_name, ch, index, f->face, iter->second.index, iter->second.letter, iter->second.face.get(), iter->second.face.use_count(), iter->second.advance);
                LOG("COPY GLYPH %lc %ld", iter->second.letter, iter->second.face.use_count());
                //glyphs[ch] = iter->second; <-- fix I'm applying
                auto& glyph = glyphs[ch];
                glyph = iter->second;
                LOG("COPIED GLYP %lc", glyph.letter);
                glyph.letter = ch;
                //glyphs[ch].letter = ch; // this makes it all work instead of crash!
                //LOG("COPIED GLYP %lc", glyphs[ch].letter); // this also makes it work instead of crash!
                return;
        }

// assignment operator (we don't have it but I added it to debug or try to find a fix inside):

GlyphInfo& GlyphInfo::operator=(const GlyphInfo& orig)
{
        size = orig.size;
        texCord = orig.texCord;
        shadowTexCord = orig.shadowTexCord;
        advance = orig.advance;
        height = orig.height;
        descender = orig.descender;
        index = orig.index;
        letter = orig.letter;
        LOG("INSIDE COPY GLYPH operator %p %f %lc", orig.face.get(), orig.advance, orig.letter);
        face = orig.face;
        return *this;
}
```

