### PR TITLE
Dollycam zero transition time

### DIFF
--- a/rts/Game/Camera/DollyController.cpp
+++ b/rts/Game/Camera/DollyController.cpp
@@ -124,7 +124,7 @@ void CDollyController::Update()
 		newRot.y += math::TWOPI * Sign(ydiff);
 	}
 	rot = newRot;
-	camHandler->CameraTransition(0.01f);
+	camHandler->CameraTransition(0.0f);
 }
 
 void CDollyController::SwitchTo(const CCameraController* oldCam, const bool showText)

--- a/rts/Game/Camera/DollyController.cpp
+++ b/rts/Game/Camera/DollyController.cpp
@@ -124,6 +124,8 @@ void CDollyController::Update()
 		newRot.y += math::TWOPI * Sign(ydiff);
 	}
 	rot = newRot;
+	/* Note, even an epsilon value here will make the camera
+	 * fail to track when smoothness is set high enough */
 	camHandler->CameraTransition(0.0f);
 }
 


### PR DESCRIPTION
The dolly camera needs to move to each position along the track instantly because when the camera smoothness is turned way up it will fail to follow the track