### PR TITLE
Remove redundant values from StartupScripts

### DIFF
--- a/rts/System/StartScriptGen.cpp
+++ b/rts/System/StartScriptGen.cpp
@@ -28,7 +28,6 @@ std::string CreateMinimalSetup(const std::string& game, const std::string& map)
 	g->add_name_value("Gametype", ArchiveNameResolver::GetGame(game));
 
 	TdfParser::TdfSection* modopts = g->construct_subsection("MODOPTIONS");
-	modopts->AddPair("MaxSpeed", 20);
 	modopts->AddPair("MinimalSetup", 1); //use for ingame detecting this type of start
 
 	g->AddPair("IsHost", 1);
@@ -56,19 +55,16 @@ std::string CreateMinimalSetup(const std::string& game, const std::string& map)
 std::string CreateDefaultSetup(const std::string& map, const std::string& game, const std::string& ai,
 			const std::string& playername)
 {
-	//FIXME:: duplicate code with CreateMinimalSetup
 	TdfParser::TdfSection setup;
 	TdfParser::TdfSection* g = setup.construct_subsection("GAME");
 	g->add_name_value("Mapname", map);
 	g->add_name_value("Gametype", game);
 
-	TdfParser::TdfSection* modopts = g->construct_subsection("MODOPTIONS");
-	modopts->AddPair("MaxSpeed", 20);
+	// we do not need to set any modoptions here (yet), but we still create the section in the script for later
+	g->construct_subsection("MODOPTIONS");
 
 	g->AddPair("IsHost", 1);
 	g->add_name_value("MyPlayerName", playername);
-
-	g->AddPair("NoHelperAIs", configHandler->GetBool("NoHelperAIs"));
 
 	TdfParser::TdfSection* player0 = g->construct_subsection("PLAYER0");
 	player0->add_name_value("Name", playername);

--- a/rts/System/StartScriptGen.cpp
+++ b/rts/System/StartScriptGen.cpp
@@ -9,8 +9,6 @@
 #include "System/Log/ILog.h"
 
 
-CONFIG(bool, NoHelperAIs).defaultValue(false);
-
 namespace StartScriptGen {
 
 //////////////////////////////////////////////////////////////////////////////
@@ -26,18 +24,14 @@ namespace StartScriptGen {
 	* @param map resolved name of the map
 	* @return a minimal config section containing general required fields
 	*/
-TdfParser::TdfSection CreateMinmalSetupSections(const std::string& map, const std::string& game) {
+void CreateMinimalSetupSections(TdfParser::TdfSection& setup, const std::string& map, const std::string& game) {
 	const std::string playername = configHandler->GetString("name");
-	TdfParser::TdfSection setup;
 	TdfParser::TdfSection* g = setup.construct_subsection("GAME");
 	g->add_name_value("Mapname", map);
 	g->add_name_value("Gametype", game);
 
 	g->AddPair("IsHost", 1);
 	g->add_name_value("MyPlayerName", playername);
-
-	// we do not need to set any modoptions here (yet), but we still create the section in the script for later
-	g->construct_subsection("MODOPTIONS");
 
 	TdfParser::TdfSection* player0 = g->construct_subsection("PLAYER0");
 	player0->add_name_value("Name", playername);
@@ -49,13 +43,13 @@ TdfParser::TdfSection CreateMinmalSetupSections(const std::string& map, const st
 
 	TdfParser::TdfSection* ally0 = g->construct_subsection("ALLYTEAM0");
 	ally0->AddPair("NumAllies", 0);
-	return setup;
 }
 
 std::string CreateMinimalSetup(const std::string& game, const std::string& map)
 {
-	TdfParser::TdfSection setup 
-		= CreateMinmalSetupSections(ArchiveNameResolver::GetMap(map), ArchiveNameResolver::GetGame(game));	
+	TdfParser::TdfSection setup;
+	CreateMinimalSetupSections(setup, ArchiveNameResolver::GetMap(map), ArchiveNameResolver::GetGame(game));
+	// section already present, using this method to get acces to GAME section
 	TdfParser::TdfSection* g = setup.construct_subsection("GAME");
 	TdfParser::TdfSection* modopts = g->construct_subsection("MODOPTIONS");
 	modopts->AddPair("MinimalSetup", 1); //use for ingame detecting this type of start
@@ -70,7 +64,9 @@ std::string CreateMinimalSetup(const std::string& game, const std::string& map)
 std::string CreateDefaultSetup(const std::string& map, const std::string& game, const std::string& ai,
 			const std::string& playername)
 {
-	TdfParser::TdfSection setup = CreateMinmalSetupSections(map, game);	
+	TdfParser::TdfSection setup;
+	CreateMinimalSetupSections(setup, map, game);
+	// section already present, using this method to get acces to GAME section
 	TdfParser::TdfSection* g = setup.construct_subsection("GAME");
 	
 

--- a/rts/System/StartScriptGen.h
+++ b/rts/System/StartScriptGen.h
@@ -5,18 +5,24 @@
 namespace StartScriptGen {
 
 	/**
-	* creates an empty script.txt with game & map, no error checking is done!
+	* creates an almost empty startup-script with game, map and some minimal 1 team-setup variables
+	* no error checking is done!
+	* the script is saved as _script.txt in the write-directory after the game terminates
 	* @param game name of the game
 	* @param map name of the map
+	* @return the generated startup-script as a string
 	*/
 	std::string CreateMinimalSetup(const std::string& game, const std::string& map);
 
 	/**
-	* creates an empty script.txt with game & map, only few error checking is done!
-	* @param game name of the game
-	* @param map name of the map
+	* creates an almost empty script.txt with game, map and some minimal 2 team-setup variables
+	* only few error checking is done!
+	* the script is saved as _script.txt in the write-directory after the game terminates
+	* @param game resolved name of the game
+	* @param map resolved name of the map
 	* @param ai ai to use (Lua/Skirmish), if not found "empty" player is used
 	* @param playername name to use ingame
+	* @return the generated startup-script as a string
 	*/
 	std::string CreateDefaultSetup(const std::string& map, const std::string& game, const std::string& ai, const std::string& playername);
 }


### PR DESCRIPTION
Addresses #1701 by removing two unused values, refactoring the two functions responsible for generating the initial minimal script and updating the comments/docs. The remaining values are required for PreGame-Setup as far as I can tell.