### PR TITLE
Add DEPRECATED Loglevel

### DIFF
--- a/rts/Game/UI/KeySet.cpp
+++ b/rts/Game/UI/KeySet.cpp
@@ -156,7 +156,7 @@ bool CKeySet::Parse(const std::string& token, bool showerror)
 
 	// parse the modifiers
 	while (!s.empty()) {
-		if (ParseModifier(s, "up+",    "u+")) { LOG_L(L_WARNING, "KeySet: Up modifier is deprecated"); } else
+		if (ParseModifier(s, "up+",    "u+")) { LOG_L(L_DEPRECATED, "KeySet: Up modifier is deprecated"); } else
 		if (ParseModifier(s, "any+",   "*+")) { modifiers |= KS_ANYMOD; } else
 		if (ParseModifier(s, "alt+",   "a+")) { modifiers |= KS_ALT; } else
 		if (ParseModifier(s, "ctrl+",  "c+")) { modifiers |= KS_CTRL; } else

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -6130,7 +6130,7 @@ int LuaSyncedRead::GetUnitCommands(lua_State* L)
 	} else {
 		static bool deprecatedMsgDone = false;
 		if (!deprecatedMsgDone) {
-			LOG_L(L_WARNING, "Getting the command count using GetUnitCommands/GetCommandQueue is deprecated. Please use Spring.GetUnitCommandCount instead.");
+			LOG_L(L_DEPRECATED, "Getting the command count using GetUnitCommands/GetCommandQueue is deprecated. Please use Spring.GetUnitCommandCount instead.");
 			deprecatedMsgDone = true;
 		}
 		// *get just wants the queue's size

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -506,12 +506,13 @@ int LuaUnsyncedCtrl::Echo(lua_State* L)
  * @string section
  * @tparam ?number|string logLevel
  *   Possible values for logLevel are:
- *    "debug"   | LOG.DEBUG
- *    "info"    | LOG.INFO
- *    "notice"  | LOG.NOTICE (engine default)
- *    "warning" | LOG.WARNING
- *    "error"   | LOG.ERROR
- *    "fatal"   | LOG.FATAL
+ *    "debug"        | LOG.DEBUG
+ *    "info"         | LOG.INFO
+ *    "notice"       | LOG.NOTICE (engine default)
+ *    "deprecated"   | LOG.DEPRECATED
+ *    "warning"      | LOG.WARNING
+ *    "error"        | LOG.ERROR
+ *    "fatal"        | LOG.FATAL
  * @string logMessage1
  * @string[opt] logMessage2
  * @string[opt] logMessagen

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2438,7 +2438,7 @@ int LuaUnsyncedCtrl::UnitIconSetDraw(lua_State* L)
 {
 	static bool deprecatedMsgDone = false;
 	if (!deprecatedMsgDone) {
-		LOG_L(L_WARNING, "Spring.UnitIconSetDraw is deprecated. Please use Spring.SetUnitIconDraw instead.");
+		LOG_L(L_DEPRECATED, "Spring.UnitIconSetDraw is deprecated. Please use Spring.SetUnitIconDraw instead.");
 		deprecatedMsgDone = true;
 	}
 	return LuaUnsyncedCtrl::SetUnitIconDraw(L);

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -1307,6 +1307,7 @@ bool LuaUtils::PushLogEntries(lua_State* L)
 	PUSH_LOG_LEVEL(DEBUG);
 	PUSH_LOG_LEVEL(INFO);
 	PUSH_LOG_LEVEL(NOTICE);
+	PUSH_LOG_LEVEL(DEPRECATED);
 	PUSH_LOG_LEVEL(WARNING);
 	PUSH_LOG_LEVEL(ERROR);
 	PUSH_LOG_LEVEL(FATAL);
@@ -1319,14 +1320,20 @@ int LuaUtils::ParseLogLevel(lua_State* L, int index)
 		return (lua_tonumber(L, index));
 
 	if (lua_israwstring(L, index)) {
-		switch (lua_tostring(L, index)[0]) {
-			case 'D': case 'd': { return LOG_LEVEL_DEBUG  ; } break;
-			case 'I': case 'i': { return LOG_LEVEL_INFO   ; } break;
-			case 'N': case 'n': { return LOG_LEVEL_NOTICE ; } break;
-			case 'W': case 'w': { return LOG_LEVEL_WARNING; } break;
-			case 'E': case 'e': { return LOG_LEVEL_ERROR  ; } break;
-			case 'F': case 'f': { return LOG_LEVEL_FATAL  ; } break;
-			default           : {                           } break;
+		const char* logLevel = lua_tostring(L, index);
+		switch (logLevel[0]) {
+			case 'D': case 'd': {
+				if (strlen(logLevel) > 2 && (logLevel[2] == 'P' || logLevel[2] == 'p'))
+					return LOG_LEVEL_DEPRECATED;
+				else
+					return LOG_LEVEL_DEBUG;
+			} break;
+			case 'I': case 'i': { return LOG_LEVEL_INFO        ; } break;
+			case 'N': case 'n': { return LOG_LEVEL_NOTICE      ; } break;
+			case 'W': case 'w': { return LOG_LEVEL_WARNING     ; } break;
+			case 'E': case 'e': { return LOG_LEVEL_ERROR       ; } break;
+			case 'F': case 'f': { return LOG_LEVEL_FATAL       ; } break;
+			default           : {                                } break;
 		}
 	}
 

--- a/rts/System/Log/ConsoleSink.cpp
+++ b/rts/System/Log/ConsoleSink.cpp
@@ -46,6 +46,8 @@ static void log_sink_record_console(int level, const char* section, const char* 
 	if (colorizedOutput) {
 		if (level >= LOG_LEVEL_ERROR) {
 			fstr = "\033[90m%s\033[31m%s\033[39m\n";
+		} else if (level == LOG_LEVEL_DEPRECATED) {
+			fstr = "\033[90m%s\033[34m%s\033[39m\n";
 		} else if (level >= LOG_LEVEL_WARNING) {
 			fstr = "\033[90m%s\033[33m%s\033[39m\n";
 		} else {

--- a/rts/System/Log/ILog.h
+++ b/rts/System/Log/ILog.h
@@ -10,12 +10,13 @@
  *
  * Aims:
  * - Support a fixed set of severities levels:
- *   * L_DEBUG   : fine-grained information that is most useful to debug
- *   * L_INFO    : same as L_NOTICE just that it is surpressed on RELEASE builds when a non-default logSection is set
- *   * L_NOTICE  : default log level (always outputed)
- *   * L_WARNING : potentially harmful situations
- *   * L_ERROR   : errors that might still allow the application to keep running
- *   * L_FATAL   : very severe errors that will lead the application to abort
+ *   * L_DEBUG      : fine-grained information that is most useful to debug
+ *   * L_INFO       : same as L_NOTICE just that it is surpressed on RELEASE builds when a non-default logSection is set
+ *   * L_NOTICE     : default log level (always outputed)
+ *   * L_DEPRECATED : deprecation messages
+ *   * L_WARNING    : potentially harmful situations
+ *   * L_ERROR      : errors that might still allow the application to keep running
+ *   * L_FATAL      : very severe errors that will lead the application to abort
  *   (the "L_" prefix is required for disambiguation from other symbols)
  * - Support arbitrary sections (strings).
  * - Allow to set the minimum severity level

--- a/rts/System/Log/Level.h
+++ b/rts/System/Log/Level.h
@@ -17,8 +17,8 @@
 #define LOG_LEVEL_DEBUG      20
 #define LOG_LEVEL_INFO       30
 #define LOG_LEVEL_NOTICE     35
-#define LOG_LEVEL_DEPRECATED 40
-#define LOG_LEVEL_WARNING    45
+#define LOG_LEVEL_DEPRECATED 37
+#define LOG_LEVEL_WARNING    40
 #define LOG_LEVEL_ERROR      50
 #define LOG_LEVEL_FATAL      60
 

--- a/rts/System/Log/Level.h
+++ b/rts/System/Log/Level.h
@@ -12,16 +12,17 @@
  */
 ///@{
 
-#define LOG_LEVEL_ALL       0
+#define LOG_LEVEL_ALL        0
 
-#define LOG_LEVEL_DEBUG     20
-#define LOG_LEVEL_INFO      30
-#define LOG_LEVEL_NOTICE    35
-#define LOG_LEVEL_WARNING   40
-#define LOG_LEVEL_ERROR     50
-#define LOG_LEVEL_FATAL     60
+#define LOG_LEVEL_DEBUG      20
+#define LOG_LEVEL_INFO       30
+#define LOG_LEVEL_NOTICE     35
+#define LOG_LEVEL_DEPRECATED 40
+#define LOG_LEVEL_WARNING    45
+#define LOG_LEVEL_ERROR      50
+#define LOG_LEVEL_FATAL      60
 
-#define LOG_LEVEL_NONE     255
+#define LOG_LEVEL_NONE      255
 
 #define DEFAULT_LOG_LEVEL_SHORT         L_NOTICE
 #define DEFAULT_LOG_LEVEL       LOG_LEVEL_NOTICE

--- a/rts/System/Log/LogUtil.c
+++ b/rts/System/Log/LogUtil.c
@@ -8,13 +8,14 @@
 const char* log_util_levelToString(int level)
 {
 	switch (level) {
-		case LOG_LEVEL_DEBUG:   return "Debug";
-		case LOG_LEVEL_INFO:    return "Info";
-		case LOG_LEVEL_NOTICE:  return "Notice";
-		case LOG_LEVEL_WARNING: return "Warning";
-		case LOG_LEVEL_ERROR:   return "Error";
-		case LOG_LEVEL_FATAL:   return "Fatal";
-		default:                return "<unknown>";
+		case LOG_LEVEL_DEBUG:      return "Debug";
+		case LOG_LEVEL_INFO:       return "Info";
+		case LOG_LEVEL_NOTICE:     return "Notice";
+		case LOG_LEVEL_DEPRECATED: return "Deprecated";
+		case LOG_LEVEL_WARNING:    return "Warning";
+		case LOG_LEVEL_ERROR:      return "Error";
+		case LOG_LEVEL_FATAL:      return "Fatal";
+		default:                   return "<unknown>";
 	}
 }
 
@@ -33,12 +34,13 @@ char log_util_levelToChar(int level)
 
 int log_util_getNearestLevel(int level)
 {
-	if (level >= LOG_LEVEL_FATAL)   return LOG_LEVEL_FATAL;
-	if (level >= LOG_LEVEL_ERROR)   return LOG_LEVEL_ERROR;
-	if (level >= LOG_LEVEL_WARNING) return LOG_LEVEL_WARNING;
-	if (level >= LOG_LEVEL_NOTICE)  return LOG_LEVEL_NOTICE;
-	if (level >= LOG_LEVEL_INFO)    return LOG_LEVEL_INFO;
-	if (level >= LOG_LEVEL_DEBUG)   return LOG_LEVEL_DEBUG;
+	if (level >= LOG_LEVEL_FATAL)      return LOG_LEVEL_FATAL;
+	if (level >= LOG_LEVEL_ERROR)      return LOG_LEVEL_ERROR;
+	if (level >= LOG_LEVEL_WARNING)    return LOG_LEVEL_WARNING;
+	if (level >= LOG_LEVEL_DEPRECATED) return LOG_LEVEL_DEPRECATED;
+	if (level >= LOG_LEVEL_NOTICE)     return LOG_LEVEL_NOTICE;
+	if (level >= LOG_LEVEL_INFO)       return LOG_LEVEL_INFO;
+	if (level >= LOG_LEVEL_DEBUG)      return LOG_LEVEL_DEBUG;
 	return DEFAULT_LOG_LEVEL;
 }
 


### PR DESCRIPTION
### Work done

- Add new DEPRECATED logLevel
  - Make them show up blue at console
- Also move WARNING up to 45 so all current levels have round numbers
- Make recent deprecations use the new level.

### Testing

- See https://github.com/beyond-all-reason/Beyond-All-Reason/pull/4135 for example of how this is used to show messages at gui just for developers in single player.

### Remarks

Having a good system to communicate deprecated methods to developers is important, it's also important to make it easy for games to filter out such messages for players.

If not properly shown, messages can be either too spammy or too easy to ignore. I think having a specific level together with showing them in a different color at infolog and having games show them for developers only is the way to go.

This way we just "spam" the right people, and have more chance for the deprecated messages to be seen and acted upon by developers. This will allow us to deprecate and then remove features faster than if developers just don't see the messages and ignore them.

The chosen infolog.txt color is just the one I found more balanced from https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit, feel free to propose a different one. I tried magenta but it seemed too flashy, other options seemed too dull. I'm not entirely happy with blue but don't see a better option atm.

Don't have a good char to represent the level at log_util_levelToChar (since DEBUG also starts with D), but that one doesn't seem to be in use. I'd just remove it, otherwise the current mapping to `?` shouldn't be a problem, or could be mapped to smth else like `P`.