### PR TITLE
`Spring.AllocateTable` -> `table.new`

### DIFF
--- a/rts/Lua/CMakeLists.txt
+++ b/rts/Lua/CMakeLists.txt
@@ -41,6 +41,7 @@ set(sources_engine_Lua
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaSyncedMoveCtrl.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaSyncedRead.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaSyncedTable.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/LuaTableExtra.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaTextures.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaAtlasTextures.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaUI.cpp"

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -12,6 +12,7 @@
 #include "LuaOpenGL.h"
 #include "LuaBitOps.h"
 #include "LuaMathExtra.h"
+#include "LuaTableExtra.h"
 #include "LuaUtils.h"
 #include "LuaZip.h"
 #include "Game/Game.h"
@@ -3845,6 +3846,10 @@ bool CLuaHandle::AddBasicCalls(lua_State* L)
 	lua_getglobal(L, "math");
 	LuaBitOps::PushEntries(L);
 	LuaMathExtra::PushEntries(L);
+	lua_pop(L, 1);
+
+	lua_getglobal(L, "table");
+	LuaTableExtra::PushEntries(L);
 	lua_pop(L, 1);
 
 	return true;

--- a/rts/Lua/LuaTableExtra.cpp
+++ b/rts/Lua/LuaTableExtra.cpp
@@ -1,0 +1,43 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "LuaTableExtra.h"
+#include "LuaUtils.h"
+
+/******************************************************************************
+ * table extensions
+ * @module TableExtra
+ * @see rts/Lua/LuaTableExtra.cpp
+******************************************************************************/
+
+/*** Returns a table with preallocated memory
+ *
+ * Returns an empty table with more memory allocated.
+ * This lets you microoptimize cases where a table receives
+ * a lot of elements and you know the number beforehand,
+ * such as one for each UnitDef, by avoiding reallocation.
+ *
+ * @function table.new
+ * @number nArray hint for count of array elements
+ * @number nHashed hint for count of hashtable elements
+ * @treturn table
+ */
+static int TableExtra_new(lua_State* L)
+{
+	int nArray = luaL_optinteger(L, 1, 0);
+	int nHash  = luaL_optinteger(L, 2, 0);
+
+	if (nArray < 0)
+		nArray = 0;
+	if (nHash < 0)
+		nHash = 0;
+
+	lua_createtable(L, nArray, nHash);
+
+	return 1;
+}
+
+bool LuaTableExtra::PushEntries(lua_State* L)
+{
+	LuaPushNamedCFunc(L, "new", TableExtra_new);
+	return true;
+}

--- a/rts/Lua/LuaTableExtra.h
+++ b/rts/Lua/LuaTableExtra.h
@@ -1,0 +1,9 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+struct lua_State;
+
+namespace LuaTableExtra {
+	bool PushEntries(lua_State* L);
+};

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -240,7 +240,6 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetConfigString);
 
 	REGISTER_LUA_CFUNC(CreateDir);
-	REGISTER_LUA_CFUNC(AllocateTable);
 
 	REGISTER_LUA_CFUNC(SendCommands);
 	REGISTER_LUA_CFUNC(GiveOrder);
@@ -2623,31 +2622,6 @@ int LuaUnsyncedCtrl::CreateDir(lua_State* L)
 	lua_pushboolean(L, FileSystem::CreateDirectory(dir));
 	return 1;
 }
-
-/***
- *
- * @function Spring.AllocateTable
- * @number narr hint for count of array elements
- * @number nrec hint for count of record elements
- * @treturn table
- */
-int LuaUnsyncedCtrl::AllocateTable(lua_State* L)
-{
-	int narr = luaL_optinteger(L, 1, 0);
-	int nrec = luaL_optinteger(L, 2, 0);
-
-	if (narr < 0) {
-		narr = 0;
-	}
-	if (nrec < 0) {
-		nrec = 0;
-	}
-
-	lua_createtable(L, narr, nrec);
-
-	return 1;
-}
-
 
 
 /******************************************************************************

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -117,7 +117,6 @@ class LuaUnsyncedCtrl {
 		static int SetConfigString(lua_State* L);
 
 		static int CreateDir(lua_State* L);
-		static int AllocateTable(lua_State* L);
 
 		static int Reload(lua_State* L);
 		static int Restart(lua_State* L);


### PR DESCRIPTION
Some Lua extensions (notably, LuaJIT) seem to offer this feature as `table.new`, with the same args we do, and it does feel like a more natural place for it to be. Fixes #1700.