### PR TITLE
Make Cannon respect srcPos on HaveFreeLineOfFire.

### DIFF
--- a/rts/Sim/Weapons/Cannon.cpp
+++ b/rts/Sim/Weapons/Cannon.cpp
@@ -67,8 +67,8 @@ bool CCannon::HaveFreeLineOfFire(const float3 srcPos, const float3 tgtPos, const
 	if (projectileSpeed == 0.0f)
 		return true;
 
-	float3 launchDir = CalcWantedDir(tgtPos - weaponMuzzlePos);
-	float3 targetVec = (tgtPos - weaponMuzzlePos) * XZVector;
+	float3 launchDir = CalcWantedDir(tgtPos - srcPos);
+	float3 targetVec = (tgtPos - srcPos) * XZVector;
 
 	if (launchDir.SqLength() == 0.0f)
 		return false;
@@ -90,7 +90,7 @@ bool CCannon::HaveFreeLineOfFire(const float3 srcPos, const float3 tgtPos, const
 	// and the prior 10.0f buffer is no longer good enough with the accurate coefficients
 	// TODO: allow this ignore distance to be set on a per-unit basis
 	const float groundDist = ((avoidFlags & Collision::NOGROUND) == 0)?
-		CGround::TrajectoryGroundCol(weaponMuzzlePos, targetVec, groundColCheckDistance, linCoeff, qdrCoeff):
+		CGround::TrajectoryGroundCol(srcPos, targetVec, groundColCheckDistance, linCoeff, qdrCoeff):
 		-1.0f;
 	const float angleSpread = (AccuracyExperience() + SprayAngleExperience()) * 0.6f * 0.9f;
 
@@ -98,7 +98,7 @@ bool CCannon::HaveFreeLineOfFire(const float3 srcPos, const float3 tgtPos, const
 		return false;
 
 	// TODO: add a forcedUserTarget mode (enabled with meta key e.g.) and skip this test accordingly
-	return (!TraceRay::TestTrajectoryCone(weaponMuzzlePos, targetVec, xzTargetDist, linCoeff, qdrCoeff, angleSpread, owner->allyteam, avoidFlags, owner));
+	return (!TraceRay::TestTrajectoryCone(srcPos, targetVec, xzTargetDist, linCoeff, qdrCoeff, angleSpread, owner->allyteam, avoidFlags, owner));
 }
 
 void CCannon::FireImpl(const bool scriptCall)


### PR DESCRIPTION
### Work done

- Make Cannon respect srcPos on HaveFreeLineOfFire.

### Details

I think all other weapons do this.

Looks safe since the only in-engine user is `HaveFreeLineOfFire(GetAimFromPos(preFire), tgtPos, trg)` at [TryTarget](https://github.com/beyond-all-reason/spring/blob/6760620ce1fcec97f846a4a2e87effd411a2b81b/rts/Sim/Weapons/Weapon.cpp#L954). And `GetAimFromPos` for cannon is hardcoded to use weaponMuzzlePos anyways. (see [Cannon.h](https://github.com/beyond-all-reason/spring/blob/6760620ce1fcec97f846a4a2e87effd411a2b81b/rts/Sim/Weapons/Cannon.h#L49)).

Could break lua api users ([GetUnitWeaponHaveFreeLineOfFire](https://github.com/beyond-all-reason/spring/blob/6760620ce1fcec97f846a4a2e87effd411a2b81b/rts/Lua/LuaSyncedRead.cpp#L5443)) but I think those seem fine too (actually the fix is for them) since also using [GetAimFromPos](https://github.com/beyond-all-reason/spring/blob/6760620ce1fcec97f846a4a2e87effd411a2b81b/rts/Lua/LuaSyncedRead.cpp#L5458) unless user wants a different srcPos.

Marking as "lua api" since afaics this only affects `Spring.GetUnitWeaponHaveFreeLineOfFire`.