### PR TITLE
Fontconfig: Make init and teardown more robust.

### DIFF
--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -158,9 +158,7 @@ public:
 			// load system configuration
 			res = FcConfigParseAndLoad(config, 0, true);
 			if (!res) {
-				LOG_MSG("%s config", true, errprefix.c_str());
-				InitFailed();
-				return false;
+				LOG_MSG("%s config, you will miss system fallback fonts", false, errprefix.c_str());
 			}
 
 			// build system fonts

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -150,7 +150,7 @@ public:
 			static constexpr const char* cacheDirFmt = R"(<fontconfig><cachedir>fontcache</cachedir></fontconfig>)";
 			res = FcConfigParseAndLoadFromMemory(config, reinterpret_cast<const FcChar8*>(cacheDirFmt), FcTrue);
 			if (!res) {
-				LOG_MSG("%s cache", true, errprefix);
+				LOG_MSG("%s cache", true, errprefix.c_str());
 				InitFailed();
 				return false;
 			}
@@ -158,7 +158,7 @@ public:
 			// load system configuration
 			res = FcConfigParseAndLoad(config, 0, true);
 			if (!res) {
-				LOG_MSG("%s config", true, errprefix);
+				LOG_MSG("%s config", true, errprefix.c_str());
 				InitFailed();
 				return false;
 			}
@@ -166,7 +166,7 @@ public:
 			// build system fonts
 			res = FcConfigBuildFonts(config);
 			if (!res) {
-				LOG_MSG("%s build fonts", true, errprefix);
+				LOG_MSG("%s build fonts", true, errprefix.c_str());
 				InitFailed();
 				return false;
 			}
@@ -174,7 +174,7 @@ public:
 			// init app fonts dir
 			res = FcConfigAppFontAddDir(config, reinterpret_cast<const FcChar8*>("fonts"));
 			if (!res) {
-				LOG_MSG("%s font dir", true, errprefix);
+				LOG_MSG("%s font dir", true, errprefix.c_str());
 				InitFailed();
 				return false;
 			}

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -105,7 +105,7 @@ public:
 		FT_Done_FreeType(lib);
 
 		#ifdef USE_FONTCONFIG
-		if (!CanUseFontConfig())
+		if (!config)
 			return;
 
 		FcConfigDestroy(config);

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -153,7 +153,7 @@ public:
 			FcConfigEnableHome(FcFalse);
 			config = FcInitLoadConfigAndFonts();
 			if (!config) {
-				LOG_MSG(errprefix.c_str(), true);
+				LOG_MSG("%s", true, errprefix);
 				FcFini();
 				return false;
 			}

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -144,7 +144,13 @@ public:
 
 			// init configuration
 			FcConfigEnableHome(FcFalse);
-			config = FcConfigCreate();
+
+			// init everything
+			config = FcInitLoadConfigAndFonts();
+			if (!config) {
+				LOG_MSG("%s config and fonts", true, errprefix.c_str());
+				return false;
+			}
 
 			// add local cache in case fontconfig one can't be used
 			static constexpr const char* cacheDirFmt = R"(<fontconfig><cachedir>fontcache</cachedir></fontconfig>)";
@@ -154,6 +160,9 @@ public:
 				InitFailed();
 				return false;
 			}
+
+			/* alternative initialization
+			config = FcConfigCreate();
 
 			// load system configuration
 			res = FcConfigParseAndLoad(config, 0, true);
@@ -167,7 +176,7 @@ public:
 				LOG_MSG("%s build fonts", true, errprefix.c_str());
 				InitFailed();
 				return false;
-			}
+			}*/
 
 			// init app fonts dir
 			res = FcConfigAppFontAddDir(config, reinterpret_cast<const FcChar8*>("fonts"));

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -172,7 +172,7 @@ public:
 			}
 
 			// init app fonts dir
-			res = FcConfigAppFontAddDir(GetFCConfig(), reinterpret_cast<const FcChar8*>("fonts"));
+			res = FcConfigAppFontAddDir(config, reinterpret_cast<const FcChar8*>("fonts"));
 			if (!res) {
 				LOG_MSG("%s font dir", true, errprefix);
 				InitFailed();
@@ -180,7 +180,7 @@ public:
 			}
 
 			// print cache dirs
-			auto dirs = FcConfigGetCacheDirs(GetFCConfig());
+			auto dirs = FcConfigGetCacheDirs(config);
 			FcStrListFirst(dirs);
 			for (FcChar8* dir = FcStrListNext(dirs); dir != nullptr; dir = FcStrListNext(dirs)) {
 				LOG_MSG("[%s] Using Fontconfig cache dir \"%s\"", false, __func__, dir);

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -91,14 +91,14 @@ public:
 	{
 		const FT_Error error = FT_Init_FreeType(&lib);
 
-		FT_Int version[3];
-		FT_Library_Version(lib, &version[0], &version[1], &version[2]);
+		if (error != 0) {
+			FT_Int version[3];
+			FT_Library_Version(lib, &version[0], &version[1], &version[2]);
 
-		std::string msg = fmt::sprintf("%s::FreeTypeInit (version %d.%d.%d)", __func__, version[0], version[1], version[2]);
-		std::string err = fmt::sprintf("[%s] FT_Init_FreeType failure \"%s\"", __func__, GetFTError(error));
-
-		if (error != 0)
+			std::string err = fmt::sprintf("[%s] FT_Init_FreeType failure (version %d.%d.%d) \"%s\"",
+						       __func__, version[0], version[1], version[2], GetFTError(error));
 			throw std::runtime_error(err);
+		}
 	}
 
 	~FtLibraryHandler() {

--- a/rts/Rendering/Fonts/CFontTexture.h
+++ b/rts/Rendering/Fonts/CFontTexture.h
@@ -21,8 +21,7 @@ class CBitmap;
 class FtLibraryHandlerProxy {
 public:
 	static void InitFtLibrary();
-	static bool CheckGenFontConfigFast();
-	static bool CheckGenFontConfigFull(bool console);
+	static bool InitFontconfig(bool console);
 };
 
 

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -329,9 +329,9 @@ bool SpringApp::InitPlatformLibs()
 bool SpringApp::InitFonts()
 {
 	FtLibraryHandlerProxy::InitFtLibrary();
-	FtLibraryHandlerProxy::CheckGenFontConfigFast();
+	FtLibraryHandlerProxy::InitFontconfig(false);
 	CFontTexture::InitFonts();
-	return CglFont::LoadConfigFonts() && FtLibraryHandlerProxy::CheckGenFontConfigFull(false);
+	return CglFont::LoadConfigFonts();
 /*
 	using namespace std::chrono_literals;
 	auto future = std::async(std::launch::async, []() {
@@ -478,7 +478,7 @@ void SpringApp::ParseCmdLine(int argc, char* argv[])
 			spring_time::setstarttime(spring_time::gettime(true));
 		}
 		FtLibraryHandlerProxy::InitFtLibrary();
-		if (FtLibraryHandlerProxy::CheckGenFontConfigFull(true)) {
+		if (FtLibraryHandlerProxy::InitFontconfig(true)) {
 			printf("[FtLibraryHandler::GenFontConfig] is succesfull\n");
 			exit(spring::EXIT_CODE_SUCCESS);
 		}


### PR DESCRIPTION
### Work done

- Remove duplicate initialization from CheckGenFontConfigFast and CheckGenFontConfigFull.
  - now it's all InitFontconfig.
- Better check and report of error conditions on fontconfig initialization and destructor.
- Rework fontconfig initialization since it wasn't doing it well. See [this comment](https://github.com/beyond-all-reason/spring/pull/1793#issuecomment-2511791812) for more info.


### Related issues

- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3884.
- Fontconfig still loading when `UseFontConfigLib = 0` in use.
- Crashing on destructor in some situations.


### Explanation

The idea here is make the whole thing more robust, this might fix [crashes on linux](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3884) when fontconfig can't init properly due to environment incompatibilities, or at least to workaround using `UseFontConfigLib = 0`.

Also it should fix fontconfig still loading when `UseFontConfigLib = 0` option is in use (the duplicated init at CheckGenFontConfigFast wasn't checking the flag).

This should be functionally equivalent to previous code, just more error checks, less duplicated init and proper fontconfig initialization procedure.

The initialization has been reworked quite a bit (see [comment below](https://github.com/beyond-all-reason/spring/pull/1793#issuecomment-2511791812)), so it will need some windows testing.
