### PR TITLE
Add unit::noGroup and Get/SetUnitNoGroup

### DIFF
--- a/cont/base/springcontent/LuaGadgets/Gadgets/unit_dead.lua
+++ b/cont/base/springcontent/LuaGadgets/Gadgets/unit_dead.lua
@@ -1,0 +1,18 @@
+function gadget:GetInfo()
+  return {
+    name      = "Dead Unit",
+    desc      = "Remove behaviours from dead units",
+    license   = "GNU GPL, v2 or later",
+    layer     = -1999999,
+    enabled   = true,
+  }
+end
+
+if gadgetHandler:IsSyncedCode() then
+  return
+end
+
+function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
+  Spring.SetUnitNoSelect(unitID, true)
+  Spring.SetUnitNoGroup(unitID, true)
+end

--- a/rts/Game/UI/Groups/Group.cpp
+++ b/rts/Game/UI/Groups/Group.cpp
@@ -35,7 +35,7 @@ void CGroup::PostLoad()
 bool CGroup::AddUnit(CUnit* unit)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (unit->team != ghIndex)
+	if (unit->team != ghIndex || unit->noGroup)
 		return false;
 
 	units.insert(unit->id);

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -216,6 +216,7 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetUnitEngineDrawMask);
 	REGISTER_LUA_CFUNC(SetUnitAlwaysUpdateMatrix);
 	REGISTER_LUA_CFUNC(SetUnitNoMinimap);
+	REGISTER_LUA_CFUNC(SetUnitNoGroup);
 	REGISTER_LUA_CFUNC(SetUnitNoSelect);
 	REGISTER_LUA_CFUNC(SetUnitLeaveTracks);
 	REGISTER_LUA_CFUNC(SetUnitSelectionVolumeData);
@@ -2178,6 +2179,29 @@ int LuaUnsyncedCtrl::SetUnitNoMinimap(lua_State* L)
 		return 0;
 
 	unit->noMinimap = luaL_checkboolean(L, 2);
+	return 0;
+}
+
+
+/***
+ *
+ * @function Spring.SetUnitNoGroup
+ * @number unitID
+ * @bool unitNoGroup whether unit can be added to selection groups
+ * @treturn nil
+ */
+int LuaUnsyncedCtrl::SetUnitNoGroup(lua_State* L)
+{
+	CUnit* unit = ParseCtrlUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	unit->noGroup = luaL_checkboolean(L, 2);
+
+	if (unit->noGroup) {
+		unit->SetGroup(nullptr);
+	}
 	return 0;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -92,6 +92,7 @@ class LuaUnsyncedCtrl {
 		static int SetUnitEngineDrawMask(lua_State* L);
 		static int SetUnitAlwaysUpdateMatrix(lua_State* L);
 		static int SetUnitNoMinimap(lua_State* L);
+		static int SetUnitNoGroup(lua_State* L);
 		static int SetUnitNoSelect(lua_State* L);
 		static int SetUnitLeaveTracks(lua_State* L);
 		static int SetUnitSelectionVolumeData(lua_State* L);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -141,6 +141,7 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetUnitNoDraw);
 	REGISTER_LUA_CFUNC(GetUnitEngineDrawMask);
 	REGISTER_LUA_CFUNC(GetUnitNoMinimap);
+	REGISTER_LUA_CFUNC(GetUnitNoGroup);
 	REGISTER_LUA_CFUNC(GetUnitNoSelect);
 	REGISTER_LUA_CFUNC(GetUnitAlwaysUpdateMatrix);
 	REGISTER_LUA_CFUNC(GetUnitDrawFlag);
@@ -1301,6 +1302,23 @@ int LuaUnsyncedRead::GetUnitNoMinimap(lua_State* L)
 		return 0;
 
 	lua_pushboolean(L, unit->noMinimap);
+	return 1;
+}
+
+/***
+ *
+ * @function Spring.GetUnitNoGroup
+ * @number unitID
+ * @treturn nil|bool nil when unitID cannot be parsed
+ */
+int LuaUnsyncedRead::GetUnitNoGroup(lua_State* L)
+{
+	CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	lua_pushboolean(L, unit->noGroup);
 	return 1;
 }
 

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -57,6 +57,7 @@ class LuaUnsyncedRead {
 		static int GetUnitNoDraw(lua_State* L);
 		static int GetUnitEngineDrawMask(lua_State* L);
 		static int GetUnitNoMinimap(lua_State* L);
+		static int GetUnitNoGroup(lua_State* L);
 		static int GetUnitNoSelect(lua_State* L);
 		static int GetUnitAlwaysUpdateMatrix(lua_State* L);
 		static int GetUnitDrawFlag(lua_State* L);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -3033,6 +3033,7 @@ CR_REG_METADATA(CUnit, (
 	CR_MEMBER(iconRadius),
 
 	CR_MEMBER(stunned),
+	CR_MEMBER_UN(noGroup),
 
 //	CR_MEMBER(expMultiplier),
 //	CR_MEMBER(expPowerScale),

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -555,6 +555,8 @@ public:
 	bool leaveTracks = false;
 
 	bool isSelected = false;
+	// if true, unit can not be added to groups by a player (UNSYNCED)
+	bool noGroup = false;
 
 	float iconRadius = 0.0f;
 


### PR DESCRIPTION
### Work done

- Add noGroup flag for units
- Add lua Get/SetUnitNoGroup

### Remarks

- Implemented this so blocking units being added to groups can be controlled in the same way as to selection
- Units in a group, even if they could be unselectable due to noSelect will affect the group centroid.