### PR TITLE
hotfix: Don't run FinishedBuilding side effects for isDead units.

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -423,6 +423,9 @@ void CUnit::FinishedBuilding(bool postInit)
 		soloBuilder = nullptr;
 	}
 
+	if (isDead)
+		return;
+
 	ChangeLos(realLosRadius, realAirLosRadius);
 
 	if (unitDef->activateWhenBuilt)

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -423,7 +423,7 @@ void CUnit::FinishedBuilding(bool postInit)
 		soloBuilder = nullptr;
 	}
 
-	if (isDead)
+	if (isDead) // Lua can kill a freshy spawned unit in UnitCreated
 		return;
 
 	ChangeLos(realLosRadius, realAirLosRadius);


### PR DESCRIPTION
### Description

- isDead unit reaching CUnit::FinishedBuilding makes the game crash on UpdateWind later on.
- For now just bailing out before reaching that
  - this could be just a symptom of something else being broken and corrupting more game logic!

### Remarks

#### About the fix

Could just skip just the generator part, but looks safe to skip from there on, other parts like calling Activate, ChangeLos or SetStorage seem a bit suspect too if the unit is dead.

Since the problem is the unit is getting killed by lua at eventHandler::UnitCreated right before calling FinishedBuilding not much more we can do than add an isDead fix there. Well, another option would be letting that run, but then making sure it gets removed from wind generators and maybe other places.

#### About the crash

- I'll investigate a bit more but for now this may help in hotfixing or further investigation.
- Seems to come there dead from `CUnitLoader::LoadUnit`, sometimes unit already isDead after that.
- Seems to be killed at eventHandler::UnitCreated inside PostInit.
- Lua is killing it
- I also didn't see the FinishedBuilding code passing from the initial check `(!beingBuild && !postInit) return` except for dead units, find that a bit strange.

### Links

- replay: https://discord.com/channels/549281623154229250/724924957074915358/1328377084250427483
- discord thread: https://discord.com/channels/549281623154229250/1328318773740179496
- this commit is related but might not be the cause of the problem, just the symptom: https://github.com/beyond-all-reason/spring/commit/35d85c7f709b03ff6b2a95d8cf72b55c86969b2a