### PR TITLE
Error out on NaNs/Infinities coming from Lua.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,15 +403,9 @@ if(NOT MSVC)
 endif(NOT MSVC)
 
 
-if(DEBUG_BUILD)
-        set(DEBUG_LUANAN_DEFAULT TRUE)
-else()
-        set(DEBUG_LUANAN_DEFAULT FALSE)
-endif()
-
-option(DEBUG_LUANAN "check for nans in lua" ${DEBUG_LUANAN_DEFAULT})
-if(DEBUG_LUANAN)
-        add_definitions(-DDEBUG_LUANAN)
+option(REPORT_LUANAN "report nans/infinities in lua" TRUE)
+if(REPORT_LUANAN)
+        add_definitions(-DREPORT_LUANAN)
 endif()
 
 

--- a/rts/lib/lua/include/LuaInclude.h
+++ b/rts/lib/lua/include/LuaInclude.h
@@ -14,6 +14,7 @@
 #include "lib/lua/src/lstate.h"
 #include "lib/streflop/streflop_cond.h"
 #include "System/Log/ILog.h"
+#include "System/BranchPrediction.h"
 
 
 
@@ -85,11 +86,12 @@ static inline int lua_toint(lua_State* L, int idx)
 static inline float lua_tofloat(lua_State* L, int idx)
 {
 	const float n = lua_tonumber(L, idx);
-#if defined(DEBUG_LUANAN)
+#if defined(REPORT_LUANAN)
 	// Note:
 	// luaL_argerror must be called from inside of lua, else it calls exit()
 	// so it can't be used in LuaParser::Get...() and similar
-	if (math::isinf(n) || math::isnan(n)) luaL_argerror(L, idx, "number expected, got NAN (check your code for div0)");
+	if unlikely(math::isinf(n)) luaL_argerror(L, idx, "number expected, got +-Inf (check your code for div0)");
+	if unlikely(math::isnan(n)) luaL_argerror(L, idx, "number expected, got +-NaN (check your code for div0)");
 #endif
 	return n;
 }

--- a/rts/lib/lua/src/lauxlib.cpp
+++ b/rts/lib/lua/src/lauxlib.cpp
@@ -24,6 +24,7 @@
 #include "lauxlib.h"
 
 #include "streflop_cond.h" // SPRING
+#include "System/BranchPrediction.h" // Recoil
 
 
 #define FREELIST_REF	0	/* free list of references */
@@ -179,15 +180,14 @@ LUALIB_API lua_Number luaL_checknumber (lua_State *L, int narg) {
   if (d == 0 && !lua_isnumber(L, narg))  /* avoid extra test when d is not 0 */
     tag_error(L, narg, LUA_TNUMBER);
 
-#if defined(DEBUG_LUANAN)
+#if defined(REPORT_LUANAN)
   // SPRING
   //   this is used by luaL_optnumber, luaL_optfloat (via luaL_optnumber),
   //   and luaL_checkfloat, so the asserts should cover 90% of all cases
   //   in which non-numbers can infect the engine -- lua_tofloat asserts
   //   take care of the rest
-  if (math::isinf(d) || math::isnan(d)) luaL_argerror(L, narg, "number expected, got NAN (check your code for div0)");
-  //assert(!math::isinf(d));
-  //assert(!math::isnan(d));
+  if unlikely(math::isinf(d)) luaL_argerror(L, narg, "number expected, got +-Inf (check your code for div0)");
+  if unlikely(math::isnan(d)) luaL_argerror(L, narg, "number expected, got +-NaN (check your code for div0)");
 #endif
 
   return d;


### PR DESCRIPTION
NaNs and Infs are contagious.
Additionally NaNs are not clamped by std::clamp() leading to all sorts of access violations.
In short NaNs should never be accepted from Lua.