### PR TITLE
Platform: add totalRAM.

### DIFF
--- a/rts/Lua/LuaConstPlatform.cpp
+++ b/rts/Lua/LuaConstPlatform.cpp
@@ -34,7 +34,7 @@
  * @number sdlVersionLinkedMajor
  * @number sdlVersionLinkedMinor
  * @number sdlVersionLinkedPatch
- * @number totalMemory Total physical system RAM in MBs.
+ * @number totalRAM Total physical system RAM in MBs.
  * @bool glSupportNonPowerOfTwoTex
  * @bool glSupportTextureQueryLOD
  * @bool glSupport24bitDepthBuffer
@@ -110,7 +110,7 @@ bool LuaConstPlatform::PushEntries(lua_State* L)
 	LuaPushNamedString(L, "hwConfig", Platform::GetHardwareStr());
 	LuaPushNamedNumber(L, "cpuLogicalCores", Threading::GetLogicalCpuCores());
 	LuaPushNamedNumber(L, "cpuPhysicalCores", Threading::GetPhysicalCpuCores());
-	LuaPushNamedNumber(L, "totalMemory", Platform::TotalRAM()/1e6);
+	LuaPushNamedNumber(L, "totalRAM", Platform::TotalRAM()/1e6);
 
 	LuaPushNamedString(L, "sysInfoHash", Platform::GetSysInfoHash());
 	LuaPushNamedString(L, "macAddrHash", Platform::GetMacAddrHash());

--- a/rts/Lua/LuaConstPlatform.cpp
+++ b/rts/Lua/LuaConstPlatform.cpp
@@ -109,6 +109,7 @@ bool LuaConstPlatform::PushEntries(lua_State* L)
 	LuaPushNamedString(L, "hwConfig", Platform::GetHardwareStr());
 	LuaPushNamedNumber(L, "cpuLogicalCores", Threading::GetLogicalCpuCores());
 	LuaPushNamedNumber(L, "cpuPhysicalCores", Threading::GetPhysicalCpuCores());
+	LuaPushNamedNumber(L, "totalMemory", Platform::TotalRAM());
 
 	LuaPushNamedString(L, "sysInfoHash", Platform::GetSysInfoHash());
 	LuaPushNamedString(L, "macAddrHash", Platform::GetMacAddrHash());

--- a/rts/Lua/LuaConstPlatform.cpp
+++ b/rts/Lua/LuaConstPlatform.cpp
@@ -2,6 +2,7 @@
 
 #include "LuaConstPlatform.h"
 #include "LuaUtils.h"
+#include "System/Platform/Hardware.h"
 #include "System/Platform/Misc.h"
 #include "Rendering/GlobalRendering.h"
 #include "Rendering/GlobalRenderingInfo.h"

--- a/rts/Lua/LuaConstPlatform.cpp
+++ b/rts/Lua/LuaConstPlatform.cpp
@@ -109,7 +109,7 @@ bool LuaConstPlatform::PushEntries(lua_State* L)
 	LuaPushNamedString(L, "hwConfig", Platform::GetHardwareStr());
 	LuaPushNamedNumber(L, "cpuLogicalCores", Threading::GetLogicalCpuCores());
 	LuaPushNamedNumber(L, "cpuPhysicalCores", Threading::GetPhysicalCpuCores());
-	LuaPushNamedNumber(L, "totalMemory", Platform::TotalRAM());
+	LuaPushNamedNumber(L, "totalMemory", Platform::TotalRAM()/1e6);
 
 	LuaPushNamedString(L, "sysInfoHash", Platform::GetSysInfoHash());
 	LuaPushNamedString(L, "macAddrHash", Platform::GetMacAddrHash());

--- a/rts/Lua/LuaConstPlatform.cpp
+++ b/rts/Lua/LuaConstPlatform.cpp
@@ -34,6 +34,7 @@
  * @number sdlVersionLinkedMajor
  * @number sdlVersionLinkedMinor
  * @number sdlVersionLinkedPatch
+ * @number totalMemory Total physical system RAM in MBs.
  * @bool glSupportNonPowerOfTwoTex
  * @bool glSupportTextureQueryLOD
  * @bool glSupport24bitDepthBuffer

--- a/rts/System/CMakeLists.txt
+++ b/rts/System/CMakeLists.txt
@@ -127,11 +127,13 @@ make_global_var(sources_engine_System_Log_sinkOutputDebugString
 	)
 set(sources_engine_System_Platform_Linux
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Linux/CrashHandler.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Linux/Hardware.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Linux/SoLib.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Linux/MessageBox.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Linux/WindowManagerHelper.cpp"
 	)
 set(sources_engine_System_Platform_Mac
+		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Linux/Hardware.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Linux/SoLib.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Mac/MessageBox.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Mac/CrashHandler.cpp"
@@ -141,6 +143,7 @@ set(sources_engine_System_Platform_Mac
 set(sources_engine_System_Platform_Windows
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Win/CrashHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Win/DllLib.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Win/Hardware.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Win/MessageBox.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Win/seh.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Win/WinVersion.cpp"

--- a/rts/System/Platform/Hardware.h
+++ b/rts/System/Platform/Hardware.h
@@ -1,0 +1,14 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef PLATFORM_HARDWARE_H
+#define PLATFORM_HARDWARE_H
+
+#include <cstdint>
+
+namespace Platform
+{
+	uint64_t TotalRAM();
+	uint64_t TotalPageFile();
+}
+
+#endif // PLATFORM_HARDWARE_H

--- a/rts/System/Platform/Linux/Hardware.cpp
+++ b/rts/System/Platform/Linux/Hardware.cpp
@@ -1,0 +1,19 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include <unistd.h>
+
+#include "System/Platform/Hardware.h"
+
+namespace Platform
+{
+	uint64_t TotalRAM() {
+		long pages = sysconf(_SC_PHYS_PAGES);
+		long page_size = sysconf(_SC_PAGE_SIZE);
+		return pages * page_size;
+	}
+	uint64_t TotalPageFile() {
+		// NOT IMPLEMENTED
+		return 0;
+	}
+
+}

--- a/rts/System/Platform/Misc.cpp
+++ b/rts/System/Platform/Misc.cpp
@@ -462,6 +462,18 @@ namespace Platform
 	}
 	#endif
 
+	uint64_t TotalRAM() {
+#ifdef _WIN32
+		MEMORYSTATUSEX status;
+		status.dwLength = sizeof(status);
+		GlobalMemoryStatusEx(&status);
+		return status.ullTotalPhys;
+#else
+		long pages = sysconf(_SC_PHYS_PAGES);
+		long page_size = sysconf(_SC_PAGE_SIZE);
+		return pages * page_size;
+#endif
+	}
 
 	std::string GetSysInfoHash() {
 		std::vector<uint8_t> sysInfo;

--- a/rts/System/Platform/Misc.h
+++ b/rts/System/Platform/Misc.h
@@ -96,7 +96,6 @@ namespace Platform
 	bool Is32BitEmulation();
 	bool IsRunningInDebugger();
 
-	uint64_t TotalRAM();
 	uint64_t FreeDiskSpace(const std::string& path);
 	uint32_t NativeWordSize(); // compiled process code
 	uint32_t SystemWordSize(); // host operating system

--- a/rts/System/Platform/Misc.h
+++ b/rts/System/Platform/Misc.h
@@ -96,6 +96,7 @@ namespace Platform
 	bool Is32BitEmulation();
 	bool IsRunningInDebugger();
 
+	uint64_t TotalRAM();
 	uint64_t FreeDiskSpace(const std::string& path);
 	uint32_t NativeWordSize(); // compiled process code
 	uint32_t SystemWordSize(); // host operating system

--- a/rts/System/Platform/Win/Hardware.cpp
+++ b/rts/System/Platform/Win/Hardware.cpp
@@ -1,0 +1,25 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include <windows.h>
+
+#include "System/Platform/Hardware.h"
+
+namespace Platform
+{
+	MEMORYSTATUSEX GetMemoryInfo() {
+		MEMORYSTATUSEX status;
+		status.dwLength = sizeof(status);
+		GlobalMemoryStatusEx(&status);
+		return status;
+	}
+
+	uint64_t TotalRAM() {
+		MEMORYSTATUSEX status = GetMemoryInfo();
+		return status.ullTotalPhys;
+	}
+
+	uint64_t TotalPageFile() {
+		MEMORYSTATUSEX status = GetMemoryInfo();
+		return status.ullTotalPageFile;
+	}
+}

--- a/rts/System/Platform/Win/WinVersion.cpp
+++ b/rts/System/Platform/Win/WinVersion.cpp
@@ -326,7 +326,7 @@ std::string windows::GetHardwareString()
 		oss << "cannot open key with processor data; ";
 	}
 
-	oss << (TotalRAM() / div) << "MB RAM, ";
-	oss << (TotalPageFile() / div) << "MB pagefile";
+	oss << (Platform::TotalRAM() / div) << "MB RAM, ";
+	oss << (Platform::TotalPageFile() / div) << "MB pagefile";
 	return oss.str();
 }

--- a/rts/System/Platform/Win/WinVersion.cpp
+++ b/rts/System/Platform/Win/WinVersion.cpp
@@ -67,6 +67,7 @@ typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 #define SM_SERVERR2 89
 #endif
 
+#include "System/Platform/Hardware.h"
 
 // from http://msdn.microsoft.com/en-us/library/ms724429(VS.85).aspx
 // Windows version table mapping (as of november 2018) is as follows:
@@ -325,13 +326,7 @@ std::string windows::GetHardwareString()
 		oss << "cannot open key with processor data; ";
 	}
 
-	MEMORYSTATUSEX statex;
-	constexpr int div = 1024 * 1024;
-	statex.dwLength = sizeof(statex);
-
-	GlobalMemoryStatusEx(&statex);
-
-	oss << (statex.ullTotalPhys / div) << "MB RAM, ";
-	oss << (statex.ullTotalPageFile / div) << "MB pagefile";
+	oss << (TotalRAM() / div) << "MB RAM, ";
+	oss << (TotalPageFile() / div) << "MB pagefile";
 	return oss.str();
 }

--- a/rts/System/Platform/Win/WinVersion.cpp
+++ b/rts/System/Platform/Win/WinVersion.cpp
@@ -326,6 +326,7 @@ std::string windows::GetHardwareString()
 		oss << "cannot open key with processor data; ";
 	}
 
+	constexpr int div = 1024 * 1024;
 	oss << (Platform::TotalRAM() / div) << "MB RAM, ";
 	oss << (Platform::TotalPageFile() / div) << "MB pagefile";
 	return oss.str();

--- a/rts/builds/dedicated/CMakeLists.txt
+++ b/rts/builds/dedicated/CMakeLists.txt
@@ -127,8 +127,11 @@ set(system_files
 	${ENGINE_SRC_ROOT_DIR}/System/float4.cpp
 	)
 if    (WIN32)
+	list(APPEND system_files ${ENGINE_SRC_ROOT_DIR}/System/Platform/Win/Hardware.cpp)
 	list(APPEND system_files ${ENGINE_SRC_ROOT_DIR}/System/Platform/Win/WinVersion.cpp)
-endif (WIN32)
+else  ()
+	list(APPEND system_files ${ENGINE_SRC_ROOT_DIR}/System/Platform/Linux/Hardware.cpp)
+endif ()
 
 set(engineDedicatedSources
 	${system_files}

--- a/tools/DemoTool/CMakeLists.txt
+++ b/tools/DemoTool/CMakeLists.txt
@@ -21,10 +21,12 @@ set(PLATFORM_SRCS "")
 set(PLATFORM_LIBS "")
 
 if     (WIN32)
+	list(APPEND PLATFORM_SRCS "${ENGINE_SRC_ROOT_DIR}/System/Platform/Win/Hardware.cpp")
 	list(APPEND PLATFORM_SRCS "${ENGINE_SRC_ROOT_DIR}/System/Platform/Win/WinVersion.cpp")
 
 	list(APPEND PLATFORM_LIBS "iphlpapi")
 elseif (UNIX)
+	list(APPEND PLATFORM_SRCS "${ENGINE_SRC_ROOT_DIR}/System/Platform/Linux/Hardware.cpp")
 	list(APPEND PLATFORM_LIBS "${CMAKE_DL_LIBS}")
 endif  (WIN32)
 

--- a/tools/unitsync/CMakeLists.txt
+++ b/tools/unitsync/CMakeLists.txt
@@ -92,9 +92,11 @@ set(main_files
 	"${ENGINE_SRC_ROOT}/System/StringUtil.cpp"
 	)
 if (WIN32)
+	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Win/Hardware.cpp")
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Win/WinVersion.cpp")
 else (WIN32)
-        list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Linux/ThreadSupport.cpp")
+	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Linux/Hardware.cpp")
+	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Linux/ThreadSupport.cpp")
 endif (WIN32)
 
 set(unitsync_files


### PR DESCRIPTION
### Work done

- Add Platform.totalRAM to get total system ram as a number in MB.

### Related issues

- Fixes https://github.com/beyond-all-reason/spring/issues/1640
  - not the same name but imo AvailableRAM or FreeRAM should be reserved for smth else reporting actual free ram, that seems a bit trickier tho and possibly not so useful because the number could be misleading, so for now just adding TotalRAM.

### Remarks

- I see games having to parse the hardware string, that seems awkward and fragile.
- Not sure if I'm using the best approach here, _SC_PHYS_PAGES is not POSIX standard, but I hope it won't be a problem. It does seem to be supported in [freebsd](https://man.freebsd.org/cgi/man.cgi?query=sysconf&sektion=3&manpath=FreeBSD+9.1-RELEASE) as well as [linux](https://www.man7.org/linux/man-pages/man3/sysconf.3.html).