### PR TITLE
Lua frontend to allow changing unit's storage

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -1892,7 +1892,7 @@ static bool SetUnitStorageParam(CUnit* unit, const char* name, float value)
 {
 	// [m|e]
 	//
-	//         metal | energy
+	// metal | energy
 
 	SResourcePack newStorage = unit->storage;
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -1895,8 +1895,6 @@ static bool SetUnitStorageParam(CUnit* unit, const char* name, float value)
 	//
 	//         metal | energy
 
-	// Hmmm wondering if there is a way to do it without copy.
-	// unit->SetStorage expects the old storage not to be tampered with
 	std::cout << "Received call to set storage: " << name[0] << ": " << value << std::endl;
 	SResourcePack newStorage = unit->storage;
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -1887,6 +1887,29 @@ static bool SetUnitResourceParam(CUnit* unit, const char* name, float value)
 }
 
 
+static bool SetUnitStorageParam(CUnit* unit, const char* name, float value)
+{
+	// [m|e]
+	//
+	//         metal | energy
+
+	switch (name[0]) {
+		case 'm': {
+			unit->storage.metal  = value; return true;
+		} break;
+
+		case 'e': {
+			unit->storage.energy = value; return true;
+		} break;
+
+		default: {
+		} break;
+	}
+
+	return false;
+}
+
+
 /***
  * Unit Resourcing
  * @section unitresourcing
@@ -1927,6 +1950,52 @@ int LuaSyncedCtrl::SetUnitResourcing(lua_State* L)
 	}
 	else {
 		luaL_error(L, "Incorrect arguments to SetUnitResourcing");
+	}
+
+	return 0;
+}
+
+
+/***
+ * Unit Storage
+ * @section unitstorage
+ */
+
+/***
+ * @function Spring.SetUnitStorage
+ * @number unitID
+ * @string res
+ * @number amount
+ * @treturn nil
+ */
+
+/***
+ * @function Spring.SetUnitStorage
+ * @number unitID
+ * @tparam {[string]=number,...} res keys are: "[m|e]" metal | energy. Values are amounts
+ * @treturn nil
+ */
+int LuaSyncedCtrl::SetUnitStorage(lua_State* L)
+{
+	CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	if (lua_israwstring(L, 2)) {
+		SetUnitStorageParam(unit, lua_tostring(L, 2), luaL_checkfloat(L, 3));
+	} else if (lua_istable(L, 2)) {
+		constexpr int tableIdx = 2;
+
+		for (lua_pushnil(L); lua_next(L, tableIdx) != 0; lua_pop(L, 1)) {
+			if (!lua_israwstring(L, LUA_TABLE_KEY_INDEX) || !lua_isnumber(L, LUA_TABLE_VALUE_INDEX))
+				continue;
+
+			SetUnitStorageParam(unit, lua_tostring(L, LUA_TABLE_KEY_INDEX), lua_tofloat(L, LUA_TABLE_VALUE_INDEX));
+		}
+	}
+	else {
+		luaL_error(L, "Incorrect arguments to SetUnitStorage");
 	}
 
 	return 0;

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -1,5 +1,5 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
-
+#include <iostream>
 #include <vector>
 #include <cctype>
 
@@ -164,6 +164,8 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(SetUnitCosts);
 	REGISTER_LUA_CFUNC(SetUnitResourcing);
+	REGISTER_LUA_CFUNC(SetUnitStorage);
+	REGISTER_LUA_CFUNC(GetUnitStorage);
 	REGISTER_LUA_CFUNC(SetUnitTooltip);
 	REGISTER_LUA_CFUNC(SetUnitHealth);
 	REGISTER_LUA_CFUNC(SetUnitMaxHealth);
@@ -1895,6 +1897,7 @@ static bool SetUnitStorageParam(CUnit* unit, const char* name, float value)
 
 	// Hmmm wondering if there is a way to do it without copy.
 	// unit->SetStorage expects the old storage not to be tampered with
+	std::cout << "Received call to set storage: " << name[0] << ": " << value << std::endl;
 	SResourcePack newStorage = unit->storage;
 
 	switch (name[0]) {
@@ -1911,6 +1914,7 @@ static bool SetUnitStorageParam(CUnit* unit, const char* name, float value)
 		}
 	}
 	unit->SetStorage(unit->storage);
+	std::cout << "Done set storage: " << name[0] << ": " << value << std::endl;
 	return true;
 }
 
@@ -1982,6 +1986,7 @@ int LuaSyncedCtrl::SetUnitResourcing(lua_State* L)
  */
 int LuaSyncedCtrl::SetUnitStorage(lua_State* L)
 {
+	std::cout << "Received call to Set Unit Storage\n";
 	CUnit* unit = ParseUnit(L, __func__, 1);
 
 	if (unit == nullptr)
@@ -2003,6 +2008,7 @@ int LuaSyncedCtrl::SetUnitStorage(lua_State* L)
 		luaL_error(L, "Incorrect arguments to SetUnitStorage");
 	}
 
+	std::cout << "Done call to Set Unit Storage\n";
 	return 0;
 }
 
@@ -2021,7 +2027,7 @@ int LuaSyncedCtrl::GetUnitStorage(lua_State* L)
 
 	lua_pushnumber(L, unit->storage.metal);
 	lua_pushnumber(L, unit->storage.energy);
-	return 1;
+	return 2;
 }
 
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -1893,20 +1893,25 @@ static bool SetUnitStorageParam(CUnit* unit, const char* name, float value)
 	//
 	//         metal | energy
 
+	// Hmmm wondering if there is a way to do it without copy.
+	// unit->SetStorage expects the old storage not to be tampered with
+	SResourcePack newStorage = unit->storage;
+
 	switch (name[0]) {
 		case 'm': {
-			unit->storage.metal  = value; return true;
+			newStorage.metal  = value;
 		} break;
 
 		case 'e': {
-			unit->storage.energy = value; return true;
+			newStorage.energy = value;
 		} break;
 
 		default: {
-		} break;
+			return false;
+		}
 	}
-
-	return false;
+	unit->SetStorage(unit->storage);
+	return true;
 }
 
 
@@ -1999,6 +2004,24 @@ int LuaSyncedCtrl::SetUnitStorage(lua_State* L)
 	}
 
 	return 0;
+}
+
+/***
+ * @function Spring.GetUnitStorage
+ * @number unitID
+ * @treturn number Unit's metal storage
+ * @treturn number Unit's energy storage
+ */
+int LuaSyncedCtrl::GetUnitStorage(lua_State* L)
+{
+	CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	lua_pushnumber(L, unit->storage.metal);
+	lua_pushnumber(L, unit->storage.energy);
+	return 1;
 }
 
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -1,5 +1,5 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
-#include <iostream>
+
 #include <vector>
 #include <cctype>
 
@@ -1895,7 +1895,6 @@ static bool SetUnitStorageParam(CUnit* unit, const char* name, float value)
 	//
 	//         metal | energy
 
-	std::cout << "Received call to set storage: " << name[0] << ": " << value << std::endl;
 	SResourcePack newStorage = unit->storage;
 
 	switch (name[0]) {
@@ -1911,8 +1910,7 @@ static bool SetUnitStorageParam(CUnit* unit, const char* name, float value)
 			return false;
 		}
 	}
-	unit->SetStorage(unit->storage);
-	std::cout << "Done set storage: " << name[0] << ": " << value << std::endl;
+	unit->SetStorage(newStorage);
 	return true;
 }
 
@@ -1984,7 +1982,6 @@ int LuaSyncedCtrl::SetUnitResourcing(lua_State* L)
  */
 int LuaSyncedCtrl::SetUnitStorage(lua_State* L)
 {
-	std::cout << "Received call to Set Unit Storage\n";
 	CUnit* unit = ParseUnit(L, __func__, 1);
 
 	if (unit == nullptr)
@@ -2006,7 +2003,6 @@ int LuaSyncedCtrl::SetUnitStorage(lua_State* L)
 		luaL_error(L, "Incorrect arguments to SetUnitStorage");
 	}
 
-	std::cout << "Done call to Set Unit Storage\n";
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -165,7 +165,6 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetUnitCosts);
 	REGISTER_LUA_CFUNC(SetUnitResourcing);
 	REGISTER_LUA_CFUNC(SetUnitStorage);
-	REGISTER_LUA_CFUNC(GetUnitStorage);
 	REGISTER_LUA_CFUNC(SetUnitTooltip);
 	REGISTER_LUA_CFUNC(SetUnitHealth);
 	REGISTER_LUA_CFUNC(SetUnitMaxHealth);
@@ -2004,24 +2003,6 @@ int LuaSyncedCtrl::SetUnitStorage(lua_State* L)
 	}
 
 	return 0;
-}
-
-/***
- * @function Spring.GetUnitStorage
- * @number unitID
- * @treturn number Unit's metal storage
- * @treturn number Unit's energy storage
- */
-int LuaSyncedCtrl::GetUnitStorage(lua_State* L)
-{
-	CUnit* unit = ParseUnit(L, __func__, 1);
-
-	if (unit == nullptr)
-		return 0;
-
-	lua_pushnumber(L, unit->storage.metal);
-	lua_pushnumber(L, unit->storage.energy);
-	return 2;
 }
 
 

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -94,7 +94,6 @@ class LuaSyncedCtrl
 		static int SetUnitUseAirLos(lua_State* L);
 		static int SetUnitResourcing(lua_State* L);
 		static int SetUnitStorage(lua_State* L);
-		static int GetUnitStorage(lua_State* L);
 		static int SetUnitMetalExtraction(lua_State* L);
 		static int SetUnitHarvestStorage(lua_State* L);
 		static int SetUnitBuildSpeed(lua_State* L);

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -94,6 +94,7 @@ class LuaSyncedCtrl
 		static int SetUnitUseAirLos(lua_State* L);
 		static int SetUnitResourcing(lua_State* L);
 		static int SetUnitStorage(lua_State* L);
+		static int GetUnitStorage(lua_State* L);
 		static int SetUnitMetalExtraction(lua_State* L);
 		static int SetUnitHarvestStorage(lua_State* L);
 		static int SetUnitBuildSpeed(lua_State* L);

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -93,6 +93,7 @@ class LuaSyncedCtrl
 		static int SetUnitAlwaysVisible(lua_State* L);
 		static int SetUnitUseAirLos(lua_State* L);
 		static int SetUnitResourcing(lua_State* L);
+		static int SetUnitStorage(lua_State* L);
 		static int SetUnitMetalExtraction(lua_State* L);
 		static int SetUnitHarvestStorage(lua_State* L);
 		static int SetUnitBuildSpeed(lua_State* L);

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -207,6 +207,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetUnitIsStunned);
 	REGISTER_LUA_CFUNC(GetUnitIsBeingBuilt);
 	REGISTER_LUA_CFUNC(GetUnitResources);
+	REGISTER_LUA_CFUNC(GetUnitStorage);
 	REGISTER_LUA_CFUNC(GetUnitCosts);
 	REGISTER_LUA_CFUNC(GetUnitCostTable);
 	REGISTER_LUA_CFUNC(GetUnitMetalExtraction);
@@ -4216,6 +4217,24 @@ int LuaSyncedRead::GetUnitResources(lua_State* L)
 	lua_pushnumber(L, unit->resourcesMake.energy);
 	lua_pushnumber(L, unit->resourcesUse.energy);
 	return 4;
+}
+
+/***
+ * @function Spring.GetUnitStorage
+ * @number unitID
+ * @treturn number Unit's metal storage
+ * @treturn number Unit's energy storage
+ */
+int LuaSyncedRead::GetUnitStorage(lua_State* L)
+{
+	const CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	lua_pushnumber(L, unit->storage.metal);
+	lua_pushnumber(L, unit->storage.energy);
+	return 2;
 }
 
 /***

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -4227,7 +4227,7 @@ int LuaSyncedRead::GetUnitResources(lua_State* L)
  */
 int LuaSyncedRead::GetUnitStorage(lua_State* L)
 {
-	const CUnit* unit = ParseUnit(L, __func__, 1);
+	const CUnit* unit = ParseAllyUnit(L, __func__, 1);
 
 	if (unit == nullptr)
 		return 0;

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -113,6 +113,7 @@ class LuaSyncedRead {
 		static int GetUnitCosts(lua_State* L);
 		static int GetUnitCostTable(lua_State* L);
 		static int GetUnitResources(lua_State* L);
+		static int GetUnitStorage(lua_State* L);
 		static int GetUnitMetalExtraction(lua_State* L);
 		static int GetUnitExperience(lua_State* L);
 		static int GetUnitStates(lua_State* L);


### PR DESCRIPTION
Addresses https://github.com/beyond-all-reason/spring/issues/1877
Copied the function to set resource modifiers, but adapted it to resource storage.

Tested by running Zero-K. Added this gadget which calls the resource set each time a command is issued:
```
function gadget:GetInfo()
    return {
        name    = "Test gadget for SpringRTS Engine",
        desc    = "Test gadget",
        author  = "xponen, GoogleFrog, seedship",
        date    = "June 12 2014",
        license = "GNU GPL, v2 or later",
        layer   = 0,
        enabled = true,
    }
end
if gadgetHandler:IsSyncedCode() then
    function gadget:AllowCommand(unitID, unitDefID, teamID)
        local m_store = math.random(10, 500)
        local e_store = math.random(10, 500)
        print("Setting m_store to ")
        print(m_store)
        print("Setting e_store to ")
        print(e_store)
        Spring.SetUnitStorage(unitID, "m", m_store)
        Spring.SetUnitStorage(unitID, "e", e_store)

        print("Calling GetUnitStorage")
        local m, e = Spring.GetUnitStorage(unitID)
        print("M store set to")
        print(m)
        print("E store set to")
        print(e)
    end
end

```
Validated that resources are correctly being changed via Zero-K UI, and that the `Get` function works too, based on gadget printouts.
```
Setting m_store to 
79
Setting e_store to 
356
Calling GetUnitStorage
M store set to
79
E store set to
356
Setting m_store to 
257
Setting e_store to 
181
Calling GetUnitStorage
M store set to
257
E store set to
181
Setting m_store to 
280
Setting e_store to 
410
Calling GetUnitStorage
M store set to
280
E store set to
410
```