### PR TITLE
Refactor BuilderCAI static caches into new BuilderCaches file.

### DIFF
--- a/rts/Sim/CMakeLists.txt
+++ b/rts/Sim/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(engineSim STATIC
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/CommandAI/CommandDescription.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/CommandAI/FactoryCAI.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/CommandAI/MobileCAI.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Units/CommandAI/BuilderCaches.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/Scripts/CobEngine.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/Scripts/CobFile.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/Scripts/CobFileHandler.cpp"

--- a/rts/Sim/Features/FeatureHandler.cpp
+++ b/rts/Sim/Features/FeatureHandler.cpp
@@ -9,7 +9,7 @@
 #include "Map/ReadMap.h"
 #include "Sim/Ecs/Registry.h"
 #include "Sim/Misc/QuadField.h"
-#include "Sim/Units/CommandAI/BuilderCAI.h"
+#include "Sim/Units/CommandAI/BuilderCaches.h"
 #include "System/creg/STL_Set.h"
 #include "System/EventHandler.h"
 #include "System/TimeProfiler.h"
@@ -209,7 +209,7 @@ void CFeatureHandler::Update()
 bool CFeatureHandler::TryFreeFeatureID(int id)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (CBuilderCAI::IsFeatureBeingReclaimed(id)) {
+	if (CBuilderCaches::IsFeatureBeingReclaimed(id)) {
 		// postpone putting this ID back into the free pool
 		// (this gives area-reclaimers time to choose a new
 		// target with a different ID)

--- a/rts/Sim/Units/CommandAI/BuilderCAI.h
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.h
@@ -27,7 +27,6 @@ public:
 	CBuilderCAI();
 	~CBuilderCAI();
 
-	static void InitStatic();
 	void PostLoad();
 
 	int GetDefaultCmd(const CUnit* unit, const CFeature* feature);
@@ -52,25 +51,12 @@ public:
 	bool ReclaimObject(CSolidObject* o);
 	bool ResurrectObject(CFeature* feature);
 
-	/**
-	 * Checks if a unit is being reclaimed by a friendly con.
-	 */
-	static bool IsUnitBeingReclaimed(const CUnit* unit, const CUnit* friendUnit = nullptr);
-	static bool IsFeatureBeingReclaimed(int featureId, const CUnit* friendUnit = nullptr);
-	static bool IsFeatureBeingResurrected(int featureId, const CUnit* friendUnit = nullptr);
-
 	bool IsInBuildRange(const CWorldObject* obj) const;
 	bool IsInBuildRange(const float3& pos, const float radius) const;
 	float GetBuildRange(const float targetRadius) const;
 
 public:
 	spring::unordered_set<int> buildOptions;
-
-	static spring::unordered_set<int> reclaimers;
-	static spring::unordered_set<int> featureReclaimers;
-	static spring::unordered_set<int> resurrecters;
-
-	static std::vector<int> removees;
 
 private:
 	enum ReclaimOptions {
@@ -123,18 +109,6 @@ private:
 	bool OutOfImmobileRange(const Command& cmd) const;
 	/// add a command to reclaim a feature that is blocking our build-site
 	void ReclaimFeature(CFeature* f);
-
-	/// fix for patrolling cons repairing/resurrecting stuff that's being reclaimed
-	static void AddUnitToReclaimers(CUnit*);
-	static void RemoveUnitFromReclaimers(CUnit*);
-
-	/// fix for cons wandering away from their target circle
-	static void AddUnitToFeatureReclaimers(CUnit*);
-	static void RemoveUnitFromFeatureReclaimers(CUnit*);
-
-	/// fix for patrolling cons reclaiming stuff that is being resurrected
-	static void AddUnitToResurrecters(CUnit*);
-	static void RemoveUnitFromResurrecters(CUnit*);
 
 	inline float f3Dist(const float3& a, const float3& b) const {
 		return range3D ? a.distance(b) : a.distance2D(b);

--- a/rts/Sim/Units/CommandAI/BuilderCaches.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCaches.cpp
@@ -1,0 +1,147 @@
+#include "Sim/Units/CommandAI/BuilderCaches.h"
+#include "Sim/Misc/TeamHandler.h"
+#include "Sim/Units/UnitHandler.h"
+#include "Sim/Units/Unit.h"
+
+// not adding to members, should repopulate itself
+spring::unordered_set<int> CBuilderCaches::reclaimers;
+spring::unordered_set<int> CBuilderCaches::featureReclaimers;
+spring::unordered_set<int> CBuilderCaches::resurrecters;
+
+std::vector<int> CBuilderCaches::removees;
+
+void CBuilderCaches::InitStatic()
+{
+	spring::clear_unordered_set(reclaimers);
+	spring::clear_unordered_set(featureReclaimers);
+	spring::clear_unordered_set(resurrecters);
+}
+
+void CBuilderCaches::AddUnitToReclaimers(CUnit* unit) { reclaimers.insert(unit->id); }
+void CBuilderCaches::RemoveUnitFromReclaimers(CUnit* unit) { reclaimers.erase(unit->id); }
+
+void CBuilderCaches::AddUnitToFeatureReclaimers(CUnit* unit) { featureReclaimers.insert(unit->id); }
+void CBuilderCaches::RemoveUnitFromFeatureReclaimers(CUnit* unit) { featureReclaimers.erase(unit->id); }
+
+void CBuilderCaches::AddUnitToResurrecters(CUnit* unit) { resurrecters.insert(unit->id); }
+void CBuilderCaches::RemoveUnitFromResurrecters(CUnit* unit) { resurrecters.erase(unit->id); }
+
+
+/**
+ * Checks if a unit is being reclaimed by a friendly con.
+ *
+ * We assume that there will not be a lot of reclaimers, because performance
+ * would suck if there were. Ideally, reclaimers should be assigned on a
+ * per-unit basis, but this requires tracking of deaths, which albeit
+ * already done, is not exactly simple to follow.
+ *
+ * TODO easy: store reclaiming units per allyteam
+ * TODO harder: update reclaimers as they start/finish reclaims and/or die
+ */
+bool CBuilderCaches::IsUnitBeingReclaimed(const CUnit* unit, const CUnit* friendUnit)
+{
+	bool retval = false;
+
+	removees.clear();
+	removees.reserve(reclaimers.size());
+
+	for (auto it = reclaimers.begin(); it != reclaimers.end(); ++it) {
+		const CUnit* u = unitHandler.GetUnit(*it);
+		const CCommandAI* cai = u->commandAI;
+		const CCommandQueue& cq = cai->commandQue;
+
+		if (cq.empty()) {
+			removees.push_back(u->id);
+			continue;
+		}
+		const Command& c = cq.front();
+		if (c.GetID() != CMD_RECLAIM || (c.GetNumParams() != 1 && c.GetNumParams() != 5)) {
+			removees.push_back(u->id);
+			continue;
+		}
+		const int cmdUnitId = (int)c.GetParam(0);
+		if (cmdUnitId == unit->id && (friendUnit == nullptr || teamHandler.Ally(friendUnit->allyteam, u->allyteam))) {
+			retval = true;
+			break;
+		}
+	}
+
+	for (auto it = removees.begin(); it != removees.end(); ++it)
+		RemoveUnitFromReclaimers(unitHandler.GetUnit(*it));
+
+	return retval;
+}
+
+
+
+bool CBuilderCaches::IsFeatureBeingReclaimed(int featureId, const CUnit* friendUnit)
+{
+	bool retval = false;
+
+	removees.clear();
+	removees.reserve(featureReclaimers.size());
+
+	for (auto it = featureReclaimers.begin(); it != featureReclaimers.end(); ++it) {
+		const CUnit* u = unitHandler.GetUnit(*it);
+		const CCommandAI* cai = u->commandAI;
+		const CCommandQueue& cq = cai->commandQue;
+
+		if (cq.empty()) {
+			removees.push_back(u->id);
+			continue;
+		}
+		const Command& c = cq.front();
+		if (c.GetID() != CMD_RECLAIM || (c.GetNumParams() != 1 && c.GetNumParams() != 5)) {
+			removees.push_back(u->id);
+			continue;
+		}
+		const int cmdFeatureId = (int)c.GetParam(0);
+		if ((cmdFeatureId - unitHandler.MaxUnits()) == featureId && (friendUnit == nullptr || teamHandler.Ally(friendUnit->allyteam, u->allyteam))) {
+			retval = true;
+			break;
+		}
+	}
+
+	for (auto it = removees.begin(); it != removees.end(); ++it)
+		RemoveUnitFromFeatureReclaimers(unitHandler.GetUnit(*it));
+
+	return retval;
+}
+
+
+bool CBuilderCaches::IsFeatureBeingResurrected(int featureId, const CUnit* friendUnit)
+{
+	bool retval = false;
+
+	removees.clear();
+	removees.reserve(resurrecters.size());
+
+	for (auto it = resurrecters.begin(); it != resurrecters.end(); ++it) {
+		const CUnit* u = unitHandler.GetUnit(*it);
+		const CCommandAI* cai = u->commandAI;
+		const CCommandQueue& cq = cai->commandQue;
+
+		if (cq.empty()) {
+			removees.push_back(u->id);
+			continue;
+		}
+		const Command& c = cq.front();
+		if (c.GetID() != CMD_RESURRECT || c.GetNumParams() != 1) {
+			removees.push_back(u->id);
+			continue;
+		}
+		const int cmdFeatureId = (int)c.GetParam(0);
+		if ((cmdFeatureId - unitHandler.MaxUnits()) == featureId && (friendUnit == nullptr || teamHandler.Ally(friendUnit->allyteam, u->allyteam))) {
+			retval = true;
+			break;
+		}
+	}
+
+	for (auto it = removees.begin(); it != removees.end(); ++it)
+		RemoveUnitFromResurrecters(unitHandler.GetUnit(*it));
+
+	return retval;
+}
+
+
+

--- a/rts/Sim/Units/CommandAI/BuilderCaches.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCaches.cpp
@@ -4,7 +4,7 @@
 #include "Sim/Units/UnitHandler.h"
 #include "Sim/Units/Unit.h"
 
-// not adding to members, should repopulate itself
+// not adding to creg, should repopulate itself
 spring::unordered_set<int> CBuilderCaches::reclaimers;
 spring::unordered_set<int> CBuilderCaches::featureReclaimers;
 spring::unordered_set<int> CBuilderCaches::resurrecters;

--- a/rts/Sim/Units/CommandAI/BuilderCaches.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCaches.cpp
@@ -1,3 +1,4 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 #include "Sim/Units/CommandAI/BuilderCaches.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Units/UnitHandler.h"

--- a/rts/Sim/Units/CommandAI/BuilderCaches.h
+++ b/rts/Sim/Units/CommandAI/BuilderCaches.h
@@ -1,0 +1,41 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef _BUILDER_CACHES_H_
+#define _BUILDER_CACHES_H_
+
+#include "System/UnorderedSet.hpp"
+
+#include <vector>
+
+class CUnit;
+
+class CBuilderCaches
+{
+public:
+	/**
+	 * Checks if a unit is being reclaimed by a friendly con.
+	 */
+	static void InitStatic();
+	static bool IsUnitBeingReclaimed(const CUnit* unit, const CUnit* friendUnit = nullptr);
+	static bool IsFeatureBeingReclaimed(int featureId, const CUnit* friendUnit = nullptr);
+	static bool IsFeatureBeingResurrected(int featureId, const CUnit* friendUnit = nullptr);
+	static spring::unordered_set<int> reclaimers;
+	static spring::unordered_set<int> featureReclaimers;
+	static spring::unordered_set<int> resurrecters;
+
+	static std::vector<int> removees;
+
+	/// fix for patrolling cons repairing/resurrecting stuff that's being reclaimed
+	static void AddUnitToReclaimers(CUnit*);
+	static void RemoveUnitFromReclaimers(CUnit*);
+
+	/// fix for cons wandering away from their target circle
+	static void AddUnitToFeatureReclaimers(CUnit*);
+	static void RemoveUnitFromFeatureReclaimers(CUnit*);
+
+	/// fix for patrolling cons reclaiming stuff that is being resurrected
+	static void AddUnitToResurrecters(CUnit*);
+	static void RemoveUnitFromResurrecters(CUnit*);
+};
+
+#endif // _BUILDER_CACHES_H_

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -20,6 +20,7 @@
 #include "CommandAI/CommandAI.h"
 #include "CommandAI/FactoryCAI.h"
 #include "CommandAI/MobileCAI.h"
+#include "CommandAI/BuilderCaches.h"
 
 #include "ExternalAI/EngineOutHandler.h"
 #include "Game/GameHelper.h"
@@ -164,7 +165,7 @@ void CUnit::InitStatic()
 	SetExpReloadScale(modInfo.unitExpReloadScale);
 	SetExpGrade(0.0f);
 
-	CBuilderCAI::InitStatic();
+	CBuilderCaches::InitStatic();
 	unitToolTipMap.Clear();
 }
 

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -21,6 +21,7 @@
 #include "Sim/Projectiles/ProjectileHandler.h"
 #include "Sim/Units/Scripts/CobInstance.h"
 #include "Sim/Units/CommandAI/BuilderCAI.h"
+#include "Sim/Units/CommandAI/BuilderCaches.h"
 #include "Sim/Units/CommandAI/CommandAI.h"
 #include "Sim/Units/UnitDefHandler.h"
 #include "Sim/Units/UnitHandler.h"
@@ -388,7 +389,6 @@ bool CBuilder::UpdateReclaim(const Command& fCommand)
 bool CBuilder::UpdateResurrect(const Command& fCommand)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	CBuilderCAI* cai = static_cast<CBuilderCAI*>(commandAI);
 	CFeature* curResurrectee = curResurrect;
 
 	if (curResurrectee == nullptr || f3SqDist(curResurrectee->pos, pos) >= Square(buildDistance + curResurrectee->buildeeRadius) || !inBuildStance)
@@ -440,7 +440,7 @@ bool CBuilder::UpdateResurrect(const Command& fCommand)
 		resurrectee->SetSoloBuilder(this, resurrecteeDef);
 		resurrectee->SetHeading(curResurrectee->heading, !resurrectee->upright && resurrectee->IsOnGround(), false, 0.0f);
 
-		for (const int resurrecterID: cai->resurrecters) {
+		for (const int resurrecterID: CBuilderCaches::resurrecters) {
 			CBuilder* resurrecter = static_cast<CBuilder*>(unitHandler.GetUnit(resurrecterID));
 			CCommandAI* resurrecterCAI = resurrecter->commandAI;
 


### PR DESCRIPTION
### Work done

- Factor out static caches from BuilderCAI

### Remarks

- Just moving code around.
- Part of a bigger effort to allow builder commands to be used by other unit and ai types.
  - See https://github.com/beyond-all-reason/spring/issues/1597#issuecomment-2583489746
  - See  https://github.com/saurtron/spring/commit/b3acf9aa06a7f2133e2c3c6e61baefd1e6225db5#diff-f07ea03231eeb0aab27b40904941d7c552446b68667f4fca981c77768e59e4a6R421
- static functions may need to be used in other modules in the future
  - even if that's not the case also cleaner this way
- This can probably be refactored even more internally to be more flexible in the future
  - Will likely need to become a CEventClient to be able to address TODOs there.
