### PR TITLE
Fix RmlUi getting blurry when using AA

### DIFF
--- a/rts/Rml/Backends/RmlUi_Renderer_GL3_Recoil.cpp
+++ b/rts/Rml/Backends/RmlUi_Renderer_GL3_Recoil.cpp
@@ -525,7 +525,7 @@ static bool CreateFramebuffer(
 #endif
 
 	constexpr GLenum color_format = GL_RGBA8;   // GL_RGBA8 GL_SRGB8_ALPHA8 GL_RGBA16F
-	constexpr GLint min_mag_filter = GL_LINEAR; // GL_NEAREST
+	constexpr GLint min_mag_filter = GL_NEAREST; // GL_NEAREST
 	const Rml::Colourf border_color(0.f, 0.f);
 
 	GLuint framebuffer = 0;
@@ -696,7 +696,7 @@ void RenderInterface_GL3_Recoil::SetViewport(int width, int height)
 
 void RenderInterface_GL3_Recoil::BeginFrame()
 {
-	RMLUI_ASSERT(viewport_width >= 1 && viewport_height >= 1)
+	RMLUI_ASSERT(viewport_width >= 1 && viewport_height >= 1);
 
 	// Backup GL state.
 	glstate_backup.enable_cull_face = glIsEnabled(GL_CULL_FACE);
@@ -761,6 +761,8 @@ void RenderInterface_GL3_Recoil::BeginFrame()
 	glStencilMask(GLuint(-1));
 	glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
 
+	glDisable(GL_DEPTH_TEST);
+
 	SetTransform(nullptr);
 
 	render_layers.BeginFrame(viewport_width, viewport_height);
@@ -797,8 +799,6 @@ void RenderInterface_GL3_Recoil::EndFrame()
 	DrawFullscreenQuad();
 
 	render_layers.EndFrame();
-
-	UseProgram(ProgramId::None);
 
 	// Restore GL state.
 	if (glstate_backup.enable_cull_face)

--- a/rts/Rml/Backends/RmlUi_Renderer_GL3_Recoil.cpp
+++ b/rts/Rml/Backends/RmlUi_Renderer_GL3_Recoil.cpp
@@ -800,6 +800,8 @@ void RenderInterface_GL3_Recoil::EndFrame()
 
 	render_layers.EndFrame();
 
+	UseProgram(ProgramId::None);
+
 	// Restore GL state.
 	if (glstate_backup.enable_cull_face)
 		glEnable(GL_CULL_FACE);


### PR DESCRIPTION
This PR fixes an issue with RmlUi widget being super blurry when AA is in use. It's particularly blurry when SSAA is activated.

Before
![Screenshot From 2025-01-15 18-52-38](https://github.com/user-attachments/assets/08c0d5aa-f6a3-4d99-b382-56800c09ecad)


After
![Screenshot From 2025-01-15 18-44-12](https://github.com/user-attachments/assets/a7b61807-b67f-4dcf-b3d3-7d79cb7ffdd8)
