### PR TITLE
Fix issue with waypoint updates

### DIFF
--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -128,10 +128,6 @@ public:
 	float GetGroundHeight(const float3&) const;
 
 	void SyncWaypoints() {
-		if (moveFailed){
-			Fail(false);
-			moveFailed = false;
-		}
 		// Synced vars trigger a checksum update on change, which is expensive so we should check
 		// that there has been a change before triggering an update to the checksum.
 		if (!currWayPoint.bitExactEquals(earlyCurrWayPoint))
@@ -296,7 +292,6 @@ private:
 	bool atGoal = true;
 	bool atEndOfPath = true;
 	bool wantRepath = false;
-	bool moveFailed = false;
 	bool lastWaypoint = false;
 
 	bool reversing = false;


### PR DESCRIPTION
Fixes https://github.com/beyond-all-reason/spring/issues/1878. Zero-K makes a call in repsonse to Arrived event, which changes a waypoint and I failed to account for that in the last change.

Also removed unused member variable.