### PR TITLE
Accept nil for params and options arguments for Spring.GiveOrder family functions.

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -5209,8 +5209,8 @@ int LuaSyncedCtrl::SetProjectileCEG(lua_State* L)
  * Used when assigning multiple commands at once
  *
  * @number cmdID
- * @tparam {number,...} params
- * @tparam cmdOpts options
+ * @tparam {number,...}|nil params
+ * @tparam cmdOpts|nil options
  */
 
 
@@ -5239,8 +5239,8 @@ int LuaSyncedCtrl::UnitFinishCommand(lua_State* L)
  * @function Spring.GiveOrderToUnit
  * @number unitID
  * @number cmdID
- * @tparam {number,...} params
- * @tparam cmdOpts options
+ * @tparam {number,...}|nil params
+ * @tparam cmdOpts|nil options
  * @treturn bool unitOrdered
  */
 int LuaSyncedCtrl::GiveOrderToUnit(lua_State* L)
@@ -5275,8 +5275,8 @@ int LuaSyncedCtrl::GiveOrderToUnit(lua_State* L)
  * @function Spring.GiveOrderToUnitMap
  * @tparam {[number]=table,...} unitMap table with unitIDs as keys
  * @number cmdID
- * @tparam {number,...} params
- * @tparam cmdOpts options
+ * @tparam {number,...}|nil params
+ * @tparam cmdOpts|nil options
  * @treturn number unitsOrdered
  */
 int LuaSyncedCtrl::GiveOrderToUnitMap(lua_State* L)
@@ -5318,8 +5318,8 @@ int LuaSyncedCtrl::GiveOrderToUnitMap(lua_State* L)
  * @function Spring.GiveOrderToUnitArray
  * @tparam {number,...} unitIDs
  * @number cmdID
- * @tparam {number,...} params
- * @tparam cmdOpts options
+ * @tparam {number,...}|nil params
+ * @tparam cmdOpts|nil options
  * @treturn number unitsOrdered
  */
 int LuaSyncedCtrl::GiveOrderToUnitArray(lua_State* L)

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -980,6 +980,10 @@ static bool ParseCommandOptions(
 		return true;
 	}
 
+	if (lua_isnoneornil(L, idx)) {
+		return true;
+	}
+
 	if (lua_istable(L, idx)) {
 		for (lua_pushnil(L); lua_next(L, idx) != 0; lua_pop(L, 1)) {
 			// "key" = value (table format of CommandNotify)
@@ -1080,8 +1084,8 @@ Command LuaUtils::ParseCommand(lua_State* L, const char* caller, int idIndex)
 
 				cmd.PushParam(lua_tofloat(L, -1));
 			}
-		} else {
-			luaL_error(L, "%s(): bad param (expected table or number)", caller);
+		} else if (!lua_isnoneornil(L, paramTableIdx)) {
+			luaL_error(L, "%s(): bad param (expected table, number or nil)", caller);
 		}
 	}
 
@@ -1124,8 +1128,8 @@ Command LuaUtils::ParseCommandTable(lua_State* L, const char* caller, int tableI
 
 				cmd.PushParam(lua_tofloat(L, -1));
 			}
-		} else {
-			luaL_error(L, "%s(): bad param (expected table or number)", caller);
+		} else if (!lua_isnil(L, -1)) {
+			luaL_error(L, "%s(): bad param (expected table, number or nil)", caller);
 		}
 
 		lua_pop(L, 1);


### PR DESCRIPTION
###  Work done

- Make GiveOrder functions accept nil/none for params and options arguments.
- Affected functions:
  - GiveOrderToUnit
  - GiveOrderToUnitMap
  - GiveOrderToUnitArray
  - GiveOrderArrayToUnit
  - GiveOrderArrayToUnitMap
  - GiveOrderArrayToUnitArray

### Related issues

- fixes https://github.com/beyond-all-reason/spring/issues/1821

### Remarks

- This allows skipping the arguments altogether on the calls, like: Spring.GiveOrderToUnit(unitID, CMD.STOP)
- Also allows setting an empty params without passing an empty table, previously it wasn't possible.
  - Spring.GiveOrderToUnit(unitID, CMD.SELFD, nil, {"shift"})
  - Ppl sometimes passing 0 there to avoid a table, but it's incorrect since it adds a param with value 0.

### How to test

- Get bar branch https://github.com/saurtron/Beyond-All-Reason/tree/nil-params-or-opts
  - Has [some calls](https://github.com/saurtron/Beyond-All-Reason/commit/595672364cde4e9700547c20aa539a42de733467) modified to set params or opts to nil (or none).
- Start skirmish in neverend mode
- Place commander
- /runtests selfd