### PR TITLE
Use `/***` on all lua doc comments

### DIFF
--- a/rts/Lua/LuaFBOs.cpp
+++ b/rts/Lua/LuaFBOs.cpp
@@ -408,7 +408,7 @@ bool LuaFBOs::ApplyDrawBuffers(lua_State* L, int index)
 /******************************************************************************/
 /******************************************************************************/
 
-/**
+/***
  * @table gl
  */
 
@@ -638,7 +638,7 @@ int LuaFBOs::ActiveFBO(lua_State* L)
 }
 
 
-/**
+/***
  * Bind default or specified via rawFboId numeric id of FBO
  * 
  * @function gl.RawBindFBO
@@ -647,7 +647,7 @@ int LuaFBOs::ActiveFBO(lua_State* L)
  * @param rawFboId integer? (Default: 0)
  * @return nil
  */
-/**
+/***
  * @function gl.RawBindFBO
  * @param fbo Fbo
  * @param target GL? (Default: `fbo.target`)

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -1287,7 +1287,7 @@ int LuaOpenGL::EndText(lua_State* L)
 	return 0;
 }
 
-/**
+/***
  * @table gl
  */
 

--- a/rts/Lua/LuaRBOs.cpp
+++ b/rts/Lua/LuaRBOs.cpp
@@ -147,7 +147,7 @@ int LuaRBOs::meta_newindex(lua_State* L)
  * @field samples integer will return globalRendering->msaaLevel for multisampled RBO or 0 otherwise
  */
 
-/**
+/***
  * @class CreateRBOData
  * @field target GL
  * @field format GL

--- a/rts/Lua/LuaShaders.cpp
+++ b/rts/Lua/LuaShaders.cpp
@@ -549,7 +549,7 @@ GLint LuaShaders::GetUniformLocation(LuaShaders::Program* p, const char* name)
 	return iter->second.location;
 }
 
-/**
+/***
  * A table of uniform name to value.
  * 
  * The Uniforms are the values you send along with the shader-program. To use

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -962,7 +962,7 @@ int LuaSyncedRead::GetWind(lua_State* L)
  * The advantage of it is that it can be read from anywhere (even from LuaUI and AIs!)
 ******************************************************************************/
 
-/**
+/***
  * @class RulesParams : table<string, integer>
  */
 
@@ -4258,7 +4258,7 @@ int LuaSyncedRead::GetUnitCosts(lua_State* L)
 	return 3;
 }
 
-/**
+/***
  * @class ResourceCost
  * @field metal number
  * @field energy number
@@ -6160,7 +6160,7 @@ int LuaSyncedRead::GetUnitCurrentCommand(lua_State* L)
  * @param count integer Number of commands to return, `-1` returns all commands, `0` returns command count.
  * @return Command[] commands
  */
-/**
+/***
  * Get the count of commands for a unit.
  *
  * @function Spring.GetUnitCommands
@@ -6387,7 +6387,7 @@ int LuaSyncedRead::GetFactoryCounts(lua_State* L)
  * @param count integer Number of commands to return, `-1` returns all commands, `0` returns command count.
  * @return Command[] commands
  */
-/**
+/***
  * Get the count of commands for a unit.
  *
  * @function Spring.GetCommandQueue

--- a/rts/Lua/LuaTracyExtra.cpp
+++ b/rts/Lua/LuaTracyExtra.cpp
@@ -29,7 +29,7 @@ static const std::string& GetImmanentPlotName(const char *plotName)
 	return *tracyLuaPlots.emplace(plotName).first;
 }
 
-/**
+/***
  * Tracy extensions
  * @table tracy
  */

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -2790,7 +2790,7 @@ int LuaUnsyncedRead::GetCameraFOV(lua_State* L)
 	return 2;
 }
 
-/**
+/***
  * @class CameraVectors
  * @field forward xyz
  * @field up xyz

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -1156,7 +1156,7 @@ void LuaUtils::ParseCommandArray(
 	}
 }
 
-/**
+/***
  * @alias Facing
  * | 0 # South
  * | 1 # East

--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -456,7 +456,7 @@ bool LuaVBOImpl::DefineElementArray(const sol::optional<sol::object> attribDefAr
 	return true;
 }
 
-/**
+/***
  * @alias VBODataType
  * | GL.BYTE
  * | GL.UNSIGNED_BYTE
@@ -467,7 +467,7 @@ bool LuaVBOImpl::DefineElementArray(const sol::optional<sol::object> attribDefAr
  * | GL.FLOAT
  */
 
-/**
+/***
  * @class VBOAttributeDef
  * 
  * @field id integer


### PR DESCRIPTION
Restoring this convention as a rule in https://github.com/rhys-vdw/lua-doc-extractor/issues/21. Missed a few in my original doc update.