### PR TITLE
Docker Build V2 Windows Guide + V1 Disclaimer

### DIFF
--- a/docker-build-v2/README.md
+++ b/docker-build-v2/README.md
@@ -74,7 +74,7 @@ If you're using VSCode as your IDE you can use [Remote Development Extension](ht
 
 #### Smaller QoL Tips - Windows
 - Symbolic Links can replace Remote Development, use them to make edits on your regular Windows OS with whatever IDE you like and sync up with WSL's folder
-- They are also useful for quick debugging, link up your `WSL/Ubuntu/{Spring-Repo-Folder}/build-windows/install` with your `{BAR-Game-Folder}/data/engine/{Local-Engine-Folder-Name}` this way you can quickly run `bash build windows` on WSL and it will appear magically and ready to use in your BAR Folder
+- They are also useful for quick debugging, link up your `WSL/Ubuntu/{Spring-Repo-Folder}/build-windows/install` with your `{BAR-Game-Folder}/data/engine/{Local-Engine-Folder-Name}` this way you can quickly run `bash build windows` on WSL and it will appear and ready to use in your BAR Folder
 - To use Symbolic Links, you can do so with `mklink` command in Terminal. However, it is highly recommended to use [Link Shell Extension (LSE)](https://schinagl.priv.at/nt/hardlinkshellext/linkshellextension.html) just make sure to make a [Restore Point](https://support.microsoft.com/en-us/windows/system-restore-a5ae3ed9-07c4-fd56-45ee-096777ecd14e#:~:text=Apply%20a%20restore%20point%20from,%E2%80%8B%E2%80%8B%E2%80%8B%E2%80%8B%E2%80%8B) just in case
 
 
@@ -104,3 +104,6 @@ To sum up, there is a separation:
   - `script/split-debug-info.sh`: Splits debug information from binaries
   - `script/package.sh`: Creates 2 archives, one with engine and one with
      debug symbols.
+
+
+For details on private testing, check the wiki [here](https://github.com/beyond-all-reason/spring/wiki/Pre-release-testing-Checklist,-and-release-engine-checklist#private-testing)

--- a/docker-build-v2/README.md
+++ b/docker-build-v2/README.md
@@ -1,9 +1,9 @@
-# Engine Docker Build v2
+# Docker Engine Build v2
 
 This directory contains work in progress next version of the Docker engine
-build scripts.
+build scripts. **If you're on Windows check the [specified section](README.md#windows-specific-guide---step-1-on-windows) first**
 
-## Local usage
+## Local usage - Step 2 on Windows
 
 To execute build locally use `build.sh` script
 
@@ -60,6 +60,23 @@ docker build -t recoil-build-amd64-windows docker-build-v2/amd64-windows
 ```
 
 and `build.sh` will use it.
+
+## Windows Specific Guide - Step 1 on Windows
+`build.sh` depends on the Docker engine, not the Docker desktop. So, to get started, there are a few steps first.
+
+### Using WSL - Ubuntu
+1. Head to Microsoft Store and install Ubuntu
+2. Follow the [Docker Engine guide](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) to install it
+3. Now you can follow Local Usage to build as normal
+
+#### VS Code Extension
+If you're using VSCode as your IDE you can use [Remote Development Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
+
+#### Smaller QoL Tips - Windows
+- Symbolic Links can replace Remote Development, use them to make edits on your regular Windows OS with whatever IDE you like and sync up with WSL's folder
+- They are also useful for quick debugging, link up your `WSL/Ubuntu/{Spring-Repo-Folder}/build-windows/install` with your `{BAR-Game-Folder}/data/engine/{Local-Engine-Folder-Name}` this way you can quickly run `bash build windows` on WSL and it will appear magically and ready to use in your BAR Folder
+- To use Symbolic Links, you can do so with `mklink` command in Terminal. However, it is highly recommended to use [Link Shell Extension (LSE)](https://schinagl.priv.at/nt/hardlinkshellext/linkshellextension.html) just make sure to make a [Restore Point](https://support.microsoft.com/en-us/windows/system-restore-a5ae3ed9-07c4-fd56-45ee-096777ecd14e#:~:text=Apply%20a%20restore%20point%20from,%E2%80%8B%E2%80%8B%E2%80%8B%E2%80%8B%E2%80%8B) just in case
+
 
 ## Overview
 

--- a/docker-build-v2/README.md
+++ b/docker-build-v2/README.md
@@ -1,7 +1,10 @@
-# Docker Engine Build v2
+# Engine Docker Build v2
 
 This directory contains work in progress next version of the Docker engine
-build scripts. **If you're on Windows check the [specified section](README.md#windows-specific-guide---step-1-on-windows) first**
+build scripts.
+
+> [!WARNING]  
+> Currently the build script supports **only** Docker *Engine*! Docker Desktop, Podman etc. won't work correctly with the build script. Under Windows it requires usage of WSL, see [section below](#windows-instructions) for step-by-step Windows instructions. 
 
 ## Local usage - Step 2 on Windows
 
@@ -61,21 +64,7 @@ docker build -t recoil-build-amd64-windows docker-build-v2/amd64-windows
 
 and `build.sh` will use it.
 
-## Windows Specific Guide - Step 1 on Windows
-`build.sh` depends on the Docker engine, not the Docker desktop. So, to get started, there are a few steps first.
-
-### Using WSL - Ubuntu
-1. Head to Microsoft Store and install Ubuntu
-2. Follow the [Docker Engine guide](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) to install it
-3. Now you can follow Local Usage to build as normal
-
-#### VS Code Extension
-If you're using VSCode as your IDE you can use [Remote Development Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
-
-#### Smaller QoL Tips - Windows
-- Symbolic Links can replace Remote Development, use them to make edits on your regular Windows OS with whatever IDE you like and sync up with WSL's folder
-- They are also useful for quick debugging, link up your `WSL/Ubuntu/{Spring-Repo-Folder}/build-windows/install` with your `{BAR-Game-Folder}/data/engine/{Local-Engine-Folder-Name}` this way you can quickly run `bash build windows` on WSL and it will appear and ready to use in your BAR Folder
-- To use Symbolic Links, you can do so with `mklink` command in Terminal. However, it is highly recommended to use [Link Shell Extension (LSE)](https://schinagl.priv.at/nt/hardlinkshellext/linkshellextension.html) just make sure to make a [Restore Point](https://support.microsoft.com/en-us/windows/system-restore-a5ae3ed9-07c4-fd56-45ee-096777ecd14e#:~:text=Apply%20a%20restore%20point%20from,%E2%80%8B%E2%80%8B%E2%80%8B%E2%80%8B%E2%80%8B) just in case
+For details on private testing, check the wiki [here](https://github.com/beyond-all-reason/spring/wiki/Pre-release-testing-Checklist,-and-release-engine-checklist#private-testing)
 
 
 ## Overview
@@ -106,4 +95,26 @@ To sum up, there is a separation:
      debug symbols.
 
 
-For details on private testing, check the wiki [here](https://github.com/beyond-all-reason/spring/wiki/Pre-release-testing-Checklist,-and-release-engine-checklist#private-testing)
+
+## Windows Instructions
+`build.sh` depends on the Docker engine, not the Docker desktop. So, to get started, there are a few steps first.
+
+### Using WSL - Ubuntu
+1. Head to Microsoft Store and install Ubuntu
+2. Follow the [Docker Engine guide](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) to install it
+3. Now you can follow Local Usage to build as normal
+
+#### Smaller QoL Tips - Windows
+- If you're using VSCode as your IDE you can use [Remote Development Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
+  
+- Symbolic Links can replace Remote Development, use them to make edits on your regular Windows OS with whatever IDE you like and sync up with WSL's folder
+  
+- They are also useful for quick debugging, link up your `WSL/Ubuntu/{Spring-Repo-Folder}/build-windows/install` with your `{BAR-Game-Folder}/data/engine/{Local-Engine-Folder-Name}` this way you can quickly run `docker-build-v2/build.sh windows` on WSL and it will appear and ready to use in your BAR Folder
+
+- To use Symbolic Links, you can do so with `mklink` command in Terminal, like so:
+
+  ```shell
+  mklink /d path-to-sym-link-folder path-to-origin-folder
+  ```
+
+- Third-Party app for Symbolic Links: [Link Shell Extension (LSE)](https://schinagl.priv.at/nt/hardlinkshellext/linkshellextension.html) just make sure to make a [Restore Point](https://support.microsoft.com/en-us/windows/system-restore-a5ae3ed9-07c4-fd56-45ee-096777ecd14e#:~:text=Apply%20a%20restore%20point%20from,%E2%80%8B%E2%80%8B%E2%80%8B%E2%80%8B%E2%80%8B) just in case

--- a/docker-build/README.md
+++ b/docker-build/README.md
@@ -9,3 +9,6 @@ List of available building flags can be printed with `build.sh -h`.
 By default Windows builds are produced. To make a Linux build use `-p linux-64` flag.
 
 `-o` can be used to speed up compilation by disabling headless and dedicated builds.
+
+## Disclaimer
+this is out of date, consider using [Docker V2](https://github.com/beyond-all-reason/spring/tree/master/docker-build-v2)

--- a/docker-build/README.md
+++ b/docker-build/README.md
@@ -10,5 +10,5 @@ By default Windows builds are produced. To make a Linux build use `-p linux-64` 
 
 `-o` can be used to speed up compilation by disabling headless and dedicated builds.
 
-## Disclaimer
-this is out of date, consider using [Docker V2](https://github.com/beyond-all-reason/spring/tree/master/docker-build-v2)
+### Version 2 - WIP
+[Docker V2](https://github.com/beyond-all-reason/spring/tree/master/docker-build-v2)


### PR DESCRIPTION
- Adds Disclaimer for V1 to mention being dated and pointing to V2
- Adds a Section to guide Windows users to start building the engine with V2