### PR TITLE
Add Spring.GetUnitCurrentCommandID a cmdID from a units queue.

### DIFF
--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -6027,7 +6027,7 @@ int LuaSyncedRead::GetUnitCurrentCommandID(lua_State* L)
 	const CCommandQueue* queue = (factoryCAI == nullptr)? &commandAI->commandQue : &factoryCAI->newUnitCommands;
 
 	// - 1 to convert from lua index to C index
-	unsigned int cmdIndex = luaL_optint(L, 2, 1);
+	int cmdIndex = luaL_optint(L, 2, 1);
 	if (cmdIndex > 0) {
 		// - 1 to convert from lua index to C index
 		cmdIndex -= 1;

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -171,6 +171,7 @@ class LuaSyncedRead {
 
 		static int GetUnitCommands(lua_State* L);
 		static int GetUnitCurrentCommand(lua_State* L);
+		static int GetUnitCurrentCommandID(lua_State* L);
 		static int GetFactoryCounts(lua_State* L);
 		static int GetFactoryCommands(lua_State* L);
 


### PR DESCRIPTION
### Work done

* Add Spring.GetUnitCurrentCommandID to get the cmdID for a specific command at the units queue.

### Remarks

* Since most of the implementation is the same as GetUnitCurrentCommand can wait to merge https://github.com/beyond-all-reason/spring/pull/1813 and refactor this so both functions reuse code.
* Could be called Spring.GetUnitCommandID instead maybe, but then the other function would have to be renamed too for consistency.

### Rationale

* I seen several widgets looking at the last command in queue, or sometimes first one, just to see if it's a specific cmdID. Since this can usually be done at AllowCommand or UnitCommand callins I think it's worth it to provide a method that's more optimal, since that can run so many times when a command is given for 100s of units against 10s/100s of other units.

### Related issues

* https://github.com/beyond-all-reason/spring/issues/1725