### PR TITLE
Create new engine release workflow

### DIFF
--- a/.github/workflows/bar-cdn-publish.yml
+++ b/.github/workflows/bar-cdn-publish.yml
@@ -32,10 +32,10 @@ jobs:
             release_id: context.payload.release?.id ?? context.payload.inputs.releaseId
           });
           const engines = rel.data.assets
-            .filter((a) => a.name.endsWith('64-minimal-portable.7z'))
+            .filter((a) => /amd64-(linux|windows)\.7z$/.test(a.name))
             .map((a) => a.browser_download_url)
             .sort();
-          if (engines.length != 2 || !/linux/.test(engines[0]) || !/windows/.test(engines[1])) {
+          if (engines.length != 2) {
             throw new Error("Not found engine archives!");
           }
 

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -20,9 +20,28 @@ on:
   workflow_dispatch:
     inputs:
       recache:
-        description: "Recache ccache build objects"
+        description: 'Recache ccache build objects'
         type: boolean
         default: false
+      cmake-options:
+        description: 'Custom CMake options for build'
+        type: string
+      split-debug-info:
+        description: 'Split debug info'
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      cmake-options:
+        description: 'Custom CMake options for build'
+        type: string
+      split-debug-info:
+        description: 'Split debug info'
+        type: boolean
+        default: true
+      package-suffix:
+        description: 'Custom suffix for the package name'
+        type: string
   pull_request:
     paths-ignore:
       - 'doc/**'
@@ -142,18 +161,18 @@ jobs:
             bash <<EOF
           set -e
           cd /build/src/docker-build-v2/scripts
-          ./configure.sh
+          ./configure.sh ${{ inputs.cmake-options || '' }}
           ./compile.sh
-          ./split-debug-info.sh
-          ./package.sh
+          ${{ inputs.split-debug-info == false && 'echo "Not splitting debug info."' || './split-debug-info.sh' }}
+          ./package.sh ${{ inputs.package-suffix }}
 
           EOF
-      # TODO: Switch to publickly accessible storage
       - name: Save
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
+        id: save-artifact
         with:
-          name: artifacts-${{ matrix.system }}
+          name: engine-artifacts-${{ matrix.system }}-${{ inputs.package-suffix }}
           path: ./artifacts
           compression-level: 0  # already compressed
       - name: Unmount bazel remote overlay

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -94,8 +94,8 @@ jobs:
           BAZEL_REMOTE_S3_SECRET_ACCESS_KEY: ${{ github.event_name == 'pull_request' && vars.R2_RO_ACCESS_KEY_SECRET || secrets.R2_ACCESS_KEY_SECRET }}
         with:
           run: |
-            if ! sha256sum --status -c <<< "8679a76074b1408a95d2b3ec0f5b1a6d0c20500cfc24c3a87ef08c1b60200f8c tools/bazel-remote"; then
-              curl -L https://github.com/buchgr/bazel-remote/releases/download/v2.4.4/bazel-remote-2.4.4-linux-x86_64 -o bazel-remote
+            if ! sha256sum --status -c <<< "0e3ccc67bced00bc783ee395160092c107a4699e06586a68dcd53fcfa7d8063e tools/bazel-remote"; then
+              curl -L https://github.com/buchgr/bazel-remote/releases/download/v2.5.0/bazel-remote-2.5.0-linux-x86_64 -o bazel-remote
               chmod +x bazel-remote
               mv bazel-remote tools/bazel-remote
             fi
@@ -121,6 +121,7 @@ jobs:
           # of health checking.
           wait-on: |
             http-get://127.0.0.1:8085/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+          wait-for: 3m
       - name: Pull builder image
         run: docker pull ghcr.io/${{ github.repository_owner }}/recoil-build-${{ matrix.system }}:latest
       - name: Build

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,66 @@
+name: Create Engine Release v2
+on:
+  workflow_dispatch:
+    inputs:
+      new-tag:
+        description: 'Set to create a new annotated release tag, e.g. 2025.01.10.'
+        type: string
+jobs:
+  get-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag_name: ${{ steps.release-tag.outputs.tag_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+      - name: Create new annotated tag
+        if: inputs.new-tag != ''
+        env:
+          NEW_TAG: ${{ inputs.new-tag }}
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git tag -a -m "Version $NEW_TAG" "$NEW_TAG"
+          git push origin tag "$NEW_TAG"
+      - name: Get release tag
+        id: release-tag
+        run: |
+          if git describe --exact-match HEAD >/dev/null 2>&1; then
+            echo "tag_name=$(git describe --exact-match HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag_name=spring_bar_{$(git rev-parse --abbrev-ref HEAD)}$(git describe --abbrev=7)" >> "$GITHUB_OUTPUT"
+          fi
+  build-engine:
+    needs: get-tag
+    uses: ./.github/workflows/engine-build.yml
+    with:
+      cmake-options: '-DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3 -g -DNDEBUG" -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O3 -g -DNDEBUG"'
+    secrets: inherit
+  build-engine-tracy:
+    needs: get-tag
+    uses: ./.github/workflows/engine-build.yml
+    with:
+      cmake-options: '-DTRACY_ENABLE=ON -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3 -g1 -DNDEBUG -fno-omit-frame-pointer" -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O3 -g1 -DNDEBUG -fno-omit-frame-pointer"'
+      package-suffix: '-tracy'
+      split-debug-info: false
+    secrets: inherit
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [build-engine, build-engine-tracy, get-tag]
+    steps:
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: engine-artifacts-*
+          merge-multiple: true
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          draft: true
+          tag_name: ${{ needs.get-tag.outputs.tag_name }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -32,7 +32,7 @@ jobs:
           if git describe --exact-match HEAD >/dev/null 2>&1; then
             echo "tag_name=$(git describe --exact-match HEAD)" >> "$GITHUB_OUTPUT"
           else
-            echo "tag_name=spring_bar_{$(git rev-parse --abbrev-ref HEAD)}$(git describe --abbrev=7)" >> "$GITHUB_OUTPUT"
+            echo "tag_name=recoil{$(git rev-parse --abbrev-ref HEAD)}$(git describe --abbrev=7)" >> "$GITHUB_OUTPUT"
           fi
   build-engine:
     needs: get-tag

--- a/docker-build-v2/scripts/package.sh
+++ b/docker-build-v2/scripts/package.sh
@@ -5,10 +5,9 @@ set -e -u -o pipefail
 cd /build/src
 
 package_suffix="${1-}"
-branch="$(git rev-parse --abbrev-ref HEAD)"
-tag_name="spring_bar_{$branch}$(git describe --abbrev=7)"
-bin_name="${tag_name}_${ENGINE_PLATFORM}${package_suffix}-minimal-portable.7z"
-dbg_name="${tag_name}_${ENGINE_PLATFORM}${package_suffix}-minimal-symbols.tar.zst"
+base_name="recoil_$(git describe --abbrev=7)_${ENGINE_PLATFORM}"
+bin_name="${base_name}${package_suffix}.7z"
+dbg_name="${base_name}-dbgsym${package_suffix}.tar.zst"
 
 cd /build/out/install
 

--- a/docker-build-v2/scripts/package.sh
+++ b/docker-build-v2/scripts/package.sh
@@ -19,5 +19,10 @@ rm -f /build/artifacts/$bin_name /build/artifacts/$dbg_name
 
 # Trigger compression of main binaries and debug info concurrently
 7z a -t7z -m0=lzma -mx=9 -mfb=64 -md=32m -ms=on /build/artifacts/$bin_name ./* -xr\!*.dbg &
-tar cvf - $(find ./ -name '*.dbg') | zstd -T0 > /build/artifacts/$dbg_name &
+
+DEBUG_SYMBOLS=$(find ./ -name '*.dbg')
+if [[ -n $DEBUG_SYMBOLS ]]; then
+    tar cvf - $DEBUG_SYMBOLS | zstd -T0 > /build/artifacts/$dbg_name &
+fi
+
 wait


### PR DESCRIPTION
A new release workflow that uses v2 engine build to create new releases.

- Releases contain standard engine build but also Tracy enabled build
- Optionally allow to create a new annotated tag right when triggering release
- Workflow doesn't use other workflow artifacts, but builds from scratch leveraging caching: This is quite useful because now the commit in release is the commit engine was build at, and not e.g. like here: https://github.com/beyond-all-reason/spring/releases/tag/spring_bar_%7Bmaster%7D105.1.1-2701-g8e52d29


There is a change in how release tags and artifacts are named. Best see example output https://github.com/p2004a/spring/releases/tag/recoil%7Bmaster%7D2025.01.2-93-g44d2480.