### PR TITLE
Adding TTL to CWeapon

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2206,6 +2206,10 @@ static bool SetSingleUnitWeaponState(lua_State* L, CWeapon* weapon, int index)
 			weapon->collisionFlags = lua_toint(L, index + 1);
 		} break;
 
+		case hashString("ttl"): {
+			weapon->ttl = lua_toint(L, index + 1);
+		} break;
+
 		default: {
 			return false;
 		} break;

--- a/rts/Sim/Weapons/BombDropper.cpp
+++ b/rts/Sim/Weapons/BombDropper.cpp
@@ -132,7 +132,7 @@ void CBombDropper::FireImpl(const bool scriptCall)
 		params.pos = weaponMuzzlePos;
 		params.end = currentTargetPos;
 		params.speed = launchSpeed;
-		params.ttl = (weaponDef->flighttime == 0)? ((range / projectileSpeed) + 15 + predict): weaponDef->flighttime;
+		params.ttl = (ttl == 0)? ((range / projectileSpeed) + 15 + predict): ttl;
 		params.tracking = tracking;
 
 		assert(weaponDef->projectileType == WEAPON_TORPEDO_PROJECTILE);

--- a/rts/Sim/Weapons/Cannon.cpp
+++ b/rts/Sim/Weapons/Cannon.cpp
@@ -110,27 +110,27 @@ void CCannon::FireImpl(const bool scriptCall)
 	launchDir += (gsRNG.NextVector() * SprayAngleExperience() + SalvoErrorExperience());
 	launchDir.SafeNormalize();
 
-	int ttl = 0;
+	int this_ttl = 0;
 	const float sqSpeed2D = launchDir.SqLength2D() * projectileSpeed * projectileSpeed;
 	const int predict = math::ceil((sqSpeed2D == 0.0f) ?
 		(-2.0f * projectileSpeed * launchDir.y / gravity):
 		math::sqrt(targetVec.SqLength2D() / sqSpeed2D));
 
-	if (weaponDef->flighttime > 0) {
-		ttl = weaponDef->flighttime;
+	if (ttl > 0) {
+		this_ttl = ttl;
 	} else if (weaponDef->selfExplode) {
-		ttl = (predict + gsRNG.NextFloat() * 2.5f - 0.5f);
+		this_ttl = (predict + gsRNG.NextFloat() * 2.5f - 0.5f);
 	} else if ((weaponDef->groundBounce || weaponDef->waterBounce) && weaponDef->numBounce > 0) {
-		ttl = (predict * (1 + weaponDef->numBounce * weaponDef->bounceRebound));
+		this_ttl = (predict * (1 + weaponDef->numBounce * weaponDef->bounceRebound));
 	} else {
-		ttl = predict * 2;
+		this_ttl = predict * 2;
 	}
 
 	ProjectileParams params = GetProjectileParams();
 	params.pos = weaponMuzzlePos;
 	params.end = currentTargetPos;
 	params.speed = launchDir * projectileSpeed;
-	params.ttl = ttl;
+	params.ttl = this_ttl;
 	params.gravity = gravity;
 
 	WeaponProjectileFactory::LoadProjectile(params);

--- a/rts/Sim/Weapons/EmgCannon.cpp
+++ b/rts/Sim/Weapons/EmgCannon.cpp
@@ -33,7 +33,7 @@ void CEmgCannon::FireImpl(const bool scriptCall)
 	ProjectileParams params = GetProjectileParams();
 	params.pos = weaponMuzzlePos;
 	params.speed = dir * projectileSpeed;
-	params.ttl = weaponDef->flighttime > 0 ? weaponDef->flighttime : math::ceil(std::max(dist, range) / projectileSpeed);
+	params.ttl = ttl > 0 ? ttl : math::ceil(std::max(dist, range) / projectileSpeed);
 
 	WeaponProjectileFactory::LoadProjectile(params);
 }

--- a/rts/Sim/Weapons/MissileLauncher.cpp
+++ b/rts/Sim/Weapons/MissileLauncher.cpp
@@ -62,7 +62,7 @@ void CMissileLauncher::FireImpl(const bool scriptCall)
 	params.pos = weaponMuzzlePos;
 	params.end = currentTargetPos;
 	params.speed = startSpeed;
-	params.ttl = weaponDef->flighttime == 0? math::ceil(std::max(targetDist, range) / projectileSpeed + 25 * weaponDef->selfExplode): weaponDef->flighttime;
+	params.ttl = ttl == 0? math::ceil(std::max(targetDist, range) / projectileSpeed + 25 * weaponDef->selfExplode): ttl;
 	params.gravity = -weaponDef->myGravity;
 
 	WeaponProjectileFactory::LoadProjectile(params);

--- a/rts/Sim/Weapons/TorpedoLauncher.cpp
+++ b/rts/Sim/Weapons/TorpedoLauncher.cpp
@@ -71,7 +71,7 @@ void CTorpedoLauncher::FireImpl(const bool scriptCall)
 	params.speed = vel;
 	params.pos = weaponMuzzlePos;
 	params.end = currentTargetPos;
-	params.ttl = (weaponDef->flighttime == 0)? math::ceil(std::max(dist, range) / projectileSpeed + 25): weaponDef->flighttime;
+	params.ttl = (ttl == 0)? math::ceil(std::max(dist, range) / projectileSpeed + 25): ttl;
 	params.tracking = tracking;
 
 	WeaponProjectileFactory::LoadProjectile(params);

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -53,6 +53,7 @@ CR_REG_METADATA(CWeapon, (
 	CR_MEMBER(nextSalvo),
 	CR_MEMBER(salvoLeft),
 	CR_MEMBER(salvoWindup),
+	CR_MEMBER(ttl),
 
 	CR_MEMBER(range),
 	CR_MEMBER(projectileSpeed),
@@ -139,6 +140,7 @@ CWeapon::CWeapon(CUnit* owner, const WeaponDef* def):
 	nextSalvo(0),
 	salvoLeft(0),
 	salvoWindup(0),
+	ttl(1),
 
 	range(1.0f),
 	projectileSpeed(1.0f),

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -151,6 +151,7 @@ public:
 	int nextSalvo;                          // when the next shot in the current salvo will fire
 	int salvoLeft;                          // number of shots left in current salvo
 	int salvoWindup;                        // delay before first shot (in frames)
+	int ttl;								// flight time for missile type weapons
 
 	float range;
 	float projectileSpeed;

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -190,5 +190,7 @@ void CWeaponLoader::InitWeapon(CUnit* owner, CWeapon* weapon, const UnitDefWeapo
 	weapon->fastAutoRetargeting = defWeapon->fastAutoRetargeting;
 	weapon->fastQueryPointUpdate = defWeapon->fastQueryPointUpdate;
 	weapon->burstControlWhenOutOfArc = defWeapon->burstControlWhenOutOfArc;
+
+	weapon->ttl = weaponDef->flighttime;
 }
 


### PR DESCRIPTION
Added option to set `ttl` in `SetUnitWeaponState`, and added a `ttl` field into `CWeapon`. This overrides the original `weaponDef->flighttime` so games can set weapon ttl per weapon.

Untested, idk how to test -- @GoogleFrog any tips?