### PR TITLE
Reduce memory usage of QTPFS

### DIFF
--- a/rts/Sim/Path/QTPFS/Node.cpp
+++ b/rts/Sim/Path/QTPFS/Node.cpp
@@ -536,7 +536,8 @@ bool QTPFS::QTNode::UpdateMoveCost(
 	assert(int(zmin()) >= r.z1);
 	assert(int(zmax()) <= r.z2);
 
-	const SpeedBinType refSpeedBin = curSpeedBins[zmin() * mapDims.mapx + xmin()];
+	const int rw = r.GetWidth();
+	const SpeedBinType refSpeedBin = curSpeedBins[(zmin() - r.z1) * rw + (xmin() - r.x1)];
 
 	// <this> can either just have been merged or added as
 	// new child of split parent; in the former case we can
@@ -549,7 +550,7 @@ bool QTPFS::QTNode::UpdateMoveCost(
 
 	for (unsigned int hmz = zmin(); hmz < zmax(); hmz++) {
 		for (unsigned int hmx = xmin(); hmx < xmax(); hmx++) {
-			const unsigned int sqrIdx = hmz * mapDims.mapx + hmx;
+			const unsigned int sqrIdx = (hmz - r.z1) * rw + (hmx - r.x1);
 
 			assert(sqrIdx >= 0);
 			assert(sqrIdx < curSpeedBins.size());

--- a/rts/Sim/Path/QTPFS/NodeLayer.cpp
+++ b/rts/Sim/Path/QTPFS/NodeLayer.cpp
@@ -92,8 +92,8 @@ bool QTPFS::NodeLayer::Update(UpdateThreadData& threadData) {
 
 	unsigned int numClosedSquares = 0;
 
-	// areaUpdated is always 16x16. areaRelinkedInner could be bigger; this doesn't happen as often and once the nodes
-	// have divided they will never again grow larger than 16x16 in a match.
+	// areaUpdated is always 16x16 squares. areaRelinkedInner could be bigger; this doesn't happen as often and once the
+	// nodes have divided they will never again grow larger than 16x16 squares in a match.
 	const SRectangle& r = threadData.areaRelinkedInner;
 	const MoveDef* md = threadData.moveDef;
 

--- a/rts/Sim/Path/QTPFS/PathDefines.h
+++ b/rts/Sim/Path/QTPFS/PathDefines.h
@@ -28,8 +28,8 @@
 
 #define QTPFS_LAST_FRAME (std::numeric_limits<int>::max())
 
-#define QTPFS_MAX_NODE_SIZE 128
-#define QTPFS_BAD_ROOT_NODE_SIZE 64
+#define QTPFS_MAX_NODE_SIZE 64
+#define QTPFS_BAD_ROOT_NODE_SIZE 32
 
 #define QTPFS_SHARE_PATH_MIN_SIZE 2
 #define QTPFS_SHARE_PATH_MAX_SIZE 16

--- a/rts/Sim/Path/QTPFS/PathDefines.h
+++ b/rts/Sim/Path/QTPFS/PathDefines.h
@@ -18,27 +18,27 @@
 #define QTPFS_ENABLE_MICRO_OPTIMIZATION_HACKS
 // #define QTPFS_CONSERVATIVE_NEIGHBOR_CACHE_UPDATES
 
-#define QTPFS_MAX_SMOOTHING_ITERATIONS 1
+static constexpr int QTPFS_MAX_SMOOTHING_ITERATIONS = 1;
 
-#define QTPFS_MAX_NETPOINTS_PER_NODE_EDGE 1
-#define QTPFS_NETPOINT_EDGE_SPACING_SCALE (1.0f / (QTPFS_MAX_NETPOINTS_PER_NODE_EDGE + 1))
+static constexpr int QTPFS_MAX_NETPOINTS_PER_NODE_EDGE = 1;
+static constexpr float QTPFS_NETPOINT_EDGE_SPACING_SCALE = (1.0f / (QTPFS_MAX_NETPOINTS_PER_NODE_EDGE + 1));
 
-#define QTPFS_POSITIVE_INFINITY (std::numeric_limits<float>::infinity())
-#define QTPFS_CLOSED_NODE_COST (1 << 24)
+static constexpr float QTPFS_POSITIVE_INFINITY = (std::numeric_limits<float>::infinity());
+static constexpr float QTPFS_CLOSED_NODE_COST = (1 << 24);
 
-#define QTPFS_LAST_FRAME (std::numeric_limits<int>::max())
+static constexpr int QTPFS_LAST_FRAME = (std::numeric_limits<int>::max());
 
-#define QTPFS_MAX_NODE_SIZE 64
-#define QTPFS_BAD_ROOT_NODE_SIZE 32
+static constexpr uint32_t QTPFS_MAX_NODE_SIZE = 64;
+static constexpr uint32_t QTPFS_BAD_ROOT_NODE_SIZE = 32;
 
-#define QTPFS_SHARE_PATH_MIN_SIZE 2
-#define QTPFS_SHARE_PATH_MAX_SIZE 16
-#define QTPFS_PARTIAL_SHARE_PATH_MAX_SIZE 32
+static constexpr uint32_t QTPFS_SHARE_PATH_MIN_SIZE = 2;
+static constexpr uint32_t QTPFS_SHARE_PATH_MAX_SIZE = 16;
+static constexpr uint32_t QTPFS_PARTIAL_SHARE_PATH_MAX_SIZE = 32;
 
-#define QTPFS_MAP_DAMAGE_SIZE 16
+static constexpr uint32_t QTPFS_MAP_DAMAGE_SIZE = 16;
 
 // Though there are four quads per level, having nothing is like a 5th state. So 3 bits, not 2, is needed per level.
-#define QTPFS_NODE_NUMBER_SHIFT_STEP 3
+static constexpr uint32_t QTPFS_NODE_NUMBER_SHIFT_STEP = 3;
 
 namespace QTPFS {
     constexpr int SEARCH_DIRS = 2;

--- a/rts/Sim/Path/QTPFS/PathManager.cpp
+++ b/rts/Sim/Path/QTPFS/PathManager.cpp
@@ -494,7 +494,7 @@ void QTPFS::PathManager::InitRootSize(const SRectangle& r) {
 
 	assert(rootSize != QTPFS_BAD_ROOT_NODE_SIZE);
 	if (rootSize == QTPFS_BAD_ROOT_NODE_SIZE)
-		LOG("%s: Warning! Map width and height are supposed to be multiples of 1024 elmos.", __func__);
+		LOG("%s: Warning! Map width and height highest common factor is smaller than QTPFS is designed to handle.", __func__);
 
 	// Prevent too big a size being picked due to 15 levels of node Indexing possible: 2^(steps -1) (steps=(bits-2)/2)
 	constexpr float maxNodeLevels = ((sizeof(uint32_t)*4)-2);


### PR DESCRIPTION
Reduces the memory consumed by QTPFS by removing a map-wide cache that is maintained for every move type - instead making it only relevant for the specific area being recalculated.

In BAR this change reduces the memory consummed when loading the map, Mediterraneum v1, (a 32x32 map) by about 300MB.