### PR TITLE
Rhys vdw/fix irregular whitespace

### DIFF
--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -611,7 +611,7 @@ int LuaUnsyncedCtrl::SendMessage(lua_State* L)
 
 
 /*** @function Spring.SendMessageToSpectators
- * @param message string `<PLAYER#>` (with # being a playerid) inside the string will be replaced with the players name - i.e. : Spring.SendMessage ("`<PLAYER1>` did something") might display as "ProRusher did something"
+ * @param message string `<PLAYER#>` (with # being a playerid) inside the string will be replaced with the players name - i.e. : Spring.SendMessage ("`<PLAYER1>` did something") might display as "ProRusher did something"
  * @return nil
  */
 int LuaUnsyncedCtrl::SendMessageToSpectators(lua_State* L)

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -611,7 +611,13 @@ int LuaUnsyncedCtrl::SendMessage(lua_State* L)
 
 
 /*** @function Spring.SendMessageToSpectators
- * @param message string `<PLAYER#>` (with # being a playerid) inside the string will be replaced with the players name - i.e. : Spring.SendMessage ("`<PLAYER1>` did something") might display as "ProRusher did something"
+ * @param message string ``"`<PLAYER#>`"`` where `#` is a player ID.
+ * 
+ * This will be replaced with the player's name. e.g.
+ * ```lua
+ * Spring.SendMessage("`<PLAYER1>` did something") -- "ProRusher did something"
+ * ```
+ * 
  * @return nil
  */
 int LuaUnsyncedCtrl::SendMessageToSpectators(lua_State* L)


### PR DESCRIPTION
Changes:
- Removed an instance of the `NO-BREAK SPACE` character.
- Tidied up the `SendMessageToSpectators` docs using proper markdown.

NOTE: I also searched the entire codebase for other instances of that character. This is the only one I found in code files.