### PR TITLE
Update NETMSG_MAPDRAW to uint32 on both sides of serialization

### DIFF
--- a/rts/Game/InMapDraw.cpp
+++ b/rts/Game/InMapDraw.cpp
@@ -169,7 +169,7 @@ int CInMapDraw::GotNetMsg(std::shared_ptr<const netcode::RawPacket>& packet)
 
 		switch (drawType) {
 			case MAPDRAW_POINT: {
-				short int x, z;
+				uint32_t x, z;
 				pckt >> x;
 				pckt >> z;
 				const float3 pos(x, 0, z);
@@ -182,7 +182,7 @@ int CInMapDraw::GotNetMsg(std::shared_ptr<const netcode::RawPacket>& packet)
 					inMapDrawerModel->AddPoint(pos, label, playerID);
 			} break;
 			case MAPDRAW_LINE: {
-				short int x1, z1, x2, z2;
+				uint32_t x1, z1, x2, z2;
 				pckt >> x1;
 				pckt >> z1;
 				pckt >> x2;
@@ -196,7 +196,7 @@ int CInMapDraw::GotNetMsg(std::shared_ptr<const netcode::RawPacket>& packet)
 					inMapDrawerModel->AddLine(pos1, pos2, playerID);
 			} break;
 			case MAPDRAW_ERASE: {
-				short int x, z;
+				uint32_t x, z;
 				pckt >> x;
 				pckt >> z;
 				float3 pos(x, 0, z);
@@ -230,7 +230,7 @@ void CInMapDraw::SendErase(const float3& pos)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (!gu->spectating || allowSpecMapDrawing)
-		clientNet->Send(CBaseNetProtocol::Get().SendMapErase(gu->myPlayerNum, (short)pos.x, (short)pos.z));
+		clientNet->Send(CBaseNetProtocol::Get().SendMapErase(gu->myPlayerNum, (uint32_t)pos.x, (uint32_t)pos.z));
 }
 
 
@@ -238,14 +238,14 @@ void CInMapDraw::SendPoint(const float3& pos, const std::string& label, bool fro
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (!gu->spectating || allowSpecMapDrawing)
-		clientNet->Send(CBaseNetProtocol::Get().SendMapDrawPoint(gu->myPlayerNum, (short)pos.x, (short)pos.z, label, fromLua));
+		clientNet->Send(CBaseNetProtocol::Get().SendMapDrawPoint(gu->myPlayerNum, (uint32_t)pos.x, (uint32_t)pos.z, label, fromLua));
 }
 
 void CInMapDraw::SendLine(const float3& pos, const float3& pos2, bool fromLua)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (!gu->spectating || allowSpecMapDrawing)
-		clientNet->Send(CBaseNetProtocol::Get().SendMapDrawLine(gu->myPlayerNum, (short)pos.x, (short)pos.z, (short)pos2.x, (short)pos2.z, fromLua));
+		clientNet->Send(CBaseNetProtocol::Get().SendMapDrawLine(gu->myPlayerNum, (uint32_t)pos.x, (uint32_t)pos.z, (uint32_t)pos2.x, (uint32_t)pos2.z, fromLua));
 }
 
 void CInMapDraw::SendWaitingInput(const std::string& label)

--- a/rts/Net/Protocol/BaseNetProtocol.cpp
+++ b/rts/Net/Protocol/BaseNetProtocol.cpp
@@ -322,7 +322,7 @@ PacketType CBaseNetProtocol::SendGameOver(uint8_t playerNum, const std::vector<u
 }
 
 
-PacketType CBaseNetProtocol::SendMapErase(uint8_t playerNum, int16_t x, int16_t z)
+PacketType CBaseNetProtocol::SendMapErase(uint8_t playerNum, uint32_t x, uint32_t z)
 {
 	constexpr uint8_t drawType = MAPDRAW_ERASE;
 
@@ -336,7 +336,7 @@ PacketType CBaseNetProtocol::SendMapErase(uint8_t playerNum, int16_t x, int16_t 
 }
 
 
-PacketType CBaseNetProtocol::SendMapDrawPoint(uint8_t playerNum, int16_t x, int16_t z, const std::string& label, bool fromLua)
+PacketType CBaseNetProtocol::SendMapDrawPoint(uint8_t playerNum, uint32_t x, uint32_t z, const std::string& label, bool fromLua)
 {
 	constexpr uint8_t drawType = MAPDRAW_POINT;
 
@@ -356,7 +356,7 @@ PacketType CBaseNetProtocol::SendMapDrawPoint(uint8_t playerNum, int16_t x, int1
 	return PacketType(packet);
 }
 
-PacketType CBaseNetProtocol::SendMapDrawLine(uint8_t playerNum, int16_t x1, int16_t z1, int16_t x2, int16_t z2, bool fromLua)
+PacketType CBaseNetProtocol::SendMapDrawLine(uint8_t playerNum, uint32_t x1, uint32_t z1, uint32_t x2, uint32_t z2, bool fromLua)
 {
 	constexpr uint8_t drawType = MAPDRAW_LINE;
 

--- a/rts/Net/Protocol/BaseNetProtocol.h
+++ b/rts/Net/Protocol/BaseNetProtocol.h
@@ -70,9 +70,9 @@ public:
 	PacketType SendShare(uint8_t playerNum, uint8_t shareTeam, uint8_t bShareUnits, float shareMetal, float shareEnergy);
 	PacketType SendSetShare(uint8_t playerNum, uint8_t myTeam, float metalShareFraction, float energyShareFraction);
 	PacketType SendGameOver(uint8_t playerNum, const std::vector<uint8_t>& winningAllyTeams);
-	PacketType SendMapErase(uint8_t playerNum, int16_t x, int16_t z);
-	PacketType SendMapDrawLine(uint8_t playerNum, int16_t x1, int16_t z1, int16_t x2, int16_t z2, bool);
-	PacketType SendMapDrawPoint(uint8_t playerNum, int16_t x, int16_t z, const std::string& label, bool);
+	PacketType SendMapErase(uint8_t playerNum, uint32_t x, uint32_t z);
+	PacketType SendMapDrawLine(uint8_t playerNum, uint32_t x1, uint32_t z1, uint32_t x2, uint32_t z2, bool);
+	PacketType SendMapDrawPoint(uint8_t playerNum, uint32_t x, uint32_t z, const std::string& label, bool);
 	PacketType SendSyncResponse(uint8_t playerNum, int32_t frameNum, uint32_t checksum);
 	PacketType SendSystemMessage(uint8_t playerNum, std::string message);
 	PacketType SendStartPos(uint8_t playerNum, uint8_t teamNum, uint8_t readyState, float x, float y, float z);

--- a/tools/DemoTool/DemoTool.cpp
+++ b/tools/DemoTool/DemoTool.cpp
@@ -355,16 +355,16 @@ void TrafficDump(CDemoReader& reader, bool trafficStats)
 				std::cout << "NETMSG_MAPDRAW Player:" << (int)buffer[2];
 				switch (buffer[3]) {
 					case MAPDRAW_POINT:
-						std::cout << " POINT x:" << *(int16_t*)&buffer[4] << " z:" << *(int16_t*)&buffer[6];
-						if (packet->length > 10) {
-							std::cout << " Msg: " << (char*)buffer+9;
+						std::cout << " POINT x:" << *(uint32_t*)&buffer[4] << " z:" << *(uint32_t*)&buffer[8];
+						if (packet->length > 16) {
+							std::cout << " Msg: " << (char*)buffer+13;
 						}
 						break;
 					case MAPDRAW_LINE:
-						std::cout << " LINE x1:" << *(int16_t*)&buffer[4] << " z1:" << *(int16_t*)&buffer[6] << " x2:" << *(int16_t*)&buffer[8] << " z2:" << *(int16_t*)&buffer[10];
+						std::cout << " LINE x1:" << *(uint32_t*)&buffer[4] << " z1:" << *(uint32_t*)&buffer[8] << " x2:" << *(uint32_t*)&buffer[12] << " z2:" << *(uint32_t*)&buffer[16];
 						break;
 					case MAPDRAW_ERASE:
-						std::cout << " ERASE x:" << *(int16_t*)&buffer[4] << " z:" << *(int16_t*)&buffer[6];
+						std::cout << " ERASE x:" << *(uint32_t*)&buffer[4] << " z:" << *(uint32_t*)&buffer[8];
 						break;
 				}
 				std::cout << std::endl;


### PR DESCRIPTION
Fixes #1868 

Tested drawing, empty point, and labelled points before and after 64x in singleplayer skirmish and watched a recorded demo of this to ensure they appear in replays.