### PR TITLE
Fix occasional crash in CBuilderCAI::ExecuteBuildCmd()

### DIFF
--- a/rts/Sim/MoveTypes/HoverAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.cpp
@@ -84,7 +84,7 @@ static const unsigned int FLOAT_MEMBER_HASHES[] = {
 
 static bool UnitIsBusy(const CCommandAI* cai) {
 	// queued move-commands (or active build/repair/etc-commands) mean unit has to stay airborne
-	return (cai->inCommand || cai->HasMoreMoveCommands(false));
+	return (cai->inCommand > CMD_STOP || cai->HasMoreMoveCommands(false));
 }
 
 static bool UnitHasLoadCmd(const CCommandAI* cai) {

--- a/rts/Sim/MoveTypes/HoverAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.cpp
@@ -84,7 +84,7 @@ static const unsigned int FLOAT_MEMBER_HASHES[] = {
 
 static bool UnitIsBusy(const CCommandAI* cai) {
 	// queued move-commands (or active build/repair/etc-commands) mean unit has to stay airborne
-	return (cai->inCommand > CMD_STOP || cai->HasMoreMoveCommands(false));
+	return (cai->inCommand != CMD_STOP || cai->HasMoreMoveCommands(false));
 }
 
 static bool UnitHasLoadCmd(const CCommandAI* cai) {

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -629,7 +629,7 @@ void CBuilderCAI::ExecuteBuildCmd(Command& c)
 	}
 
 	// guard against dangling non-build commands
-	if (inCommand != c.GetID())
+	if (inCommand >= CMD_STOP)
 		return;
 
 	assert(build.def != nullptr);

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -629,7 +629,7 @@ void CBuilderCAI::ExecuteBuildCmd(Command& c)
 	}
 
 	// guard against dangling non-build commands
-	if (inCommand >= CMD_STOP)
+	if (inCommand != c.GetID())
 		return;
 
 	assert(build.def != nullptr);

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -593,7 +593,7 @@ void CBuilderCAI::ExecuteBuildCmd(Command& c)
 	if (buildOptions.find(c.GetID()) == buildOptions.end())
 		return;
 
-	if (!inCommand) {
+	if (inCommand == CMD_STOP) {
 		BuildInfo bi;
 
 		// note:
@@ -625,8 +625,12 @@ void CBuilderCAI::ExecuteBuildCmd(Command& c)
 
 		// <build> is never parsed (except in PostLoad) so just copy it
 		build = bi;
-		inCommand = true;
+		inCommand = c.GetID();
 	}
+
+	// guard against dangling non-build commands
+	if (inCommand >= CMD_STOP)
+		return;
 
 	assert(build.def != nullptr);
 	assert(build.def->id == -c.GetID() && build.def->id != 0);
@@ -686,7 +690,7 @@ void CBuilderCAI::ExecuteBuildCmd(Command& c)
 		}
 
 		if (f != nullptr && (!build.def->isFeature || build.def->wreckName != f->def->name)) {
-			inCommand = false;
+			inCommand = CMD_STOP;
 			ReclaimFeature(f);
 			return;
 		}
@@ -795,7 +799,7 @@ void CBuilderCAI::ExecuteRepair(Command& c)
 
 		ownerBuilder->StopBuild();
 		if (FindRepairTargetAndRepair(pos, radius, c.GetOpts(), false, (c.GetOpts() & META_KEY))) {
-			inCommand = false;
+			inCommand = CMD_STOP;
 			SlowUpdate();
 			return;
 		}
@@ -851,7 +855,7 @@ void CBuilderCAI::ExecuteCapture(Command& c)
 		ownerBuilder->StopBuild();
 
 		if (FindCaptureTargetAndCapture(pos, radius, c.GetOpts(), (c.GetOpts() & META_KEY))) {
-			inCommand = false;
+			inCommand = CMD_STOP;
 			SlowUpdate();
 			return;
 		}
@@ -927,7 +931,7 @@ void CBuilderCAI::ExecuteGuard(Command& c)
 			Command nc(CMD_REPAIR, c.GetOpts(), b->curBuild->id);
 
 			commandQue.push_front(nc);
-			inCommand = false;
+			inCommand = CMD_STOP;
 			SlowUpdate();
 			return;
 		}
@@ -944,7 +948,7 @@ void CBuilderCAI::ExecuteGuard(Command& c)
 			StopSlowGuard();
 
 			commandQue.push_front(Command(CMD_REPAIR, c.GetOpts(), fac->curBuild->id));
-			inCommand = false;
+			inCommand = CMD_STOP;
 			// SlowUpdate();
 			return;
 		}
@@ -969,7 +973,7 @@ void CBuilderCAI::ExecuteGuard(Command& c)
 			StopSlowGuard();
 
 			commandQue.push_front(Command(CMD_REPAIR, c.GetOpts(), guardee->id));
-			inCommand = false;
+			inCommand = CMD_STOP;
 			return;
 		}
 
@@ -1105,7 +1109,7 @@ void CBuilderCAI::ExecuteReclaim(Command& c)
 		if (recSpecial)   recopt |= REC_SPECIAL;
 
 		if (FindReclaimTargetAndReclaim(pos, radius, c.GetOpts(), recopt)) {
-			inCommand = false;
+			inCommand = CMD_STOP;
 			SlowUpdate();
 			return;
 		}
@@ -1163,7 +1167,7 @@ void CBuilderCAI::ExecuteResurrect(Command& c)
 					c = Command(CMD_REPAIR, c.GetOpts() | INTERNAL_ORDER, ownerBuilder->lastResurrected);
 
 					ownerBuilder->lastResurrected = 0;
-					inCommand = false;
+					inCommand = CMD_STOP;
 					SlowUpdate();
 					return;
 				}
@@ -1180,7 +1184,7 @@ void CBuilderCAI::ExecuteResurrect(Command& c)
 		const float radius = c.GetParam(3);
 
 		if (FindResurrectableFeatureAndResurrect(pos, radius, c.GetOpts(), (c.GetOpts() & META_KEY))) {
-			inCommand = false;
+			inCommand = CMD_STOP;
 			SlowUpdate();
 			return;
 		}
@@ -1223,7 +1227,7 @@ void CBuilderCAI::ExecuteFight(Command& c)
 
 	if (tempOrder) {
 		tempOrder = false;
-		inCommand = true;
+		inCommand = CMD_FIGHT;
 	}
 	if (c.GetNumParams() < 3) {
 		LOG_L(L_ERROR, "[BuilderCAI::%s][f=%d][id=%d][#c.params=%d min=3]", __func__, gs->frameNum, owner->id, c.GetNumParams());
@@ -1231,7 +1235,7 @@ void CBuilderCAI::ExecuteFight(Command& c)
 	}
 
 	if (c.GetNumParams() >= 6) {
-		if (!inCommand)
+		if (inCommand == CMD_STOP)
 			commandPos1 = c.GetPos(3);
 
 	} else {
@@ -1245,8 +1249,8 @@ void CBuilderCAI::ExecuteFight(Command& c)
 	}
 
 	float3 pos = c.GetPos(0);
-	if (!inCommand) {
-		inCommand = true;
+	if (inCommand == CMD_STOP) {
+		inCommand = CMD_FIGHT;
 		commandPos2 = pos;
 	}
 
@@ -1274,7 +1278,7 @@ void CBuilderCAI::ExecuteFight(Command& c)
 	// Priority 1: Repair
 	if (!reclaimEnemyOnlyMode && (ownerDef->canRepair || ownerDef->canAssist) && FindRepairTargetAndRepair(curPosOnLine, searchRadius, c.GetOpts(), true, resurrectMode)){
 		tempOrder = true;
-		inCommand = false;
+		inCommand = CMD_STOP;
 
 		if (lastPC1 != gs->frameNum) {  //avoid infinite loops
 			lastPC1 = gs->frameNum;
@@ -1287,7 +1291,7 @@ void CBuilderCAI::ExecuteFight(Command& c)
 	// Priority 2: Resurrect (optional)
 	if (!reclaimEnemyOnlyMode && resurrectMode && ownerDef->canResurrect && FindResurrectableFeatureAndResurrect(curPosOnLine, searchRadius, c.GetOpts(), false)) {
 		tempOrder = true;
-		inCommand = false;
+		inCommand = CMD_STOP;
 
 		if (lastPC2 != gs->frameNum) {  //avoid infinite loops
 			lastPC2 = gs->frameNum;
@@ -1300,7 +1304,7 @@ void CBuilderCAI::ExecuteFight(Command& c)
 	// Priority 3: Reclaim / reclaim non resurrectable (optional) / reclaim enemy units (optional)
 	if (ownerDef->canReclaim && FindReclaimTargetAndReclaim(curPosOnLine, searchRadius, c.GetOpts(), recopt)) {
 		tempOrder = true;
-		inCommand = false;
+		inCommand = CMD_STOP;
 
 		if (lastPC3 != gs->frameNum) {  //avoid infinite loops
 			lastPC3 = gs->frameNum;
@@ -1329,7 +1333,7 @@ void CBuilderCAI::ExecuteRestore(Command& c)
 	if (!owner->unitDef->canRestore)
 		return;
 
-	if (inCommand) {
+	if (inCommand == CMD_RESTORE) {
 		if (!ownerBuilder->terraforming)
 			StopMoveAndFinishCommand();
 
@@ -1342,7 +1346,7 @@ void CBuilderCAI::ExecuteRestore(Command& c)
 
 		if (MoveInBuildRange(pos, radius * 0.7f)) {
 			ownerBuilder->StartRestore(pos, radius);
-			inCommand = true;
+			inCommand = CMD_RESTORE;
 		}
 	}
 }

--- a/rts/Sim/Units/CommandAI/Command.h
+++ b/rts/Sim/Units/CommandAI/Command.h
@@ -10,74 +10,72 @@
 #include "System/creg/creg_cond.h"
 #include "System/float3.h"
 
-
-
 // ID's lower than 0 are reserved for build options (cmd -x = unitdefs[x])
-#define CMD_STOP                   0
-#define CMD_INSERT                 1
-#define CMD_REMOVE                 2
-#define CMD_WAIT                   5
-#define CMD_TIMEWAIT               6
-#define CMD_DEATHWAIT              7
-#define CMD_SQUADWAIT              8
-#define CMD_GATHERWAIT             9
-#define CMD_MOVE                  10
-#define CMD_PATROL                15
-#define CMD_FIGHT                 16
-#define CMD_ATTACK                20
-#define CMD_AREA_ATTACK           21
-#define CMD_GUARD                 25
-#define CMD_GROUPSELECT           35
-#define CMD_GROUPADD              36
-#define CMD_GROUPCLEAR            37
-#define CMD_REPAIR                40
-#define CMD_FIRE_STATE            45
-#define CMD_MOVE_STATE            50
-#define CMD_SETBASE               55
-#define CMD_INTERNAL              60
-#define CMD_SELFD                 65
-#define CMD_LOAD_UNITS            75
-#define CMD_LOAD_ONTO             76
-#define CMD_UNLOAD_UNITS          80
-#define CMD_UNLOAD_UNIT           81
-#define CMD_ONOFF                 85
-#define CMD_RECLAIM               90
-#define CMD_CLOAK                 95
-#define CMD_STOCKPILE            100
-#define CMD_MANUALFIRE           105
-#define CMD_RESTORE              110
-#define CMD_REPEAT               115
-#define CMD_TRAJECTORY           120
-#define CMD_RESURRECT            125
-#define CMD_CAPTURE              130
-#define CMD_AUTOREPAIRLEVEL      135
-#define CMD_IDLEMODE             145
-#define CMD_FAILED               150
+static constexpr int CMD_STOP                =   0;
+static constexpr int CMD_INSERT              =   1;
+static constexpr int CMD_REMOVE              =   2;
+static constexpr int CMD_WAIT                =   5;
+static constexpr int CMD_TIMEWAIT            =   6;
+static constexpr int CMD_DEATHWAIT           =   7;
+static constexpr int CMD_SQUADWAIT           =   8;
+static constexpr int CMD_GATHERWAIT          =   9;
+static constexpr int CMD_MOVE                =  10;
+static constexpr int CMD_PATROL              =  15;
+static constexpr int CMD_FIGHT               =  16;
+static constexpr int CMD_ATTACK              =  20;
+static constexpr int CMD_AREA_ATTACK         =  21;
+static constexpr int CMD_GUARD               =  25;
+static constexpr int CMD_GROUPSELECT         =  35;
+static constexpr int CMD_GROUPADD            =  36;
+static constexpr int CMD_GROUPCLEAR          =  37;
+static constexpr int CMD_REPAIR              =  40;
+static constexpr int CMD_FIRE_STATE          =  45;
+static constexpr int CMD_MOVE_STATE          =  50;
+static constexpr int CMD_SETBASE             =  55;
+static constexpr int CMD_INTERNAL            =  60;
+static constexpr int CMD_SELFD               =  65;
+static constexpr int CMD_LOAD_UNITS          =  75;
+static constexpr int CMD_LOAD_ONTO           =  76;
+static constexpr int CMD_UNLOAD_UNITS        =  80;
+static constexpr int CMD_UNLOAD_UNIT         =  81;
+static constexpr int CMD_ONOFF               =  85;
+static constexpr int CMD_RECLAIM             =  90;
+static constexpr int CMD_CLOAK               =  95;
+static constexpr int CMD_STOCKPILE           = 100;
+static constexpr int CMD_MANUALFIRE          = 105;
+static constexpr int CMD_RESTORE             = 110;
+static constexpr int CMD_REPEAT              = 115;
+static constexpr int CMD_TRAJECTORY          = 120;
+static constexpr int CMD_RESURRECT           = 125;
+static constexpr int CMD_CAPTURE             = 130;
+static constexpr int CMD_AUTOREPAIRLEVEL     = 135;
+static constexpr int CMD_IDLEMODE            = 145;
+static constexpr int CMD_FAILED              = 150;
 
-#define CMDTYPE_ICON                        0  // expect 0 parameters in return
-#define CMDTYPE_ICON_MODE                   5  // expect 1 parameter in return (number selected mode)
-#define CMDTYPE_ICON_MAP                   10  // expect 3 parameters in return (mappos)
-#define CMDTYPE_ICON_AREA                  11  // expect 4 parameters in return (mappos+radius)
-#define CMDTYPE_ICON_UNIT                  12  // expect 1 parameters in return (unitid)
-#define CMDTYPE_ICON_UNIT_OR_MAP           13  // expect 1 parameters in return (unitid) or 3 parameters in return (mappos)
-#define CMDTYPE_ICON_FRONT                 14  // expect 3 or 6 parameters in return (middle of front and right side of front if a front was defined)
-#define CMDTYPE_ICON_UNIT_OR_AREA          16  // expect 1 parameter in return (unitid) or 4 parameters in return (mappos+radius)
-#define CMDTYPE_NEXT                       17  // used with CMD_INTERNAL
-#define CMDTYPE_PREV                       18  // used with CMD_INTERNAL
-#define CMDTYPE_ICON_UNIT_FEATURE_OR_AREA  19  // expect 1 parameter in return (unitid or featureid+unitHandler.MaxUnits() (id>unitHandler.MaxUnits()=feature)) or 4 parameters in return (mappos+radius)
-#define CMDTYPE_ICON_BUILDING              20  // expect 3 parameters in return (mappos)
-#define CMDTYPE_CUSTOM                     21  // used with CMD_INTERNAL
-#define CMDTYPE_ICON_UNIT_OR_RECTANGLE     22  // expect 1 parameter in return (unitid)
-                                               //     or 3 parameters in return (mappos)
-                                               //     or 6 parameters in return (startpos+endpos)
-#define CMDTYPE_NUMBER                     23  // expect 1 parameter in return (number)
+static constexpr int CMDTYPE_ICON                      =  0;  // expect 0 parameters in return
+static constexpr int CMDTYPE_ICON_MODE                 =  5;  // expect 1 parameter in return (number selected mode)
+static constexpr int CMDTYPE_ICON_MAP                  = 10;  // expect 3 parameters in return (mappos)
+static constexpr int CMDTYPE_ICON_AREA                 = 11;  // expect 4 parameters in return (mappos+radius)
+static constexpr int CMDTYPE_ICON_UNIT                 = 12;  // expect 1 parameters in return (unitid)
+static constexpr int CMDTYPE_ICON_UNIT_OR_MAP          = 13;  // expect 1 parameters in return (unitid) or 3 parameters in return (mappos)
+static constexpr int CMDTYPE_ICON_FRONT                = 14;  // expect 3 or 6 parameters in return (middle of front and right side of front if a front was defined)
+static constexpr int CMDTYPE_ICON_UNIT_OR_AREA         = 16;  // expect 1 parameter in return (unitid) or 4 parameters in return (mappos+radius)
+static constexpr int CMDTYPE_NEXT                      = 17;  // used with CMD_INTERNAL
+static constexpr int CMDTYPE_PREV                      = 18;  // used with CMD_INTERNAL
+static constexpr int CMDTYPE_ICON_UNIT_FEATURE_OR_AREA = 19;  // expect 1 parameter in return (unitid or featureid+unitHandler.MaxUnits() (id>unitHandler.MaxUnits()=feature)) or 4 parameters in return (mappos+radius)
+static constexpr int CMDTYPE_ICON_BUILDING             = 20;  // expect 3 parameters in return (mappos)
+static constexpr int CMDTYPE_CUSTOM                    = 21;  // used with CMD_INTERNAL
+static constexpr int CMDTYPE_ICON_UNIT_OR_RECTANGLE    = 22;  // expect 1 parameter in return (unitid)
+                                                              //     or 3 parameters in return (mappos)
+                                                              //     or 6 parameters in return (startpos+endpos)
+static constexpr int CMDTYPE_NUMBER                    = 23;  // expect 1 parameter in return (number)
 
 
 // wait codes
-#define CMD_WAITCODE_TIMEWAIT    1.0f
-#define CMD_WAITCODE_DEATHWAIT   2.0f
-#define CMD_WAITCODE_SQUADWAIT   3.0f
-#define CMD_WAITCODE_GATHERWAIT  4.0f
+static constexpr float CMD_WAITCODE_TIMEWAIT   = 1.0f;
+static constexpr float CMD_WAITCODE_DEATHWAIT  = 2.0f;
+static constexpr float CMD_WAITCODE_SQUADWAIT  = 3.0f;
+static constexpr float CMD_WAITCODE_GATHERWAIT = 4.0f;
 
 
 // bits for the option field of Command
@@ -88,15 +86,15 @@
 //   be QUEUED_ORDER), ALT_KEY in most contexts means
 //   OVERRIDE_QUEUED_ORDER, etc.
 //
-#define META_KEY        (1 << 2) //   4
-#define INTERNAL_ORDER  (1 << 3) //   8
-#define RIGHT_MOUSE_KEY (1 << 4) //  16
-#define SHIFT_KEY       (1 << 5) //  32
-#define CONTROL_KEY     (1 << 6) //  64
-#define ALT_KEY         (1 << 7) // 128
+static constexpr uint8_t META_KEY        = (1 << 2); //   4
+static constexpr uint8_t INTERNAL_ORDER  = (1 << 3); //   8
+static constexpr uint8_t RIGHT_MOUSE_KEY = (1 << 4); //  16
+static constexpr uint8_t SHIFT_KEY       = (1 << 5); //  32
+static constexpr uint8_t CONTROL_KEY     = (1 << 6); //  64
+static constexpr uint8_t ALT_KEY         = (1 << 7); // 128
 
 // maximum number of inline parameters for any (default and custom) command type
-#define MAX_COMMAND_PARAMS 8
+static constexpr uint32_t MAX_COMMAND_PARAMS = 8;
 
 
 #if defined(BUILDING_AI)

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1097,8 +1097,6 @@ void CCommandAI::GiveWaitCommand(const Command& c)
 
 		inCommand = CMD_STOP;
 		targetDied = false;
-		if (gs->frameNum >= 74000 && owner->id == 25081)
-			LOG("CCommandAI::GiveWaitCommand()");
 
 		commandQue.push_front(c);
 		return;
@@ -1198,8 +1196,6 @@ void CCommandAI::ExecuteInsert(const Command& c, bool fromSynced)
 	if (!queue->empty() && (insertIt == queue->begin())) {
 		inCommand = CMD_STOP;
 		targetDied = false;
-		if (gs->frameNum >= 74000 && owner->id == 25081)
-			LOG("CCommandAI::ExecuteInsert()");
 
 		SetOrderTarget(nullptr);
 		const Command& cmd = queue->front();
@@ -1524,13 +1520,9 @@ void CCommandAI::ExecuteAttack(Command& c)
 			SetOrderTarget(targetUnit);
 			owner->AttackUnit(targetUnit, !c.IsInternalOrder(), c.GetID() == CMD_MANUALFIRE);
 			inCommand = CMD_ATTACK;
-			if (gs->frameNum >= 74000 && owner->id == 25081)
-				LOG("CCommandAI::ExecuteAttack1()");
 		} else {
 			owner->AttackGround(c.GetPos(0), !c.IsInternalOrder(), c.GetID() == CMD_MANUALFIRE);
 			inCommand = CMD_ATTACK;
-			if (gs->frameNum >= 74000 && owner->id == 25081)
-				LOG("CCommandAI::ExecuteAttack2()");
 		}
 	}
 }
@@ -1682,8 +1674,6 @@ void CCommandAI::FinishCommand()
 
 	inCommand = CMD_STOP;
 	targetDied = false;
-	if (gs->frameNum >= 74000 && owner->id == 25081)
-		LOG("CCommandAI::FinishCommand()");
 
 	SetOrderTarget(nullptr);
 	eoh->CommandFinished(*owner, cmd);

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -129,10 +129,9 @@ public:
 	CUnit* orderTarget;
 
 	bool targetDied;
-	bool inCommand;
 	bool repeatOrders;
 	int lastSelectedCommandPage;
-
+	int inCommand;
 protected:
 	bool HandleBuildOptionInsertion(int cmdId);
 	bool HandleBuildOptionRemoval(int cmdId);

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -500,8 +500,6 @@ void CMobileCAI::ExecuteFight(Command& c)
 				c.SetParam(0, newTarget->id);
 
 				inCommand = CMD_STOP;
-				if (gs->frameNum >= 74000 && owner->id == 25081)
-					LOG("CMobileCAI::ExecuteFight1()");
 			}
 		}
 
@@ -560,8 +558,6 @@ void CMobileCAI::ExecuteFight(Command& c)
 
 			inCommand = CMD_STOP;
 			tempOrder = true;
-			if (gs->frameNum >= 74000 && owner->id == 25081)
-				LOG("CMobileCAI::ExecuteFight2()");
 
 			if (lastCommandFrame == gs->frameNum)
 				return;
@@ -897,9 +893,6 @@ void CMobileCAI::ExecuteAttack(Command& c)
 				const float3 tgtErrPos = targetUnit->GetErrorPos(owner->allyteam, false);
 				const float3 tgtPosDir = (tgtErrPos - owner->pos).Normalize();
 
-				if (gs->frameNum == 74737 && owner->id == 25081)
-					LOG("CMobileCAI::ExecuteAttack1()");
-
 				// FIXME: don't call SetGoal() if target is already in range of some weapon?
 				SetGoal(tgtErrPos - tgtPosDir * CalcTargetRadius(targetUnit, targetUnit->radius, 1.0f), owner->pos);
 				SetOrderTarget(targetUnit);
@@ -916,8 +909,6 @@ void CMobileCAI::ExecuteAttack(Command& c)
 				SetGoal(c.GetPos(0), owner->pos);
 
 				inCommand = CMD_ATTACK;
-				if (gs->frameNum >= 74000 && owner->id == 25081)
-					LOG("CMobileCAI::ExecuteAttack2()");
 			} break;
 		}
 	}
@@ -1467,8 +1458,6 @@ void CMobileCAI::ExecuteLoadUnits(Command& c)
 			if (unit != nullptr && owner->CanTransport(unit)) {
 				commandQue.push_front(Command(CMD_LOAD_UNITS, c.GetOpts() | INTERNAL_ORDER, unit->id));
 				inCommand = CMD_STOP;
-				if (gs->frameNum >= 74000 && owner->id == 25081)
-					LOG("CMobileCAI::ExecuteLoadUnits()");
 
 				SlowUpdate();
 				return;


### PR DESCRIPTION
* Fix occasional crash in CBuilderCAI::ExecuteBuildCmd() caused by a dangling other command, the reason for such commands to dangle is unknown for now
* Actually assign commands in CCommandAI::inCommand instead of specifying boolean flag, will help debug the above
* C++ pass on CMD_ and other related constants