### PR TITLE
Allow negative index at GetUnitCurrentCommand to index from queue end.

### DIFF
--- a/rts/Lua/LuaConstEngine.cpp
+++ b/rts/Lua/LuaConstEngine.cpp
@@ -39,7 +39,8 @@ bool LuaConstEngine::PushEntries(lua_State* L)
 
 
 	lua_pushliteral(L, "FeatureSupport");
-	lua_createtable(L, 0, 2);
+	lua_createtable(L, 0, 3);
+		LuaPushNamedBool(L, "NegativeGetUnitCurrentCommand", true);
 		LuaPushNamedBool(L, "hasExitOnlyYardmaps", true);
 		LuaPushNamedNumber(L, "rmlUiApiVersion", 1);
 	lua_rawset(L, -3);

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -5977,6 +5977,10 @@ static void PackCommandQueue(lua_State* L, const CCommandQueue& commands, size_t
 /***
  *
  * @function Spring.GetUnitCurrentCommand
+ *
+ * @number unitID Unit id.
+ * @number cmdIndex Command index to get. If negative will count from the end of the queue,
+ * for example -1 will be the last command.
  */
 int LuaSyncedRead::GetUnitCurrentCommand(lua_State* L)
 {
@@ -5989,10 +5993,15 @@ int LuaSyncedRead::GetUnitCurrentCommand(lua_State* L)
 	const CFactoryCAI* factoryCAI = dynamic_cast<const CFactoryCAI*>(commandAI);
 	const CCommandQueue* queue = (factoryCAI == nullptr)? &commandAI->commandQue : &factoryCAI->newUnitCommands;
 
-	// - 1 to convert from lua index to C index
-	const unsigned int cmdIndex = luaL_optint(L, 2, 1) - 1;
+	unsigned int cmdIndex = luaL_optint(L, 2, 1);
+	if (cmdIndex > 0) {
+		// - 1 to convert from lua index to C index
+		cmdIndex -= 1;
+	} else {
+		cmdIndex = queue->size()-cmdIndex;
+	}
 
-	if (cmdIndex >= queue->size())
+	if (cmdIndex >= queue->size() || cmdIndex < 0)
 		return 0;
 
 	const Command& cmd = queue->at(cmdIndex);

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -5993,7 +5993,7 @@ int LuaSyncedRead::GetUnitCurrentCommand(lua_State* L)
 	const CFactoryCAI* factoryCAI = dynamic_cast<const CFactoryCAI*>(commandAI);
 	const CCommandQueue* queue = (factoryCAI == nullptr)? &commandAI->commandQue : &factoryCAI->newUnitCommands;
 
-	unsigned int cmdIndex = luaL_optint(L, 2, 1);
+	int cmdIndex = luaL_optint(L, 2, 1);
 	if (cmdIndex > 0) {
 		// - 1 to convert from lua index to C index
 		cmdIndex -= 1;


### PR DESCRIPTION
### Work done

- Allow negative index at GetUnitCurrentCommand to index from the end of the queue.

### Related issues

- https://github.com/beyond-all-reason/spring/issues/1725

