### PR TITLE
More strict sync check

### DIFF
--- a/rts/Game/GameVersion.cpp
+++ b/rts/Game/GameVersion.cpp
@@ -211,11 +211,7 @@ const std::string& Get()
 
 const std::string& GetSync()
 {
-	static const std::string sync = IsRelease()
-			? GetMajor() + "." + GetMinor() + "." + GetPatchSet()
-			: SPRING_VERSION_ENGINE;
-
-	return sync;
+	return SPRING_VERSION_ENGINE;
 }
 
 const std::string& GetFull()


### PR DESCRIPTION
Different commits no longer sync with each other (even if changes are cosmetic) and being a release version doesn't change that.