### PR TITLE
Add Spring.SetProjectileTimeToLive.

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -5017,6 +5017,28 @@ int LuaSyncedCtrl::SetProjectileTarget(lua_State* L)
 
 
 /***
+ * @function Spring.SetProjectileTimeToLive
+ * @number projectileID
+ * @number flightTime
+ * @treturn nil
+ */
+int LuaSyncedCtrl::SetProjectileTimeToLive(lua_State* L)
+{
+	CProjectile* proj = ParseProjectile(L, __func__, 1);
+
+	const int newTimeToLive = luaL_checkint(L, 2);
+
+	if (proj == nullptr || !proj->weapon)
+		return 0;
+
+	CWeaponProjectile* wproj = static_cast<CWeaponProjectile*>(proj);
+
+	wproj->SetTimeToLive(newTimeToLive);
+	return 0;
+}
+
+
+/***
  * @function Spring.SetProjectileIsIntercepted
  * @number projectileID
  * @treturn nil

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -5019,7 +5019,7 @@ int LuaSyncedCtrl::SetProjectileTarget(lua_State* L)
 /***
  * @function Spring.SetProjectileTimeToLive
  * @number projectileID
- * @number flightTime
+ * @number ttl remaining time to live in frames
  * @treturn nil
  */
 int LuaSyncedCtrl::SetProjectileTimeToLive(lua_State* L)

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -178,6 +178,7 @@ class LuaSyncedCtrl
 		static int SetProjectileVelocity(lua_State* L);
 		static int SetProjectileCollision(lua_State* L);
 		static int SetProjectileTarget(lua_State* L);
+		static int SetProjectileTimeToLive(lua_State* L);
 		static int SetProjectileIsIntercepted(lua_State* L);
 		static int SetProjectileDamages(lua_State* L);
 		static int SetProjectileIgnoreTrackingError(lua_State* L);

--- a/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.h
+++ b/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.h
@@ -65,6 +65,7 @@ public:
 	const WeaponDef* GetWeaponDef() const { return weaponDef; }
 
 	int GetTimeToLive() const { return ttl; }
+	void SetTimeToLive(int newTTL) { ttl = newTTL; }
 
 	void SetStartPos(const float3& newStartPos) { startPos = newStartPos; }
 	void SetTargetPos(const float3& newTargetPos) { targetPos = newTargetPos; }


### PR DESCRIPTION
### Work done

- Add Spring.SetProjectileTimeToLive

### More details

- Allows declaring a future frame where the projectile will burn out at any moment, from lua.
- Getter already exists [Spring.GetProjectileTimeToLive](https://github.com/beyond-all-reason/spring/blob/0c3689c3678219f529eb965f4aae91627d1b98ee/rts/Lua/LuaSyncedRead.cpp#L7082).