### PR TITLE
Add selectableKilled modrule to control whether dead units should be selectable

### DIFF
--- a/rts/Game/SelectedUnitsHandler.cpp
+++ b/rts/Game/SelectedUnitsHandler.cpp
@@ -397,7 +397,7 @@ void CSelectedUnitsHandler::AddUnit(CUnit* unit)
 	if (trans != nullptr && trans->unitDef->IsTransportUnit() && !trans->unitDef->isFirePlatform)
 		return;
 
-	if (unit->noSelect)
+	if (unit->noSelect || unit->isDead)
 		return;
 
 	if (selectedUnits.insert(unit->id).second)
@@ -475,7 +475,7 @@ void CSelectedUnitsHandler::SelectGroup(int num)
 	for (const int unitID: group->units) {
 		CUnit* u = unitHandler.GetUnit(unitID);
 
-		if (!u->noSelect) {
+		if (!u->noSelect && !u->isDead) {
 			u->isSelected = true;
 			selectedUnits.insert(u->id);
 			AddDeathDependence(u, DEPENDENCE_SELECTED);

--- a/rts/Game/SelectedUnitsHandler.cpp
+++ b/rts/Game/SelectedUnitsHandler.cpp
@@ -397,7 +397,7 @@ void CSelectedUnitsHandler::AddUnit(CUnit* unit)
 	if (trans != nullptr && trans->unitDef->IsTransportUnit() && !trans->unitDef->isFirePlatform)
 		return;
 
-	if (unit->noSelect || unit->isDead)
+	if (unit->noSelect)
 		return;
 
 	if (selectedUnits.insert(unit->id).second)
@@ -475,7 +475,7 @@ void CSelectedUnitsHandler::SelectGroup(int num)
 	for (const int unitID: group->units) {
 		CUnit* u = unitHandler.GetUnit(unitID);
 
-		if (!u->noSelect && !u->isDead) {
+		if (!u->noSelect) {
 			u->isSelected = true;
 			selectedUnits.insert(u->id);
 			AddDeathDependence(u, DEPENDENCE_SELECTED);

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -131,6 +131,9 @@ void CModInfo::ResetState()
 		// make windChangeReportPeriod equal to EnvResourceHandler::WIND_UPDATE_RATE = 15 * GAME_SPEED;
 		windChangeReportPeriod = 15 * GAME_SPEED;
 	}
+	{
+		selectableKilled = true;
+	}
 }
 
 void CModInfo::Init(const std::string& modFileName)
@@ -340,6 +343,10 @@ void CModInfo::Init(const std::string& modFileName)
 		const LuaTable& misc = root.SubTable("misc");
 
 		windChangeReportPeriod = static_cast<int>(math::roundf(misc.GetFloat("windChangeReportPeriod", static_cast<float>(windChangeReportPeriod) / GAME_SPEED) * GAME_SPEED));
+	}
+	{
+		//selection
+		selectableKilled = root.GetBool("selectableKilled", selectableKilled);
 	}
 
 	if (!std::has_single_bit <unsigned> (quadFieldQuadSizeInElmos))

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -237,6 +237,9 @@ public:
 
 	// how often to report wind speed/direction to wind gens
 	int windChangeReportPeriod;
+
+	// selection behaviour
+	bool selectableKilled;
 };
 
 extern CModInfo modInfo;

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -481,9 +481,11 @@ void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, i
 	ReleaseTransportees(attacker, selfDestruct, reclaimed);
 
 	// release from selection
-	noSelect = true;
-	if (isSelected)
-		selectedUnitsHandler.RemoveUnit(this);
+	if (!modInfo.selectableKilled) {
+		noSelect = true;
+		if (isSelected)
+			selectedUnitsHandler.RemoveUnit(this);
+	}
 
 	// pre-destruction event; unit may be kept around for its death sequence
 	eventHandler.UnitDestroyed(this, attacker, weaponDefID);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -480,6 +480,10 @@ void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, i
 	// release attached units
 	ReleaseTransportees(attacker, selfDestruct, reclaimed);
 
+	// release from selection
+	if (isSelected)
+		selectedUnitsHandler.RemoveUnit(this);
+
 	// pre-destruction event; unit may be kept around for its death sequence
 	eventHandler.UnitDestroyed(this, attacker, weaponDefID);
 	eoh->UnitDestroyed(*this, attacker, weaponDefID);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -480,19 +480,18 @@ void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, i
 	// release attached units
 	ReleaseTransportees(attacker, selfDestruct, reclaimed);
 
+	// pre-destruction event; unit may be kept around for its death sequence
+	eventHandler.UnitDestroyed(this, attacker, weaponDefID);
+	eoh->UnitDestroyed(*this, attacker, weaponDefID);
+
 	// release from selection
 	if (!modInfo.selectableKilled) {
 		noSelect = true;
 		if (isSelected)
 			selectedUnitsHandler.RemoveUnit(this);
+
+		SetGroup(nullptr);
 	}
-
-	// pre-destruction event; unit may be kept around for its death sequence
-	eventHandler.UnitDestroyed(this, attacker, weaponDefID);
-	eoh->UnitDestroyed(*this, attacker, weaponDefID);
-
-	// Will be called in the destructor again, but this can not hurt
-	SetGroup(nullptr);
 
 	if (unitDef->windGenerator > 0.0f)
 		envResHandler.DelGenerator(this);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -481,6 +481,7 @@ void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, i
 	ReleaseTransportees(attacker, selfDestruct, reclaimed);
 
 	// release from selection
+	noSelect = true;
 	if (isSelected)
 		selectedUnitsHandler.RemoveUnit(this);
 


### PR DESCRIPTION
### Work Done

- Make Unit.cpp call selectedUnitsHandler::RemoveUnit on unit::ForcedUnitKill.
- Make Unit also set noSelect when killed.
- Controllable through modrules `selectableKilled`
  - defaults to true for backwards compatibility

### Remarks

- Current behavour is ambivalent, since units get removed from groups but not from selection.
- Seems just an overlook
- This is a real issue because api users get confused by units still in selection even after UnitDestroyed called

### How to test

- Get BAR branch from https://github.com/saurtron/Beyond-All-Reason/tree/test-selection-destroy
  - Could make a better test, but this is the one I used to find the issue
- Start skirmish in neverend game end mode
- Start game
- Run /runtests attackrange
  - You might need to run this several times, but finally the assertion will trigger
  - gui_attackrange_gl4.lua has an issue where GetSelection still returns dead units, thus corrupting its logic
  - Might be other affected lua code in the wild not sure
