### PR TITLE
Don't preload glyphs for non-alphanumeric fonts.

### DIFF
--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -601,6 +601,9 @@ CFontTexture::CFontTexture(const std::string& fontfile, int size, int _outlinesi
 	// precache ASCII glyphs & kernings (save them in kerningPrecached array for better lvl2 cpu cache hitrate)
 
 	//preload Glyphs
+	// if given face doesn't contain alphanumerics, don't preload it
+	if (!FT_Get_Char_Index(face, 'a'))
+		return;
 	LoadWantedGlyphs(32, 127);
 	for (char32_t i = 32; i < 127; ++i) {
 		const auto& lgl = GetGlyph(i);


### PR DESCRIPTION
### Work done

- Don't preload glyphs for non-alphanumeric fonts

### Explanation

- Forces loading lots of fallbacks in that case so not very useful
- Have this in the `colored-fonts` branch, but doesn't really belong there.
- Fits better into the `fallback-fonts*` branches (just because with that ppl will likely be using more non-alphanumeric fonts), but anyways I think this is stand alone so maybe we can review and merge this independently.