### PR TITLE
Stablize sorts used by path finders

### DIFF
--- a/rts/Sim/Path/HAPFS/PathDataTypes.h
+++ b/rts/Sim/Path/HAPFS/PathDataTypes.h
@@ -39,7 +39,14 @@ struct PathNode {
 /// functor to define node priority
 struct lessCost {
 	inline bool operator() (const PathNode* x, const PathNode* y) const {
-		return (x->fCost == y->fCost) ? (x->gCost < y->gCost) : (x->fCost > y->fCost);
+		if (x->fCost == y->fCost) {
+			if (x->gCost == y->gCost)
+				// This is needed to guarantee that the sorting is stable.
+				return (x->nodeNum < y->nodeNum);
+			else
+				return (x->gCost < y->gCost);
+		} else
+			return (x->fCost > y->fCost);
 	}
 };
 

--- a/rts/Sim/Path/HAPFS/PathDataTypes.h
+++ b/rts/Sim/Path/HAPFS/PathDataTypes.h
@@ -40,7 +40,7 @@ struct PathNode {
 /// This needs to guarantee that the sorting is stable.
 struct lessCost {
 	inline bool operator() (const PathNode* x, const PathNode* y) const {
-		return std::tie(x->fCost, x->gCost, x->nodeNum) > std::tie(y->fCost, y->gCost, y->nodeNum);
+		return std::tie(x->fCost, y->gCost, x->nodeNum) > std::tie(y->fCost, x->gCost, y->nodeNum);
 	}
 };
 

--- a/rts/Sim/Path/HAPFS/PathDataTypes.h
+++ b/rts/Sim/Path/HAPFS/PathDataTypes.h
@@ -39,8 +39,11 @@ struct PathNode {
 /// functor to define node priority
 /// This needs to guarantee that the sorting is stable.
 struct lessCost {
-	inline bool operator() (const PathNode* x, const PathNode* y) const {
-		return std::tie(x->fCost, y->gCost, x->nodeNum) > std::tie(y->fCost, x->gCost, y->nodeNum);
+	inline bool operator() (const PathNode* lhs, const PathNode* rhs) const {
+		// fCost == gCost + hCost.
+		// When fCosts are the same, prioritize the node closest the goal. Since we don't have hCost to hand, we know
+		// that hCost == fCost - gCost. This is why we invert the left/right side for the gCost comparison.
+		return std::tie(lhs->fCost, rhs->gCost, lhs->nodeNum) > std::tie(rhs->fCost, lhs->gCost, rhs->nodeNum);
 	}
 };
 

--- a/rts/Sim/Path/HAPFS/PathDataTypes.h
+++ b/rts/Sim/Path/HAPFS/PathDataTypes.h
@@ -37,16 +37,10 @@ struct PathNode {
 
 
 /// functor to define node priority
+/// This needs to guarantee that the sorting is stable.
 struct lessCost {
 	inline bool operator() (const PathNode* x, const PathNode* y) const {
-		if (x->fCost == y->fCost) {
-			if (x->gCost == y->gCost)
-				// This is needed to guarantee that the sorting is stable.
-				return (x->nodeNum < y->nodeNum);
-			else
-				return (x->gCost < y->gCost);
-		} else
-			return (x->fCost > y->fCost);
+		return std::tie(x->fCost, x->gCost, x->nodeNum) > std::tie(y->fCost, y->gCost, y->nodeNum);
 	}
 };
 

--- a/rts/Sim/Path/QTPFS/PathThreads.h
+++ b/rts/Sim/Path/QTPFS/PathThreads.h
@@ -103,10 +103,7 @@ namespace QTPFS {
     /// Needs to guarantee stable ordering, even if the sorting algorithm itself is not stable.
     struct ShouldMoveTowardsBottomOfPriorityQueue {
         inline bool operator() (const SearchQueueNode& lhs, const SearchQueueNode& rhs) const {
-            if (lhs.heapPriority == rhs.heapPriority)
-                return (lhs.nodeIndex < rhs.nodeIndex);
-            else
-                return (lhs.heapPriority > rhs.heapPriority);
+            return std::tie(lhs.heapPriority, lhs.nodeIndex) > std::tie(rhs.heapPriority, rhs.nodeIndex);
         }
     };
 

--- a/rts/Sim/Path/QTPFS/PathThreads.h
+++ b/rts/Sim/Path/QTPFS/PathThreads.h
@@ -90,26 +90,6 @@ namespace QTPFS {
     };
 
     struct SearchQueueNode {
-        // Sorting Comparisons
-        // These need to guarantee stable ordering, even if the sorting algorithm itself is not stable.
-        bool operator <  (const SearchQueueNode& n) const {
-        if (heapPriority == n.heapPriority)
-                return (nodeIndex > n.nodeIndex);
-            else
-                return (heapPriority < n.heapPriority);
-        }
-        bool operator >  (const SearchQueueNode& n) const {
-            if (heapPriority == n.heapPriority)
-                return (nodeIndex < n.nodeIndex);
-            else
-                return (heapPriority > n.heapPriority);
-        }
-
-        // General Comparisons
-        bool operator == (const SearchQueueNode& n) const { return (heapPriority == n.heapPriority); }
-        bool operator <= (const SearchQueueNode& n) const { return (heapPriority <= n.heapPriority); }
-        bool operator >= (const SearchQueueNode& n) const { return (heapPriority >= n.heapPriority); }
-
         SearchQueueNode(int index, float newPriorty)
             : heapPriority(newPriorty)
             , nodeIndex(index)
@@ -119,9 +99,21 @@ namespace QTPFS {
         int nodeIndex;
     };
 
+    /// Functor to define node priority.
+    /// Needs to guarantee stable ordering, even if the sorting algorithm itself is not stable.
+    struct ShouldMoveTowardsBottomOfPriorityQueue {
+        inline bool operator() (const SearchQueueNode& lhs, const SearchQueueNode& rhs) const {
+            if (lhs.heapPriority == rhs.heapPriority)
+                return (lhs.nodeIndex < rhs.nodeIndex);
+            else
+                return (lhs.heapPriority > rhs.heapPriority);
+        }
+    };
+
+
     // Reminder that std::priority does comparisons to push element back to the bottom. So using
-    // std::greater here means the smallest value will be top()
-    typedef std::priority_queue<SearchQueueNode, std::vector<SearchQueueNode>, std::greater<SearchQueueNode>> SearchPriorityQueue;
+    // ShouldMoveTowardsBottomOfPriorityQueue here means the smallest value will be top()
+    typedef std::priority_queue<SearchQueueNode, std::vector<SearchQueueNode>, ShouldMoveTowardsBottomOfPriorityQueue> SearchPriorityQueue;
 
 	struct SearchThreadData {
 

--- a/rts/Sim/Path/QTPFS/PathThreads.h
+++ b/rts/Sim/Path/QTPFS/PathThreads.h
@@ -93,17 +93,17 @@ namespace QTPFS {
         // Sorting Comparisons
         // These need to guarantee stable ordering, even if the sorting algorithm itself is not stable.
         bool operator <  (const SearchQueueNode& n) const {
+        if (heapPriority == n.heapPriority)
+                return (nodeIndex > n.nodeIndex);
+            else
+                return (heapPriority < n.heapPriority);
+        }
+        bool operator >  (const SearchQueueNode& n) const {
             if (heapPriority == n.heapPriority)
-                    return (nodeIndex > n.nodeIndex);
-                else
-                    return (heapPriority < n.heapPriority);
-            }
-            bool operator >  (const SearchQueueNode& n) const {
-                if (heapPriority == n.heapPriority)
-                    return (nodeIndex < n.nodeIndex);
-                else
-                    return (heapPriority > n.heapPriority);
-            }
+                return (nodeIndex < n.nodeIndex);
+            else
+                return (heapPriority > n.heapPriority);
+        }
 
         // General Comparisons
         bool operator == (const SearchQueueNode& n) const { return (heapPriority == n.heapPriority); }

--- a/rts/Sim/Path/QTPFS/PathThreads.h
+++ b/rts/Sim/Path/QTPFS/PathThreads.h
@@ -90,11 +90,25 @@ namespace QTPFS {
     };
 
     struct SearchQueueNode {
-		bool operator <  (const SearchQueueNode& n) const { return (heapPriority <  n.heapPriority); }
-		bool operator >  (const SearchQueueNode& n) const { return (heapPriority >  n.heapPriority); }
-		bool operator == (const SearchQueueNode& n) const { return (heapPriority == n.heapPriority); }
-		bool operator <= (const SearchQueueNode& n) const { return (heapPriority <= n.heapPriority); }
-		bool operator >= (const SearchQueueNode& n) const { return (heapPriority >= n.heapPriority); }
+        // Sorting Comparisons
+        // These need to guarantee stable ordering, even if the sorting algorithm itself is not stable.
+        bool operator <  (const SearchQueueNode& n) const {
+            if (heapPriority == n.heapPriority)
+                    return (nodeIndex > n.nodeIndex);
+                else
+                    return (heapPriority < n.heapPriority);
+            }
+            bool operator >  (const SearchQueueNode& n) const {
+                if (heapPriority == n.heapPriority)
+                    return (nodeIndex < n.nodeIndex);
+                else
+                    return (heapPriority > n.heapPriority);
+            }
+
+        // General Comparisons
+        bool operator == (const SearchQueueNode& n) const { return (heapPriority == n.heapPriority); }
+        bool operator <= (const SearchQueueNode& n) const { return (heapPriority <= n.heapPriority); }
+        bool operator >= (const SearchQueueNode& n) const { return (heapPriority >= n.heapPriority); }
 
         SearchQueueNode(int index, float newPriorty)
             : heapPriority(newPriorty)


### PR DESCRIPTION
std::priority_que doesn't guarantee that the sorts it performs is stable. This could potentially lead to a desync between different platforms or build chains.