### PR TITLE
Fix crash in SpringVersion::GetSync

### DIFF
--- a/rts/Game/GameVersion.cpp
+++ b/rts/Game/GameVersion.cpp
@@ -211,7 +211,8 @@ const std::string& Get()
 
 const std::string& GetSync()
 {
-	return SPRING_VERSION_ENGINE;
+	static const std::string sync = SPRING_VERSION_ENGINE;
+	return sync;
 }
 
 const std::string& GetFull()


### PR DESCRIPTION
Returning reference to a constexpr char * creates a null pointer in SpringVersion::GetSync