### PR TITLE
Switch push resistant units to use trap check system

### DIFF
--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -40,6 +40,7 @@
 #include "System/type2.h"
 #include "System/Sound/ISoundChannels.h"
 #include "System/SpringHash.h"
+#include "Utils/UnitTrapCheckUtils.h"
 
 #include "System/Misc/TracyDefs.h"
 
@@ -2402,12 +2403,6 @@ void CGroundMoveType::StartEngine(bool callScript) {
 			// makes no sense to call this unless we have a new path
 			owner->script->StartMoving(reversing);
 		}
-
-		// Due to how push resistant units work, they can trap units when they stop moving.
-		// Have units check they are not trapped when beginning to move is any push resistant units
-		// are used by the game.
-		if (!forceStaticObjectCheck)
-			forceStaticObjectCheck = (unitDefHandler->NumPushResistantUnitDefs() > 0);
 	}
 }
 
@@ -3565,6 +3560,7 @@ bool CGroundMoveType::UpdateOwnerSpeed(float oldSpeedAbs, float newSpeedAbs, flo
 		} else {
 			owner->Block();
 			pushResistanceBlockActive = true;
+			RegisterUnitForUnitTrapCheck(owner);
 		}
 
 		// this has to be done manually because units don't trigger it with block commands

--- a/rts/Sim/MoveTypes/Utils/UnitTrapCheckUtils.cpp
+++ b/rts/Sim/MoveTypes/Utils/UnitTrapCheckUtils.cpp
@@ -8,6 +8,7 @@
 #include "Sim/Features/Feature.h"
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/MoveTypes/Components/MoveTypesComponents.h"
+#include "Sim/Units/Unit.h"
 
 #include "System/Misc/TracyDefs.h"
 
@@ -22,5 +23,17 @@ void MoveTypes::RegisterFeatureForUnitTrapCheck(CFeature* object) {
 
     Sim::registry.emplace_or_replace<UnitTrapCheck>(object->entityReference
             , UnitTrapCheckType::TRAPPER_IS_FEATURE
+            , object->id);
+}
+
+void MoveTypes::RegisterUnitForUnitTrapCheck(CUnit* object) {
+    RECOIL_DETAILED_TRACY_ZONE;
+    if (gs->frameNum < 0)
+        return;
+
+    assert(Sim::registry.valid(object->entityReference));
+
+    Sim::registry.emplace_or_replace<UnitTrapCheck>(object->entityReference
+            , UnitTrapCheckType::TRAPPER_IS_UNIT
             , object->id);
 }

--- a/rts/Sim/MoveTypes/Utils/UnitTrapCheckUtils.h
+++ b/rts/Sim/MoveTypes/Utils/UnitTrapCheckUtils.h
@@ -4,9 +4,11 @@
 #define UNIT_TRAP_CHECK_UTILS_H__
 
 struct CFeature;
+struct CUnit;
 
 namespace MoveTypes {
     void RegisterFeatureForUnitTrapCheck(CFeature* object);
+    void RegisterUnitForUnitTrapCheck(CUnit* object);
 }
 
 #endif

--- a/rts/Sim/Units/UnitDefHandler.cpp
+++ b/rts/Sim/Units/UnitDefHandler.cpp
@@ -79,8 +79,6 @@ int CUnitDefHandler::PushNewUnitDef(const std::string& unitName, const LuaTable&
 		// force-initialize the real* members
 		newDef.SetNoCost(true);
 		newDef.SetNoCost(noCost);
-
-		numPushResistantUnitDefs += int(newDef.pushResistant);
 	} catch (const content_error& err) {
 		LOG_L(L_ERROR, "%s", err.what());
 		return 0;

--- a/rts/Sim/Units/UnitDefHandler.h
+++ b/rts/Sim/Units/UnitDefHandler.h
@@ -58,8 +58,6 @@ public:
 	const spring::unordered_map<std::string, int>& GetUnitDefIDs() const { return unitDefIDs; }
 	const spring::unordered_map<int, std::vector<int> >& GetDecoyDefIDs() const { return decoyMap; }
 
-	int NumPushResistantUnitDefs() const { return numPushResistantUnitDefs; }
-
 	void SanitizeUnitDefs();
 
 protected:
@@ -76,7 +74,6 @@ private:
 	std::vector< std::pair<std::string, std::string> > decoyNameMap;
 
 	bool noCost = false;
-	int numPushResistantUnitDefs = 0;
 };
 
 extern CUnitDefHandler* unitDefHandler;


### PR DESCRIPTION
Currently the engine has to get a global counter for the number of push resistant move types, and then if the count is greater than one then all units that start moving have to check if they are stuck.

With the trap check system introduced when fixing the issue with wrecks, we can now use that same system for units with push resistance. This means that only when push resistence creates a situation that may lead to it trapping another unit does any checks need to be carried out, which saves on the unneccessary checking for all units whenever they execute a move command.

This also allows for the removal of the global counter for push resistant move types.

This change has the added benefit of allowing units trapped mid-move by a push resistant unit stopping (and creating a blocked zone around the unit) the chance to notice and escape immediately.