### PR TITLE
Don't remove unit from groups on CUnit::ForcedKillUnit.

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -484,9 +484,6 @@ void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, i
 	eventHandler.UnitDestroyed(this, attacker, weaponDefID);
 	eoh->UnitDestroyed(*this, attacker, weaponDefID);
 
-	// Will be called in the destructor again, but this can not hurt
-	SetGroup(nullptr);
-
 	if (unitDef->windGenerator > 0.0f)
 		envResHandler.DelGenerator(this);
 


### PR DESCRIPTION
### Work done

- Remove the automatic group removal at ForcedKillUnit.

### Remarks

- Currently the unit is removed from groups but not from selection, I think it should either be removed from both, or none.
  - Fixable also by allowing to be removed from selection like #1824.
  - This is an alternative fix, together with #1853 and maybe adding an example gadget to the engine.