### PR TITLE
Add Spring.GetUnitCommandCount for getting a units command queue count.

### DIFF
--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -169,6 +169,7 @@ class LuaSyncedRead {
 		static int GetUnitBlocking(lua_State* L);
 		static int GetUnitMoveTypeData(lua_State* L);
 
+		static int GetUnitCommandCount(lua_State* L);
 		static int GetUnitCommands(lua_State* L);
 		static int GetUnitCurrentCommand(lua_State* L);
 		static int GetFactoryCounts(lua_State* L);


### PR DESCRIPTION
### Work done

* Add Spring.GetUnitCommandCount to get a units command queue count.
* Deprecate getting the count from GetUnitCommands/GetCommandQueue.

### Related issues

* https://github.com/beyond-all-reason/spring/issues/1725