### PR TITLE
Add Spring.GetSoundDevices.

### DIFF
--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3122,10 +3122,20 @@ int LuaUnsyncedRead::GetDrawSeconds(lua_State* L)
  * @section sound
 ******************************************************************************/
 
+/*** Sound device spec
+ *
+ * @table soundDeviceSpec
+ *
+ * Contains data about a sound device
+ *
+ * @string name
+ */
+
+
 /***
  *
  * @function Spring.GetSoundDevices
- * @treturn {[string],...} deviceNames Array of device names
+ * @treturn {[soundDeviceSpec],...} devices Sound devices
  */
 int LuaUnsyncedRead::GetSoundDevices(lua_State* L)
 {
@@ -3135,8 +3145,14 @@ int LuaUnsyncedRead::GetSoundDevices(lua_State* L)
 
 	for(int i; i < devices.size(); ++i) {
 		std::string &device = devices[i];
-		lua_pushsstring(L, device);
-		lua_rawseti(L, -2, i);
+
+                lua_createtable(L, 0, 1); {
+			lua_pushliteral(L, "name");
+	                lua_pushsstring(L, device);
+	                lua_rawset(L, -3);
+		}
+
+                lua_rawseti(L, -2, i);
 	}
 
 	return 1;

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3143,7 +3143,7 @@ int LuaUnsyncedRead::GetSoundDevices(lua_State* L)
 
 	lua_createtable(L, 0, devices.size());
 
-	for(int i; i < devices.size(); ++i) {
+	for (size_t i = 0; i < devices.size(); ++i) {
 		std::string &device = devices[i];
 
                 lua_createtable(L, 0, 1); {

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -68,6 +68,7 @@
 #include "System/Log/DefaultFilter.h"
 #include "System/Platform/SDL1_keysym.h"
 #include "System/Platform/Misc.h"
+#include "System/Sound/ISound.h"
 #include "System/Sound/ISoundChannels.h"
 #include "System/StringUtil.h"
 #include "System/Misc/SpringTime.h"
@@ -220,6 +221,7 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(GetDrawSeconds);
 
+	REGISTER_LUA_CFUNC(GetSoundDevices);
 	REGISTER_LUA_CFUNC(GetSoundStreamTime);
 	REGISTER_LUA_CFUNC(GetSoundEffectParams);
 
@@ -3120,6 +3122,25 @@ int LuaUnsyncedRead::GetDrawSeconds(lua_State* L)
  * @section sound
 ******************************************************************************/
 
+/***
+ *
+ * @function Spring.GetSoundDevices
+ * @treturn {[string],...} deviceNames Array of device names
+ */
+int LuaUnsyncedRead::GetSoundDevices(lua_State* L)
+{
+	std::vector<std::string> devices = sound->GetSoundDevices();
+
+	lua_createtable(L, 0, devices.size());
+
+	for(int i; i < devices.size(); ++i) {
+		std::string &device = devices[i];
+		lua_pushsstring(L, device);
+		lua_rawseti(L, -2, i);
+	}
+
+	return 1;
+}
 
 /***
  *

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3152,7 +3152,7 @@ int LuaUnsyncedRead::GetSoundDevices(lua_State* L)
 	                lua_rawset(L, -3);
 		}
 
-                lua_rawseti(L, -2, i);
+                lua_rawseti(L, -2, i + 1);
 	}
 
 	return 1;

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -136,6 +136,7 @@ class LuaUnsyncedRead {
 
 		static int GetSoundStreamTime(lua_State* L);
 		static int GetSoundEffectParams(lua_State* L);
+		static int GetSoundDevices(lua_State* L);
 
 		static int GetFPS(lua_State* L);
 		static int GetGameSpeed(lua_State* L);

--- a/rts/System/Sound/ISound.h
+++ b/rts/System/Sound/ISound.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 class float3;
 class LuaParser;
@@ -70,6 +71,7 @@ public:
 
 	virtual const float3& GetListenerPos() const = 0;
 
+	virtual std::vector<std::string> GetSoundDevices() = 0;
 public:
 	unsigned numEmptyPlayRequests = 0;
 	unsigned numAbortedPlays = 0;

--- a/rts/System/Sound/Null/NullSound.h
+++ b/rts/System/Sound/Null/NullSound.h
@@ -45,6 +45,8 @@ public:
 	bool LoadSoundDefsImpl(LuaParser* defsParser) { return false; }
 
 	const float3& GetListenerPos() const override { return ZeroVector; }
+
+	std::vector<std::string> GetSoundDevices() override { return std::vector<std::string>(); };
 };
 
 #endif // _NULL_SOUND_H_

--- a/rts/System/Sound/OpenAL/Sound.cpp
+++ b/rts/System/Sound/OpenAL/Sound.cpp
@@ -669,16 +669,11 @@ void CSound::InitThread(int cfgMaxSounds)
 			// LOG("  Implementation: %s", (const char*) alcGetString(curDevice, ALC_DEVICE_SPECIFIER));
 			LOG("  Devices:");
 
-			const bool hasAllEnumExt = alcIsExtensionPresent(nullptr, "ALC_ENUMERATE_ALL_EXT");
-			const bool hasDefEnumExt = alcIsExtensionPresent(nullptr, "ALC_ENUMERATION_EXT");
+			std::vector<std::string> devices = GetSoundDevices();
 
-			if (hasAllEnumExt || hasDefEnumExt) {
-				const char* deviceSpecStr = alcGetString(nullptr, hasAllEnumExt? ALC_ALL_DEVICES_SPECIFIER: ALC_DEVICE_SPECIFIER);
-
-				while (*deviceSpecStr != '\0') {
-					LOG("    [%s]", deviceSpecStr);
-					while (*deviceSpecStr++ != '\0');
-				}
+			if (devices.size()) {
+				for(const std::string& deviceName: devices)
+					LOG("    [%s]", deviceName.c_str());
 			} else {
 				LOG("    [N/A]");
 			}
@@ -1054,3 +1049,20 @@ void CSound::GenSources(int alMaxSounds)
 	}
 }
 
+std::vector<std::string> CSound::GetSoundDevices()
+{
+	std::vector<std::string> devices;
+	const bool hasAllEnumExt = alcIsExtensionPresent(nullptr, "ALC_ENUMERATE_ALL_EXT");
+	const bool hasDefEnumExt = alcIsExtensionPresent(nullptr, "ALC_ENUMERATION_EXT");
+
+	if (hasAllEnumExt || hasDefEnumExt) {
+		const char* deviceSpecStr = alcGetString(nullptr, hasAllEnumExt? ALC_ALL_DEVICES_SPECIFIER: ALC_DEVICE_SPECIFIER);
+
+		while (*deviceSpecStr != '\0') {
+			devices.emplace_back(deviceSpecStr);
+
+			while (*deviceSpecStr++ != '\0');
+		}
+	}
+	return devices;
+}

--- a/rts/System/Sound/OpenAL/Sound.h
+++ b/rts/System/Sound/OpenAL/Sound.h
@@ -71,6 +71,7 @@ public:
 	ALCdevice* GetCurrentDevice() { return curDevice; }
 	int GetFrameSize() const { return frameSize; }
 
+	std::vector<std::string> GetSoundDevices() override;
 private:
 	typedef spring::unordered_map<std::string, std::string> SoundItemNameMap;
 	typedef spring::unordered_map<std::string, SoundItemNameMap> SoundItemDefsMap;


### PR DESCRIPTION
### Work Done

- Add Spring.GetSoundDevices(), returning an array of device names.

### Remarks

- Games having to parse infolog.txt, that seems awkward and fragile.
- Thought about naming it Spring.GetSoundDeviceNames(), in case later we want to return tables with more information about devices (number of channels...), but I thought maybe later we can just add another argument to make it return everything: Spring.GetSoundDevices(full).
- Thought about putting this at Platform, but I guess this is not static since devices can come and go.