### PR TITLE
Remove unit from groups too on SetUnitNoSelect.

### DIFF
--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2187,6 +2187,7 @@ int LuaUnsyncedCtrl::SetUnitNoMinimap(lua_State* L)
  * @function Spring.SetUnitNoSelect
  * @number unitID
  * @bool unitNoSelect whether unit can be selected or not
+ * @bool [opt]doGroups also remove from groups
  * @treturn nil
  */
 int LuaUnsyncedCtrl::SetUnitNoSelect(lua_State* L)
@@ -2205,7 +2206,13 @@ int LuaUnsyncedCtrl::SetUnitNoSelect(lua_State* L)
 		if (selUnits.find(unit->id) != selUnits.end()) {
 			selectedUnitsHandler.RemoveUnit(unit);
 		}
+
+		// also remove from groups if requested
+		bool doGroups = luaL_optboolean(L, 3, false);
+		if (doGroups)
+			unit->SetGroup(nullptr);
 	}
+
 	return 0;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2187,7 +2187,6 @@ int LuaUnsyncedCtrl::SetUnitNoMinimap(lua_State* L)
  * @function Spring.SetUnitNoSelect
  * @number unitID
  * @bool unitNoSelect whether unit can be selected or not
- * @bool [opt]doGroups also remove from groups
  * @treturn nil
  */
 int LuaUnsyncedCtrl::SetUnitNoSelect(lua_State* L)
@@ -2207,12 +2206,9 @@ int LuaUnsyncedCtrl::SetUnitNoSelect(lua_State* L)
 			selectedUnitsHandler.RemoveUnit(unit);
 		}
 
-		// also remove from groups if requested
-		bool doGroups = luaL_optboolean(L, 3, false);
-		if (doGroups)
-			unit->SetGroup(nullptr);
+		// also remove from selection group
+		unit->SetGroup(nullptr);
 	}
-
 	return 0;
 }
 


### PR DESCRIPTION
### Work done

- Remove unit from selection groups when set to "noselect".

### Remarks

- Could use a third parameter to allow control from outside but probably not needed. Let me know if you prefer this to be toggleable through a method argument.
- Atm when units are killed, they are automatically removed from groups, but not from selection. It should probably be removed from both or none, this will allow fixing that while still allowing games to override the behavior with one function call, or if they already calling SetUnitNoSelect it'll work transparently when removing the Unit::OnDestroyed::SetGroup(nullptr).