### PR TITLE
Fix blurred minimap

### DIFF
--- a/rts/Game/UI/MiniMap.h
+++ b/rts/Game/UI/MiniMap.h
@@ -196,7 +196,6 @@ protected:
 	CMatrix44f projMats[3];
 
 	FBO fbo;
-	FBO fboResolve;
 	GLuint minimapTex = 0;
 	int2 minimapTexSize;
 

--- a/rts/Game/UI/MiniMap.h
+++ b/rts/Game/UI/MiniMap.h
@@ -164,6 +164,7 @@ protected:
 
 	bool renderToTexture = true;
 	bool multisampledFBO = false;
+	bool minimapCrispy = false;
 
 	struct IntBox {
 		bool Inside(int x, int y) const {
@@ -196,6 +197,7 @@ protected:
 	CMatrix44f projMats[3];
 
 	FBO fbo;
+	FBO fboResolve;
 	GLuint minimapTex = 0;
 	int2 minimapTexSize;
 


### PR DESCRIPTION
The minimap clarity and sharpness shouldn't be impacted by AA settings.
Turns out the texture was also linearly filtered.

This PR 
- removes AA entirely from the minimap rendering
- changes the Linear filtering to a Nearest filtering

Here is a screenshot of the issue
![Screenshot From 2025-01-13 21-35-44](https://github.com/user-attachments/assets/d5ee8b4c-9907-435f-ae8d-4e7b17fedd23)
