### PR TITLE
Add /debugquadfield to draw quadfield related information (v2).

### DIFF
--- a/doc/site/_data/unsynced_commands.json
+++ b/doc/site/_data/unsynced_commands.json
@@ -183,7 +183,7 @@
       "arguments" : {},
       "cheatRequired" : false,
       "command" : "DebugQuadField",
-      "description" : "Draw quadfield sectors around GuiTraceRay and selected units (only if compiled into engine)"
+      "description" : "Draw quadfield sectors around GuiTraceRay and selected units"
    },
    "debugdrawai" : {
       "arguments" : {},

--- a/doc/site/_data/unsynced_commands.json
+++ b/doc/site/_data/unsynced_commands.json
@@ -179,6 +179,12 @@
       "command" : "DebugCubeMap",
       "description" : "Use debug cubemap texture instead of the sky"
    },
+   "debugquadfield" : {
+      "arguments" : {},
+      "cheatRequired" : false,
+      "command" : "DebugQuadField",
+      "description" : "Draw quadfield sectors around GuiTraceRay and selected units (only if compiled into engine)"
+   },
    "debugdrawai" : {
       "arguments" : {},
       "cheatRequired" : false,

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -65,6 +65,7 @@
 #include "Rendering/DebugColVolDrawer.h"
 #include "Rendering/DebugVisibilityDrawer.h"
 #include "Rendering/DebugDrawerAI.h"
+#include "Rendering/DebugDrawerQuadField.h"
 #include "Rendering/IPathDrawer.h"
 #include "Rendering/Features/FeatureDrawer.h"
 #include "Rendering/HUDDrawer.h"
@@ -1545,6 +1546,19 @@ public:
 	bool Execute(const UnsyncedAction& action) const final {
 		globalRendering->drawDebugCubeMap = !globalRendering->drawDebugCubeMap;
 		ISky::SetSky();
+		return true;
+	}
+};
+
+class DebugQuadFieldActionExecutor : public IUnsyncedActionExecutor {
+public:
+	DebugQuadFieldActionExecutor() : IUnsyncedActionExecutor("DebugQuadField", "Draw quadfield sectors around GuiTraceRay and selected units") {
+	}
+
+	bool Execute(const UnsyncedAction& action) const final {
+		bool enabled = DebugDrawerQuadField::IsEnabled();
+		DebugDrawerQuadField::SetEnabled(!enabled);
+		LogSystemStatus("quadfield debug", !enabled);
 		return true;
 	}
 };
@@ -3950,6 +3964,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<PauseActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DebugActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DebugCubeMapActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<DebugQuadFieldActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DrawSkyActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DebugGLActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DebugGLErrorsActionExecutor>());

--- a/rts/Rendering/CMakeLists.txt
+++ b/rts/Rendering/CMakeLists.txt
@@ -7,6 +7,7 @@ set(sources_engine_Rendering
 		"${CMAKE_CURRENT_SOURCE_DIR}/DebugVisibilityDrawer.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/DepthBufferCopy.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/DebugDrawerAI.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/DebugDrawerQuadField.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/QTPFSPathDrawer.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/HAPFSPathDrawer.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Env/AdvWater.cpp"

--- a/rts/Rendering/DebugDrawerQuadField.cpp
+++ b/rts/Rendering/DebugDrawerQuadField.cpp
@@ -159,7 +159,6 @@ void DebugDrawerQuadField::DrawCamera() const
 	constexpr float w = 100;
 	constexpr auto camColor   = float4(1.0, 1.0, 1.0, 0.8);
 	constexpr auto frustColor = float4(1.0, 0.5, 0.5, 1.0);
-	constexpr auto altColor   = float4(0.5, 0.5, 1.0, 1.0);
 
 	// draw camera position
 	DrawRect(pos, w, w, camColor);

--- a/rts/Rendering/DebugDrawerQuadField.cpp
+++ b/rts/Rendering/DebugDrawerQuadField.cpp
@@ -44,7 +44,19 @@ void DebugDrawerQuadField::SetEnabled(bool enable)
 	instance = new DebugDrawerQuadField();
 }
 
-void DebugDrawerQuadField::Update()
+void DebugDrawerQuadField::DrawWorldPreUnit()
+{
+	// lineDrawer cleans up after drawing, so we need to queue lines
+	// before minimap and world drawing.
+	DrawAll();
+}
+
+void DebugDrawerQuadField::DrawInMiniMapBackground()
+{
+	DrawAll();
+}
+
+void DebugDrawerQuadField::DrawAll() const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 

--- a/rts/Rendering/DebugDrawerQuadField.cpp
+++ b/rts/Rendering/DebugDrawerQuadField.cpp
@@ -143,37 +143,38 @@ float3 DebugDrawerQuadField::TraceToMaxHeight(float3 start, float3 point, float 
 	const float3 dir = (point-start).Normalize();
 	const float maxHeight = readMap->GetCurrMaxHeight();
 
-	const float rayLength = CGround::LinePlaneCol(start, dir, length, maxHeight);
-	if (rayLength < 0.0)
+	const float dist = CGround::LinePlaneCol(start, dir, length, maxHeight);
+	if (dist < 0.0)
 		return start;
 
-	return start + dir * rayLength;
+	return start + dir * dist;
 }
 
 void DebugDrawerQuadField::DrawCamera() const
 {
 	// draw some camera information we can use to find a better ray start.
-	const float viewRange = camera->GetFarPlaneDist() * 1.4f;
-	const float3 pos = camera->GetPos();
-	const float3 mouseDir = mouse->dir;
+	const float3 start = camera->GetPos();
+	const float3 dir = mouse->dir;
+	const float length = camera->GetFarPlaneDist() * 1.4f;
+
 	constexpr float w = 100;
 	constexpr auto camColor   = float4(1.0, 1.0, 1.0, 0.8);
 	constexpr auto frustColor = float4(1.0, 0.5, 0.5, 1.0);
 
 	// draw camera position
-	DrawRect(pos, w, w, camColor);
+	DrawRect(start, w, w, camColor);
 
 	// intersection of frustum to map max height
 	for(int i=0; i<4; i++) {
 		auto fv = camera->GetFrustumVert(CCamera::FRUSTUM_POINT_FBL+i);
-		DrawRect(TraceToMaxHeight(pos, fv, viewRange), w, w, camColor);
+		DrawRect(TraceToMaxHeight(start, fv, length), w, w, camColor);
 	}
 
 	// draw intersection of near frustum to mouse ray
 	// note: seems to be the same as camPos
 	float3 intersection;
 	float4 nearPlane = camera->GetFrustumPlane(CCamera::FRUSTUM_PLANE_NEA);
-	bool res = RayAndPlaneIntersection(pos, pos + mouseDir * viewRange, nearPlane, false, intersection);
+	bool res = RayAndPlaneIntersection(start, start + dir * length, nearPlane, false, intersection);
 	if (res)
 		DrawRect(intersection, w*0.9, w*0.9, frustColor);
 }

--- a/rts/Rendering/DebugDrawerQuadField.cpp
+++ b/rts/Rendering/DebugDrawerQuadField.cpp
@@ -1,0 +1,169 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "DebugDrawerQuadField.h"
+
+#include "Game/Camera.h"
+#include "Game/GlobalUnsynced.h"
+#include "Sim/Misc/GlobalSynced.h"
+#include "Game/SelectedUnitsHandler.h"
+#include "Game/UI/MouseHandler.h"
+
+#include "Map/Ground.h"
+#include "Map/ReadMap.h"
+
+#include "Sim/Misc/LosHandler.h"
+#include "Sim/Misc/QuadField.h"
+#include "Sim/Units/UnitHandler.h"
+
+#include "Rendering/LineDrawer.h"
+
+#include "System/EventHandler.h"
+#include "System/GlobalConfig.h"
+#include "System/Misc/TracyDefs.h"
+#include "System/SafeUtil.h"
+
+
+DebugDrawerQuadField* DebugDrawerQuadField::instance = nullptr;
+
+DebugDrawerQuadField::DebugDrawerQuadField()
+: CEventClient("[DebugDrawerQuadField]", 199991, false)
+{
+	autoLinkEvents = true;
+	RegisterLinkedEvents(this);
+	eventHandler.AddClient(this);
+}
+
+void DebugDrawerQuadField::SetEnabled(bool enable)
+{
+	if (!enable) {
+		spring::SafeDelete(instance);
+		return;
+	}
+
+	assert(instance == nullptr);
+	instance = new DebugDrawerQuadField();
+}
+
+void DebugDrawerQuadField::Update()
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+
+	DrawSelectionQuads();
+	DrawMouseRayQuads();
+	DrawCamera();
+}
+
+void DebugDrawerQuadField::DrawRect(float3 pos, float widthX, float widthZ, float4 color) const
+{
+	const float x0 = pos.x - widthX/2.0;
+	const float x1 = pos.x + widthX/2.0;
+	const float y0 = pos.z - widthZ/2.0;
+	const float y1 = pos.z + widthZ/2.0;
+
+	const float h = CGround::GetHeightReal(pos.x, pos.z, false);
+
+	lineDrawer.StartPath(float3(x0, h, y0), color);
+	lineDrawer.DrawLine(float3(x1, h, y0), color);
+	lineDrawer.DrawLine(float3(x1, h, y1), color);
+	lineDrawer.DrawLine(float3(x0, h, y1), color);
+	lineDrawer.DrawLine(float3(x0, h, y0), color);
+	lineDrawer.FinishPath();
+}
+
+void DebugDrawerQuadField::DrawQuad(unsigned i, float4 color) const
+{
+	const int qx = i % quadField.GetNumQuadsX();
+	const int qz = i / quadField.GetNumQuadsZ();
+
+	const int quadSizeX = quadField.GetQuadSizeX();
+	const int quadSizeZ = quadField.GetQuadSizeZ();
+
+	const float3 pos = float3((qx+0.5)*quadSizeX, 0, (qz+0.5)*quadSizeZ);
+
+	DrawRect(pos, 1.0*quadSizeX, 1.0*quadSizeZ, color);
+}
+
+void DebugDrawerQuadField::DrawSelectionQuads() const
+{
+	const float4 quadColor = {0.4, 1.0, 0.4, 1.0};
+	const auto& selectedUnits = selectedUnitsHandler.selectedUnits;
+	for (const int unitID: selectedUnits) {
+		const CUnit* su = unitHandler.GetUnit(unitID);
+		for(const int qIdx: su->quads) {
+			DrawQuad(qIdx, quadColor);
+		}
+	}
+}
+
+void DebugDrawerQuadField::DrawMouseRayQuads() const
+{
+	// Replicating GuiTraceRay ray setup and query so we can draw the same
+	const float3 start = camera->GetPos();
+	const float3 dir = mouse->dir;
+	const float length = camera->GetFarPlaneDist() * 1.4f;
+
+	const float    guiRayLength = length;
+	const float groundRayLength = CGround::LineGroundCol(start, dir, length, false);
+	const float  waterRayLength = CGround::LinePlaneCol(start, dir, length, CGround::GetWaterPlaneLevel());
+
+	float maxRayLength;
+	if (groundRayLength >= 0.0) {
+		maxRayLength = groundRayLength;
+	} else if (waterRayLength >= 0.0) {
+		maxRayLength = waterRayLength;
+	} else {
+		maxRayLength = length;
+	}
+	maxRayLength = std::min(maxRayLength + globalConfig.selectThroughGround, length);
+
+	QuadFieldQuery qfQuery;
+	const float allyTeamError = losHandler->GetAllyTeamRadarErrorSize(gu->myAllyTeam);
+	quadField.GetQuadsOnWideRay(qfQuery, start, dir, maxRayLength, allyTeamError);
+
+	for (const int quadIdx: *qfQuery.quads) {
+		DrawQuad(quadIdx, float4(1.0, 1.0, 1.0, 1.0));
+	}
+}
+
+float3 DebugDrawerQuadField::TraceToMaxHeight(float3 start, float3 point, float length) const
+{
+	// return intersection with max map height or just original start if we don't find any
+	const float3 dir = (point-start).Normalize();
+	const float maxHeight = readMap->GetCurrMaxHeight();
+
+	const float rayLength = CGround::LinePlaneCol(start, dir, length, maxHeight);
+	if (rayLength < 0.0)
+		return start;
+
+	return start + dir * rayLength;
+}
+
+void DebugDrawerQuadField::DrawCamera() const
+{
+	// draw some camera information we can use to find a better ray start.
+	const float viewRange = camera->GetFarPlaneDist() * 1.4f;
+	const float3 pos = camera->GetPos();
+	const float3 mouseDir = mouse->dir;
+	constexpr float w = 100;
+	constexpr auto camColor   = float4(1.0, 1.0, 1.0, 0.8);
+	constexpr auto frustColor = float4(1.0, 0.5, 0.5, 1.0);
+	constexpr auto altColor   = float4(0.5, 0.5, 1.0, 1.0);
+
+	// draw camera position
+	DrawRect(pos, w, w, camColor);
+
+	// intersection of frustum to map max height
+	for(int i=0; i<4; i++) {
+		auto fv = camera->GetFrustumVert(CCamera::FRUSTUM_POINT_FBL+i);
+		DrawRect(TraceToMaxHeight(pos, fv, viewRange), w, w, camColor);
+	}
+
+	// draw intersection of near frustum to mouse ray
+	// note: seems to be the same as camPos
+	float3 intersection;
+	float4 nearPlane = camera->GetFrustumPlane(CCamera::FRUSTUM_PLANE_NEA);
+	bool res = RayAndPlaneIntersection(pos, pos + mouseDir * viewRange, nearPlane, false, intersection);
+	if (res)
+		DrawRect(intersection, w*0.9, w*0.9, frustColor);
+}
+

--- a/rts/Rendering/DebugDrawerQuadField.h
+++ b/rts/Rendering/DebugDrawerQuadField.h
@@ -11,7 +11,8 @@ class DebugDrawerQuadField : public CEventClient
 {
 public:
 	// CEventClient interface
-	virtual void Update() override;
+	virtual void DrawInMiniMapBackground() override;
+	virtual void DrawWorldPreUnit() override;
 
 	static void SetEnabled(bool enable);
 	static bool IsEnabled() { return (instance != nullptr); }
@@ -25,6 +26,7 @@ private:
 	void DrawSelectionQuads() const;
 	void DrawMouseRayQuads() const;
 	void DrawCamera() const;
+	void DrawAll() const;
 
 	static DebugDrawerQuadField* instance;
 };

--- a/rts/Rendering/DebugDrawerQuadField.h
+++ b/rts/Rendering/DebugDrawerQuadField.h
@@ -1,0 +1,32 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef DEBUG_DRAWER_QUAD_FIELD
+#define DEBUG_DRAWER_QUAD_FIELD
+
+#include "System/EventClient.h"
+
+#include "System/float4.h"
+
+class DebugDrawerQuadField : public CEventClient
+{
+public:
+	// CEventClient interface
+	virtual void Update() override;
+
+	static void SetEnabled(bool enable);
+	static bool IsEnabled() { return (instance != nullptr); }
+
+private:
+	DebugDrawerQuadField();
+
+	float3 TraceToMaxHeight(float3 start, float3 point, float length) const;
+	void DrawQuad(unsigned i, float4 color) const;
+	void DrawRect(float3 pos, float widthX, float widthZ, float4 color) const;
+	void DrawSelectionQuads() const;
+	void DrawMouseRayQuads() const;
+	void DrawCamera() const;
+
+	static DebugDrawerQuadField* instance;
+};
+
+#endif // DEBUG_DRAWER_QUAD_FIELD


### PR DESCRIPTION
### Work done

* Remake of [#1774](https://github.com/beyond-all-reason/spring/pull/1774) that doesn't require compile time option.
  * It also doesn't need to modify engine modules, and doesn't cost any perf when not in use.
  * Introduces the DebugDrawerQuadField module.

### Remarks

* The other PR needed to check in all GuiTraceRay and selection handler, so it would require lots of checks per draw, I didn't feel good about leaving that always compiled in.
* This one does replicate a bit of GuiTraceRay code in order to draw in the same way.
  * I think it's not a big problem, but if controversial, a solution can be to refactor GuiTraceRay so it exports the part we need for this (taking some parameters and return quads). That way the same code could be used by the new DebugDrawerQuadField introduced here and GuiTraceRay. The problem is the code does more things interleaved, so this likely isn't easy without several out parameters, so quite dirty.
* Need to setup twice since lineDrawer cleans up after drawing (instead of just once in Update() as I wanted to do initially), this could be improved but imo this is just debug code so better to leave it be.

### What it shows

- Quads below GuiTraceRay.
- Quads where selected units live.
- Camera frustum to highest map height plane (to give an idea of where optimal ray start could be).
- Camera position.
- Mouse ray to near frustum plane intersection (seems to be almost the same as camera position?).

![quadfield](https://github.com/user-attachments/assets/bb6831aa-b156-41e3-891c-929ee74f0a9f)
