### PR TITLE
chore: Configure editorconfig for lua and c++ files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root=true
+
+[*.cpp,*.h,*.lua]
+indent_style = tab


### PR DESCRIPTION
We use tabs instead of spaces everywhere.

This should assist developers writing code in convention.