### PR TITLE
add rotation to set/get state functions for controllers that have their own rotations

### DIFF
--- a/rts/Game/Camera/DollyController.cpp
+++ b/rts/Game/Camera/DollyController.cpp
@@ -168,6 +168,9 @@ void CDollyController::GetState(StateMap& sm) const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	CCameraController::GetState(sm);
+	sm["rx"]   = rot.x;
+	sm["ry"]   = rot.y;
+	sm["rz"]   = rot.z;
 }
 
 bool CDollyController::SetState(const StateMap& sm)

--- a/rts/Game/Camera/FPSController.cpp
+++ b/rts/Game/Camera/FPSController.cpp
@@ -151,6 +151,9 @@ void CFPSController::GetState(StateMap& sm) const
 	RECOIL_DETAILED_TRACY_ZONE;
 	CCameraController::GetState(sm);
 	sm["oldHeight"] = oldHeight;
+	sm["rx"]   = rot.x;
+	sm["ry"]   = rot.y;
+	sm["rz"]   = rot.z;
 }
 
 
@@ -159,6 +162,9 @@ bool CFPSController::SetState(const StateMap& sm)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CCameraController::SetState(sm);
 	SetStateFloat(sm, "oldHeight", oldHeight);
+	SetStateFloat(sm, "rx",   rot.x);
+	SetStateFloat(sm, "ry",   rot.y);
+	SetStateFloat(sm, "rz",   rot.z);
 
 	return true;
 }

--- a/rts/Game/Camera/RotOverheadController.cpp
+++ b/rts/Game/Camera/RotOverheadController.cpp
@@ -133,6 +133,9 @@ void CRotOverheadController::GetState(StateMap& sm) const
 	CCameraController::GetState(sm);
 
 	sm["oldHeight"] = oldHeight;
+	sm["rx"]   = rot.x;
+	sm["ry"]   = rot.y;
+	sm["rz"]   = rot.z;
 }
 
 
@@ -142,6 +145,9 @@ bool CRotOverheadController::SetState(const StateMap& sm)
 	CCameraController::SetState(sm);
 
 	SetStateFloat(sm, "oldHeight", oldHeight);
+	SetStateFloat(sm, "rx",   rot.x);
+	SetStateFloat(sm, "ry",   rot.y);
+	SetStateFloat(sm, "rz",   rot.z);
 
 	return true;
 }


### PR DESCRIPTION
I missed updating these functions when moving these controllers to contain their own rotation