### PR TITLE
Improve Lua docs for enums and fields.

### DIFF
--- a/.github/workflows/generate-lua-library.yml
+++ b/.github/workflows/generate-lua-library.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Generate Lua library
         working-directory: recoil
         run: |
-          npm install -g lua-doc-extractor@2
+          npm install -g lua-doc-extractor@3
           lua-doc-extractor rts/Lua/*.cpp \
             --dest rts/Lua/library/generated \
             --repo https://github.com/${{ github.repository }}/blob/${{ github.sha }}

--- a/.github/workflows/generate-lua-library.yml
+++ b/.github/workflows/generate-lua-library.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Generate Lua library
         working-directory: recoil
         run: |
-          npm install -g lua-doc-extractor@1
+          npm install -g lua-doc-extractor@2
           lua-doc-extractor rts/Lua/*.cpp \
             --dest rts/Lua/library/generated \
             --repo https://github.com/${{ github.repository }}/blob/${{ github.sha }}

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -24,7 +24,7 @@ jobs:
       # NOTE: This step is duplicated in `generate-lua-library.yml`
       - name: Generate Lua library
         run: |
-          npm install -g lua-doc-extractor@2
+          npm install -g lua-doc-extractor@3
           lua-doc-extractor rts/Lua/*.cpp \
             --dest rts/Lua/library/generated \
             --repo https://github.com/${{ github.repository }}/blob/${{ github.sha }}

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -28,6 +28,12 @@ jobs:
           lua-doc-extractor rts/Lua/*.cpp \
             --dest rts/Lua/library/generated \
             --repo https://github.com/${{ github.repository }}/blob/${{ github.sha }}
+      # Upload the Lua library artifact for debugging.
+      - name: Upload Lua Library artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{github.run_id}}-library
+          path: rts/Lua/library/
       - name: Install emmylua_doc_cli
         run: |
           cargo install emmylua_doc_cli

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -24,7 +24,7 @@ jobs:
       # NOTE: This step is duplicated in `generate-lua-library.yml`
       - name: Generate Lua library
         run: |
-          npm install -g lua-doc-extractor@1
+          npm install -g lua-doc-extractor@2
           lua-doc-extractor rts/Lua/*.cpp \
             --dest rts/Lua/library/generated \
             --repo https://github.com/${{ github.repository }}/blob/${{ github.sha }}

--- a/doc/emmlua-doc-cli-template/lua_enum_template.tl
+++ b/doc/emmlua-doc-cli-template/lua_enum_template.tl
@@ -15,10 +15,14 @@ permalink: lua-api/types/{{ type_name }}
 {{ description }}
 {% endif %}
 
-```cpp
-enum {{ type_name }} {
-    {% for field in fields -%}
-        {{ field.name }} = {{ field.value }}, {{ field.description }}
-    {% endfor %}
-}
+{% for field in fields -%}
+
+### {{ field.name }}
+
+```lua
+{{ type_name }}.{{ field.name }} = {{ field.value }}
 ```
+
+{{ field.description }}
+
+{% endfor %}

--- a/doc/emmlua-doc-cli-template/lua_global_template.tl
+++ b/doc/emmlua-doc-cli-template/lua_global_template.tl
@@ -10,13 +10,13 @@ permalink: lua-api/globals/{{ global_name }}
 {% if description %}
 {{ description }}
 {% endif %}
----
+
 {% if methods %}
 ## methods
----
+
 {% for method in methods %}
 ### {{ method.name }}
----
+
 {{ method.display }}
 
 {% if method.description %}
@@ -27,10 +27,10 @@ permalink: lua-api/globals/{{ global_name }}
 
 {% if fields %}
 ## fields
----
+
 {% for field in fields %}
 ### {{ field.name }}
----
+
 {{ field.display }}
 
 {% if field.description %}

--- a/doc/emmlua-doc-cli-template/lua_global_template_simple.tl
+++ b/doc/emmlua-doc-cli-template/lua_global_template_simple.tl
@@ -7,7 +7,6 @@ permalink: lua-api/globals/{{ global_name }}
 
 # global {{ global_name }}
 
----
 {% if display %}
 {{ display }}
 {% endif %}

--- a/doc/emmlua-doc-cli-template/lua_module_template.tl
+++ b/doc/emmlua-doc-cli-template/lua_module_template.tl
@@ -10,13 +10,13 @@ permalink: lua-api/modules/{{ module_name }}
 {% if description %}
 {{ description }}
 {% endif %}
----
+
 {% if methods %}
 ## methods
----
+
 {% for method in methods %}
 ### {{ method.name }}
----
+
 {{ method.display }}
 
 {% if method.description %}
@@ -27,10 +27,10 @@ permalink: lua-api/modules/{{ module_name }}
 
 {% if fields %}
 ## fields
----
+
 {% for field in fields %}
 ### {{ field.name }}
----
+
 {{ field.display }}
 
 {% if field.description %}

--- a/doc/emmlua-doc-cli-template/lua_type_template.tl
+++ b/doc/emmlua-doc-cli-template/lua_type_template.tl
@@ -17,13 +17,13 @@ permalink: lua-api/types/{{ type_name }}
 {% if description %}
 {{ description }}
 {% endif %}
----
+
 {% if methods %}
 ## methods
----
+
 {% for method in methods %}
 ### {{ method.name }}
----
+
 {{ method.display }}
 
 {% if method.description %}
@@ -34,10 +34,10 @@ permalink: lua-api/types/{{ type_name }}
 
 {% if fields %}
 ## fields
----
+
 {% for field in fields %}
 ### {{ field.name }}
----
+
 {{ field.display }}
 
 {% if field.description %}

--- a/doc/site/README.md
+++ b/doc/site/README.md
@@ -20,6 +20,7 @@ Navigate to http://localhost:4000/spring
 Have [emmylua_doc_cli](https://github.com/CppCXY/emmylua-analyzer-rust/tree/main/crates/emmylua_doc_cli) and [lua-doc-extractor](https://github.com/rhys-vdw/lua-doc-extractor) installed and available in `$PATH`.
 
 ```bash
+rm -rf rts/Lua/library/generated &&
 lua-doc-extractor rts/Lua/*.cpp --dest rts/Lua/library/generated &&
   emmylua_doc_cli \
     -i rts/Lua/library/ \

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -9,149 +9,139 @@
 #include "Sim/Units/CommandAI/Command.h"
 
 
-/******************************************************************************
- * Command constants
- * @see rts/Lua/LuaConstCMD.cpp
-******************************************************************************/
-
 /***
+ * Command constants.
  * @enum CMD
- * @field FIRESTATE_NONE -1
- * @field MOVESTATE_NONE -1
- * @field STOP 0
- * @field MOVESTATE_HOLDPOS 0
- * @field FIRESTATE_HOLDFIRE 0
- * @field INSERT 1
- * @field MOVESTATE_MANEUVER 1
- * @field FIRESTATE_RETURNFIRE 1
- * @field WAITCODE_TIME 1
- * @field WAITCODE_DEATH 2
- * @field MOVESTATE_ROAM 2
- * @field REMOVE 2
- * @field FIRESTATE_FIREATWILL 2
- * @field FIRESTATE_FIREATNEUTRAL 3
- * @field WAITCODE_SQUAD 3
- * @field OPT_META 4
- * @field WAITCODE_GATHER 4
- * @field WAIT 5
- * @field TIMEWAIT 6
- * @field DEATHWAIT 7
- * @field OPT_INTERNAL 8
- * @field SQUADWAIT 8
- * @field GATHERWAIT 9
- * @field MOVE 10
- * @field PATROL 15
- * @field FIGHT 16
- * @field OPT_RIGHT 16
- * @field LOOPBACKATTACK 20
- * @field ATTACK 20
- * @field AREA_ATTACK 21
- * @field GUARD 25
- * @field OPT_SHIFT 32
- * @field GROUPSELECT 35
- * @field GROUPADD 36
- * @field GROUPCLEAR 37
- * @field REPAIR 40
- * @field FIRE_STATE 45
- * @field MOVE_STATE 50
- * @field SETBASE 55
- * @field INTERNAL 60
- * @field OPT_CTRL 64
- * @field SELFD 65
- * @field SET_WANTED_MAX_SPEED 70
- * @field LOAD_UNITS 75
- * @field LOAD_ONTO 76
- * @field UNLOAD_UNITS 80
- * @field UNLOAD_UNIT 81
- * @field ONOFF 85
- * @field RECLAIM 90
- * @field CLOAK 95
- * @field STOCKPILE 100
- * @field MANUALFIRE 105
- * @field DGUN 105
- * @field RESTORE 110
- * @field REPEAT 115
- * @field TRAJECTORY 120
- * @field RESURRECT 125
- * @field OPT_ALT 128
- * @field CAPTURE 130
- * @field AUTOREPAIRLEVEL 135
- * @field IDLEMODE 145 
  */
-
 
 bool LuaConstCMD::PushEntries(lua_State* L)
 {
+	/*** @field CMD.OPT_ALT 128 */
 	LuaPushNamedNumber(L, "OPT_ALT",      ALT_KEY);
+	/*** @field CMD.OPT_CTRL 64 */
 	LuaPushNamedNumber(L, "OPT_CTRL",     CONTROL_KEY);
+	/*** @field CMD.OPT_SHIFT 32 */
 	LuaPushNamedNumber(L, "OPT_SHIFT",    SHIFT_KEY);
+	/*** @field CMD.OPT_RIGHT 16 */
 	LuaPushNamedNumber(L, "OPT_RIGHT",    RIGHT_MOUSE_KEY);
+	/*** @field CMD.OPT_INTERNAL 8 */
 	LuaPushNamedNumber(L, "OPT_INTERNAL", INTERNAL_ORDER);
+	/*** @field CMD.OPT_META 4 */
 	LuaPushNamedNumber(L, "OPT_META",     META_KEY);
 
+	/*** @field CMD.MOVESTATE_NONE -1 */
 	LuaPushNamedNumber(L, "MOVESTATE_NONE"    , MOVESTATE_NONE    );
+	/*** @field CMD.MOVESTATE_HOLDPOS 0 */
 	LuaPushNamedNumber(L, "MOVESTATE_HOLDPOS" , MOVESTATE_HOLDPOS );
+	/*** @field CMD.MOVESTATE_MANEUVER 1 */
 	LuaPushNamedNumber(L, "MOVESTATE_MANEUVER", MOVESTATE_MANEUVER);
+	/*** @field CMD.MOVESTATE_ROAM 2 */
 	LuaPushNamedNumber(L, "MOVESTATE_ROAM"    , MOVESTATE_ROAM    );
 
+	/*** @field CMD.FIRESTATE_NONE -1 */
 	LuaPushNamedNumber(L, "FIRESTATE_NONE"         , FIRESTATE_NONE         );
+	/*** @field CMD.FIRESTATE_HOLDFIRE 0 */
 	LuaPushNamedNumber(L, "FIRESTATE_HOLDFIRE"     , FIRESTATE_HOLDFIRE     );
+	/*** @field CMD.FIRESTATE_RETURNFIRE 1 */
 	LuaPushNamedNumber(L, "FIRESTATE_RETURNFIRE"   , FIRESTATE_RETURNFIRE   );
+	/*** @field CMD.FIRESTATE_FIREATWILL 2 */
 	LuaPushNamedNumber(L, "FIRESTATE_FIREATWILL"   , FIRESTATE_FIREATWILL   );
+	/*** @field CMD.FIRESTATE_FIREATNEUTRAL 3 */
 	LuaPushNamedNumber(L, "FIRESTATE_FIREATNEUTRAL", FIRESTATE_FIREATNEUTRAL);
 
+	/*** @field CMD.WAITCODE_TIME 1 */
 	LuaPushNamedNumber(L, "WAITCODE_TIME",   CMD_WAITCODE_TIMEWAIT);
+	/*** @field CMD.WAITCODE_DEATH 2 */
 	LuaPushNamedNumber(L, "WAITCODE_DEATH",  CMD_WAITCODE_DEATHWAIT);
+	/*** @field CMD.WAITCODE_SQUAD 3 */
 	LuaPushNamedNumber(L, "WAITCODE_SQUAD",  CMD_WAITCODE_SQUADWAIT);
+	/*** @field CMD.WAITCODE_GATHER 4 */
 	LuaPushNamedNumber(L, "WAITCODE_GATHER", CMD_WAITCODE_GATHERWAIT);
 
 #define PUSH_CMD(cmd) LuaInsertDualMapPair(L, #cmd, CMD_ ## cmd);
 
+	/*** @field CMD.STOP 0 */
 	PUSH_CMD(STOP);
+	/*** @field CMD.INSERT 1 */
 	PUSH_CMD(INSERT);
+	/*** @field CMD.REMOVE 2 */
 	PUSH_CMD(REMOVE);
+	/*** @field CMD.WAIT 5 */
 	PUSH_CMD(WAIT);
+	/*** @field CMD.TIMEWAIT 6 */
 	PUSH_CMD(TIMEWAIT);
+	/*** @field CMD.DEATHWAIT 7 */
 	PUSH_CMD(DEATHWAIT);
+	/*** @field CMD.SQUADWAIT 8 */
 	PUSH_CMD(SQUADWAIT);
+	/*** @field CMD.GATHERWAIT 9 */
 	PUSH_CMD(GATHERWAIT);
+	/*** @field CMD.MOVE 10 */
 	PUSH_CMD(MOVE);
+	/*** @field CMD.PATROL 15 */
 	PUSH_CMD(PATROL);
+	/*** @field CMD.FIGHT 16 */
 	PUSH_CMD(FIGHT);
+	/*** @field CMD.ATTACK 20 */
 	PUSH_CMD(ATTACK);
+	/*** @field CMD.AREA_ATTACK 21 */
 	PUSH_CMD(AREA_ATTACK);
+	/*** @field CMD.GUARD 25 */
 	PUSH_CMD(GUARD);
+	/*** @field CMD.GROUPSELECT 35 */
 	PUSH_CMD(GROUPSELECT);
+	/*** @field CMD.GROUPADD 36 */
 	PUSH_CMD(GROUPADD);
+	/*** @field CMD.GROUPCLEAR 37 */
 	PUSH_CMD(GROUPCLEAR);
+	/*** @field CMD.REPAIR 40 */
 	PUSH_CMD(REPAIR);
+	/*** @field CMD.FIRE_STATE 45 */
 	PUSH_CMD(FIRE_STATE);
+	/*** @field CMD.MOVE_STATE 50 */
 	PUSH_CMD(MOVE_STATE);
+	/*** @field CMD.SETBASE 55 */
 	PUSH_CMD(SETBASE);
+	/*** @field CMD.INTERNAL 60 */
 	PUSH_CMD(INTERNAL);
+	/*** @field CMD.SELFD 65 */
 	PUSH_CMD(SELFD);
+	/*** @field CMD.LOAD_UNITS 75 */
 	PUSH_CMD(LOAD_UNITS);
+	/*** @field CMD.LOAD_ONTO 76 */
 	PUSH_CMD(LOAD_ONTO);
+	/*** @field CMD.UNLOAD_UNITS 80 */
 	PUSH_CMD(UNLOAD_UNITS);
+	/*** @field CMD.UNLOAD_UNIT 81 */
 	PUSH_CMD(UNLOAD_UNIT);
+	/*** @field CMD.ONOFF 85 */
 	PUSH_CMD(ONOFF);
+	/*** @field CMD.RECLAIM 90 */
 	PUSH_CMD(RECLAIM);
+	/*** @field CMD.CLOAK 95 */
 	PUSH_CMD(CLOAK);
+	/*** @field CMD.STOCKPILE 100 */
 	PUSH_CMD(STOCKPILE);
+	/*** @field CMD.MANUALFIRE 105 */
 	PUSH_CMD(MANUALFIRE);
+	/*** @field CMD.DGUN 105 */
 	LuaInsertDualMapPair(L, "DGUN", CMD_MANUALFIRE); // backward compatibility (TODO: find a way to print a warning when used!)
+	/*** @field CMD.RESTORE 110 */
 	PUSH_CMD(RESTORE);
+	/*** @field CMD.REPEAT 115 */
 	PUSH_CMD(REPEAT);
+	/*** @field CMD.TRAJECTORY 120 */
 	PUSH_CMD(TRAJECTORY);
+	/*** @field CMD.RESURRECT 125 */
 	PUSH_CMD(RESURRECT);
+	/*** @field CMD.CAPTURE 130 */
 	PUSH_CMD(CAPTURE);
+	/*** @field CMD.AUTOREPAIRLEVEL 135 */
 	PUSH_CMD(AUTOREPAIRLEVEL);
+	/*** @field CMD.LOOPBACKATTACK 20 */
 	LuaInsertDualMapPair(L, "LOOPBACKATTACK", CMD_ATTACK); // backward compatibility (TODO: find a way to print a warning when used!)
+	/*** @field CMD.IDLEMODE 145  */
 	PUSH_CMD(IDLEMODE);
 
 	return true;
 }
-
-
-/******************************************************************************/
-/******************************************************************************/

--- a/rts/Lua/LuaConstCMDTYPE.cpp
+++ b/rts/Lua/LuaConstCMDTYPE.cpp
@@ -8,56 +8,47 @@
 #include "LuaUtils.h"
 #include "Sim/Units/CommandAI/Command.h"
 
-
-/******************************************************************************
+/*** 
  * Command type constants
- * @see rts/Lua/LuaConstCMDTYPE.cpp
-******************************************************************************/
-
-/*** Note, the CMDTYPE[] table is bidirectional. That means: CMDTYPE[CMDTYPE.ICON] := "CMDTYPE_ICON"
- *
+ * 
+ * Note, the `CMDTYPE[]` table is bidirectional. That means: `CMDTYPE[CMDTYPE.ICON] := "CMDTYPE_ICON"`
+ * 
  * @enum CMDTYPE
- * @field ICON number expect 0 parameters in return
- * @field ICON_MODE number expect 1 parameter in return (number selected mode)
- * @field ICON_MAP number expect 3 parameters in return (mappos)
- * @field ICON_AREA number expect 4 parameters in return (mappos+radius)
- * @field ICON_UNIT number expect 1 parameters in return (unitid)
- * @field ICON_UNIT_OR_MAP number expect 1 parameters in return (unitid) or 3 parameters in return (mappos)
- * @field ICON_FRONT number expect 3 or 6 parameters in return (middle and right side of front if a front was defined)
- * @field COMBO_BOX number expect 1 parameter in return (number selected option)
- * @field ICON_UNIT_OR_AREA number expect 1 parameter in return (unitid) or 4 parameters in return (mappos+radius)
- * @field ICON_UNIT_FEATURE_OR_AREA number expect 1 parameter in return (unitid or Game.maxUnits+featureid) or 4 parameters in return (mappos+radius)
- * @field ICON_BUILDING number expect 3 parameters in return (mappos)
- * @field ICON_UNIT_OR_RECTANGLE number expect 1 parameter in return (unitid) or 3 parameters in return (mappos) or 6 parameters in return (startpos+endpos)
- * @field NUMBER number expect 1 parameter in return (number)
- * @field CUSTOM number used with CMD_INTERNAL
- * @field NEXT number next command page used with CMD_INTERNAL
- * @field PREV number previous command page used with CMD_INTERNAL
  */
 
 bool LuaConstCMDTYPE::PushEntries(lua_State* L)
 {
 #define PUSH_CMDTYPE(cmd) LuaInsertDualMapPair(L, #cmd, CMDTYPE_ ## cmd)
-
+	/*** @field CMDTYPE.ICON integer Expect 0 parameters in return. */
 	PUSH_CMDTYPE(ICON);
+	/*** @field CMDTYPE.ICON_MODE integer Expect 1 parameter in return (number selected mode). */
 	PUSH_CMDTYPE(ICON_MODE);
+	/*** @field CMDTYPE.ICON_MAP integer Expect 3 parameters in return (mappos). */
 	PUSH_CMDTYPE(ICON_MAP);
+	/*** @field CMDTYPE.ICON_AREA integer Expect 4 parameters in return (mappos+radius). */
 	PUSH_CMDTYPE(ICON_AREA);
+	/*** @field CMDTYPE.ICON_UNIT integer Expect 1 parameters in return (unitid). */
 	PUSH_CMDTYPE(ICON_UNIT);
+	/*** @field CMDTYPE.ICON_UNIT_OR_MAP integer Expect 1 parameters in return (unitid) or 3 parameters in return (mappos). */
 	PUSH_CMDTYPE(ICON_UNIT_OR_MAP);
+	/*** @field CMDTYPE.ICON_FRONT integer Expect 3 or 6 parameters in return (middle and right side of front if a front was defined). */
 	PUSH_CMDTYPE(ICON_FRONT);
+	/*** @field CMDTYPE.ICON_UNIT_OR_AREA integer Expect 1 parameter in return (unitid) or 4 parameters in return (mappos+radius). */
 	PUSH_CMDTYPE(ICON_UNIT_OR_AREA);
+	/*** @field CMDTYPE.NEXT integer Expect command page used with `CMD_INTERNAL`. */
 	PUSH_CMDTYPE(NEXT);
+	/*** @field CMDTYPE.PREV integer Expect command page used with `CMD_INTERNAL`. */
 	PUSH_CMDTYPE(PREV);
+	/*** @field CMDTYPE.ICON_UNIT_FEATURE_OR_AREA integer Expect 1 parameter in return (unitid or Game.maxUnits+featureid) or 4 parameters in return (mappos+radius). */
 	PUSH_CMDTYPE(ICON_UNIT_FEATURE_OR_AREA);
+	/*** @field CMDTYPE.ICON_BUILDING integer Expect 3 parameters in return (mappos). */
 	PUSH_CMDTYPE(ICON_BUILDING);
+	/*** @field CMDTYPE.CUSTOM integer Expect with `CMD_INTERNAL`. */
 	PUSH_CMDTYPE(CUSTOM);
+	/*** @field CMDTYPE.ICON_UNIT_OR_RECTANGLE integer Expect 1 parameter in return (unitid) or 3 parameters in return (mappos) or 6 parameters in return (startpos+endpos). */
 	PUSH_CMDTYPE(ICON_UNIT_OR_RECTANGLE);
+	/*** @field CMDTYPE.NUMBER integer Expect 1 parameter in return (number). */
 	PUSH_CMDTYPE(NUMBER);
 
 	return true;
 }
-
-
-/******************************************************************************/
-/******************************************************************************/

--- a/rts/Lua/LuaConstCOB.cpp
+++ b/rts/Lua/LuaConstCOB.cpp
@@ -9,116 +9,52 @@
 #include "Sim/Projectiles/PieceProjectile.h"
 
 
-/******************************************************************************
- * COB constants
- * @see rts/Lua/LuaConstCOB.cpp
-******************************************************************************/
-
-
 bool LuaConstCOB::PushEntries(lua_State* L)
 {
 #define PUSH_COB(cmd) LuaPushNamedNumber(L, #cmd, cmd)
 
 	/***
+	 * COB constants
 	 * @enum COB
-	 * @field ACTIVATION number 
-	 * @field STANDINGMOVEORDERS number 
-	 * @field STANDINGFIREORDERS number 
-	 * @field HEALTH number 
-	 * @field INBUILDSTANCE number 
-	 * @field BUSY number 
-	 * @field PIECE_XZ number 
-	 * @field PIECE_Y number 
-	 * @field UNIT_XZ number 
-	 * @field UNIT_Y number 
-	 * @field UNIT_HEIGHT number 
-	 * @field XZ_ATAN number 
-	 * @field XZ_HYPOT number 
-	 * @field ATAN number 
-	 * @field HYPOT number 
-	 * @field GROUND_HEIGHT number 
-	 * @field BUILD_PERCENT_LEFT number 
-	 * @field YARD_OPEN number 
-	 * @field BUGGER_OFF number 
-	 * @field ARMORED number 
-	 * @field IN_WATER number 
-	 * @field CURRENT_SPEED number 
-	 * @field VETERAN_LEVEL number 
-	 * @field ON_ROAD number 
-	 * @field MAX_ID number 
-	 * @field MY_ID number 
-	 * @field UNIT_TEAM number 
-	 * @field UNIT_BUILD_PERCENT_LEFT number 
-	 * @field UNIT_ALLIED number 
-	 * @field MAX_SPEED number 
-	 * @field CLOAKED number 
-	 * @field WANT_CLOAK number 
-	 * @field GROUND_WATER_HEIGHT number 
-	 * @field UPRIGHT number 
-	 * @field POW number 
-	 * @field PRINT number 
-	 * @field HEADING number 
-	 * @field TARGET_ID number 
-	 * @field LAST_ATTACKER_ID number 
-	 * @field LOS_RADIUS number 
-	 * @field AIR_LOS_RADIUS number 
-	 * @field RADAR_RADIUS number 
-	 * @field JAMMER_RADIUS number 
-	 * @field SONAR_RADIUS number 
-	 * @field SONAR_JAM_RADIUS number 
-	 * @field SEISMIC_RADIUS number 
-	 * @field DO_SEISMIC_PING number 
-	 * @field CURRENT_FUEL number 
-	 * @field TRANSPORT_ID number 
-	 * @field SHIELD_POWER number 
-	 * @field STEALTH number 
-	 * @field CRASHING number 
-	 * @field CHANGE_TARGET number 
-	 * @field CEG_DAMAGE number 
-	 * @field COB_ID number 
-	 * @field PLAY_SOUND number 
-	 * @field KILL_UNIT number 
-	 * @field ALPHA_THRESHOLD number 
-	 * @field SET_WEAPON_UNIT_TARGET number 
-	 * @field SET_WEAPON_GROUND_TARGET number 
-	 * @field SONAR_STEALTH number 
-	 * @field REVERSING number 
-	 * @field FLANK_B_MODE number 
-	 * @field FLANK_B_DIR number 
-	 * @field FLANK_B_MOBILITY_ADD number 
-	 * @field FLANK_B_MAX_DAMAGE number 
-	 * @field FLANK_B_MIN_DAMAGE number 
-	 * @field WEAPON_RELOADSTATE number 
-	 * @field WEAPON_RELOADTIME number 
-	 * @field WEAPON_ACCURACY number 
-	 * @field WEAPON_SPRAY number 
-	 * @field WEAPON_RANGE number 
-	 * @field WEAPON_PROJECTILE_SPEED number 
-	 * @field MIN number 
-	 * @field MAX number 
-	 * @field ABS number 
-	 * @field GAME_FRAME  number 
 	 */
 
 	PUSH_COB(ACTIVATION);
 	PUSH_COB(STANDINGMOVEORDERS);
+	/*** @field COB.STANDINGFIREORDERS integer */
 	PUSH_COB(STANDINGFIREORDERS);
+	/*** @field COB.HEALTH integer */
 	PUSH_COB(HEALTH);
+	/*** @field COB.INBUILDSTANCE integer */
 	PUSH_COB(INBUILDSTANCE);
+	/*** @field COB.BUSY integer */
 	PUSH_COB(BUSY);
+	/*** @field COB.PIECE_XZ integer */
 	PUSH_COB(PIECE_XZ);
+	/*** @field COB.PIECE_Y integer */
 	PUSH_COB(PIECE_Y);
+	/*** @field COB.UNIT_XZ integer */
 	PUSH_COB(UNIT_XZ);
+	/*** @field COB.UNIT_Y integer */
 	PUSH_COB(UNIT_Y);
+	/*** @field COB.UNIT_HEIGHT integer */
 	PUSH_COB(UNIT_HEIGHT);
+	/*** @field COB.XZ_ATAN integer */
 	PUSH_COB(XZ_ATAN);
+	/*** @field COB.XZ_HYPOT integer */
 	PUSH_COB(XZ_HYPOT);
+	/*** @field COB.ATAN integer */
 	PUSH_COB(ATAN);
+	/*** @field COB.HYPOT integer */
 	PUSH_COB(HYPOT);
+	/*** @field COB.GROUND_HEIGHT integer */
 	PUSH_COB(GROUND_HEIGHT);
+	/*** @field COB.BUILD_PERCENT_LEFT integer */
 	PUSH_COB(BUILD_PERCENT_LEFT);
+	/*** @field COB.YARD_OPEN integer */
 	PUSH_COB(YARD_OPEN);
+	/*** @field COB.BUGGER_OFF integer */
 	PUSH_COB(BUGGER_OFF);
+	/*** @field COB.ARMORED integer */
 	PUSH_COB(ARMORED);
 
 /*	PUSH_COB(WEAPON_AIM_ABORTED);
@@ -126,66 +62,122 @@ bool LuaConstCOB::PushEntries(lua_State* L)
 	PUSH_COB(WEAPON_LAUNCH_NOW);
 	PUSH_COB(FINISHED_DYING);
 	PUSH_COB(ORIENTATION);*/
+	/*** @field COB.IN_WATER integer */
 	PUSH_COB(IN_WATER);
+	/*** @field COB.CURRENT_SPEED integer */
 	PUSH_COB(CURRENT_SPEED);
 //	PUSH_COB(MAGIC_DEATH);
+	/*** @field COB.VETERAN_LEVEL integer */
 	PUSH_COB(VETERAN_LEVEL);
+	/*** @field COB.ON_ROAD integer */
 	PUSH_COB(ON_ROAD);
 
+	/*** @field COB.MAX_ID integer */
 	PUSH_COB(MAX_ID);
+	/*** @field COB.MY_ID integer */
 	PUSH_COB(MY_ID);
+	/*** @field COB.UNIT_TEAM integer */
 	PUSH_COB(UNIT_TEAM);
+	/*** @field COB.UNIT_BUILD_PERCENT_LEFT integer */
 	PUSH_COB(UNIT_BUILD_PERCENT_LEFT);
+	/*** @field COB.UNIT_ALLIED integer */
 	PUSH_COB(UNIT_ALLIED);
+	/*** @field COB.MAX_SPEED integer */
 	PUSH_COB(MAX_SPEED);
+	/*** @field COB.CLOAKED integer */
 	PUSH_COB(CLOAKED);
+	/*** @field COB.WANT_CLOAK integer */
 	PUSH_COB(WANT_CLOAK);
+	/*** @field COB.GROUND_WATER_HEIGHT integer */
 	PUSH_COB(GROUND_WATER_HEIGHT);
+	/*** @field COB.UPRIGHT integer */
 	PUSH_COB(UPRIGHT);
+	/*** @field COB.POW integer */
 	PUSH_COB(POW);
+	/*** @field COB.PRINT integer */
 	PUSH_COB(PRINT);
+	/*** @field COB.HEADING integer */
 	PUSH_COB(HEADING);
+	/*** @field COB.TARGET_ID integer */
 	PUSH_COB(TARGET_ID);
+	/*** @field COB.LAST_ATTACKER_ID integer */
 	PUSH_COB(LAST_ATTACKER_ID);
+	/*** @field COB.LOS_RADIUS integer */
 	PUSH_COB(LOS_RADIUS);
+	/*** @field COB.AIR_LOS_RADIUS integer */
 	PUSH_COB(AIR_LOS_RADIUS);
+	/*** @field COB.RADAR_RADIUS integer */
 	PUSH_COB(RADAR_RADIUS);
+	/*** @field COB.JAMMER_RADIUS integer */
 	PUSH_COB(JAMMER_RADIUS);
+	/*** @field COB.SONAR_RADIUS integer */
 	PUSH_COB(SONAR_RADIUS);
+	/*** @field COB.SONAR_JAM_RADIUS integer */
 	PUSH_COB(SONAR_JAM_RADIUS);
+	/*** @field COB.SEISMIC_RADIUS integer */
 	PUSH_COB(SEISMIC_RADIUS);
+	/*** @field COB.DO_SEISMIC_PING integer */
 	PUSH_COB(DO_SEISMIC_PING);
+	/*** @field COB.CURRENT_FUEL integer */
 	PUSH_COB(CURRENT_FUEL);
+	/*** @field COB.TRANSPORT_ID integer */
 	PUSH_COB(TRANSPORT_ID);
+	/*** @field COB.SHIELD_POWER integer */
 	PUSH_COB(SHIELD_POWER);
+	/*** @field COB.STEALTH integer */
 	PUSH_COB(STEALTH);
+	/*** @field COB.CRASHING integer */
 	PUSH_COB(CRASHING);
+	/*** @field COB.CHANGE_TARGET integer */
 	PUSH_COB(CHANGE_TARGET);
+	/*** @field COB.CEG_DAMAGE integer */
 	PUSH_COB(CEG_DAMAGE);
+	/*** @field COB.COB_ID integer */
 	PUSH_COB(COB_ID);
+	/*** @field COB.PLAY_SOUND integer */
 	PUSH_COB(PLAY_SOUND);
+	/*** @field COB.KILL_UNIT integer */
 	PUSH_COB(KILL_UNIT);
+	/*** @field COB.SET_WEAPON_UNIT_TARGET integer */
 	PUSH_COB(SET_WEAPON_UNIT_TARGET);
+	/*** @field COB.SET_WEAPON_GROUND_TARGET integer */
 	PUSH_COB(SET_WEAPON_GROUND_TARGET);
+	/*** @field COB.SONAR_STEALTH integer */
 	PUSH_COB(SONAR_STEALTH);
+	/*** @field COB.REVERSING integer */
 	PUSH_COB(REVERSING);
 
 	// NOTE: [LUA0 - LUA9] are defined in CobThread.cpp as [110 - 119]
 
+	/*** @field COB.FLANK_B_MODE integer */
 	PUSH_COB(FLANK_B_MODE);
+	/*** @field COB.FLANK_B_DIR integer */
 	PUSH_COB(FLANK_B_DIR);
+	/*** @field COB.FLANK_B_MOBILITY_ADD integer */
 	PUSH_COB(FLANK_B_MOBILITY_ADD);
+	/*** @field COB.FLANK_B_MAX_DAMAGE integer */
 	PUSH_COB(FLANK_B_MAX_DAMAGE);
+	/*** @field COB.FLANK_B_MIN_DAMAGE integer */
 	PUSH_COB(FLANK_B_MIN_DAMAGE);
+	/*** @field COB.WEAPON_RELOADSTATE integer */
 	PUSH_COB(WEAPON_RELOADSTATE);
+	/*** @field COB.WEAPON_RELOADTIME integer */
 	PUSH_COB(WEAPON_RELOADTIME);
+	/*** @field COB.WEAPON_ACCURACY integer */
 	PUSH_COB(WEAPON_ACCURACY);
+	/*** @field COB.WEAPON_SPRAY integer */
 	PUSH_COB(WEAPON_SPRAY);
+	/*** @field COB.WEAPON_RANGE integer */
 	PUSH_COB(WEAPON_RANGE);
+	/*** @field COB.WEAPON_PROJECTILE_SPEED integer */
 	PUSH_COB(WEAPON_PROJECTILE_SPEED);
+	/*** @field COB.MIN integer */
 	LuaPushNamedNumber(L, "MIN", COB_MIN);
+	/*** @field COB.MAX integer */
 	LuaPushNamedNumber(L, "MAX", COB_MAX);
+	/*** @field COB.ABS integer */
 	PUSH_COB(ABS);
+	/*** @field COB.GAME_FRAME  integer */
 	PUSH_COB(GAME_FRAME);
 
 	// NOTE: shared variables use codes [1024 - 5119]
@@ -193,75 +185,25 @@ bool LuaConstCOB::PushEntries(lua_State* L)
 	return true;
 }
 
-
-/******************************************************************************/
-/******************************************************************************/
-
-
 bool LuaConstSFX::PushEntries(lua_State* L)
 {
 	/*** 
 	 * @enum SFX
+	 */
+
+	/***
+	 * Piece flag for `Spring.UnitScript.Explode`.
 	 * 
-	 * @field SHATTER number
-	 * Piece Flag for `Spring.UnitScript.Explode`
-	 * 
-	 * @field EXPLODE number
-	 * Piece Flag for `Spring.UnitScript.Explode`
-	 * 
-	 * @field EXPLODE_ON_HIT number
-	 * Piece Flag for `Spring.UnitScript.Explode`
-	 * 
-	 * @field FALL number
-	 * Piece Flag for `Spring.UnitScript.Explode`
-	 * 
-	 * @field SMOKE number
-	 * Piece Flag for `Spring.UnitScript.Explode`
-	 * 
-	 * @field FIRE number
-	 * Piece Flag for `Spring.UnitScript.Explode`
-	 * 
-	 * @field NONE number
-	 * Piece Flag for `Spring.UnitScript.Explode`
-	 * 
-	 * @field NO_CEG_TRAIL number
-	 * Piece Flag for `Spring.UnitScript.Explode`
-	 * 
-	 * @field NO_HEATCLOUD number
-	 * Piece Flag for `Spring.UnitScript.Explode`
-	 * 
-	 * @field RECURSIVE number
-	 * Piece Flag for `Spring.UnitScript.Explode`
-	 * 
-	 * @field VTOL number 
-	 * For `Spring.UnitScript.EmitSfx`.
-	 * 
-	 * @field WAKE number 
-	 * For `Spring.UnitScript.EmitSfx`.
-	 * 
-	 * @field REVERSE_WAKE number 
-	 * For `Spring.UnitScript.EmitSfx`.
-	 * 
-	 * @field WHITE_SMOKE number 
-	 * For `Spring.UnitScript.EmitSfx`.
-	 * 
-	 * @field BLACK_SMOKE number 
-	 * For `Spring.UnitScript.EmitSfx`.
-	 * 
-	 * @field BUBBLE number 
-	 * For `Spring.UnitScript.EmitSfx`.
-	 * 
-	 * @field CEG number 
-	 * For `Spring.UnitScript.EmitSfx`.
-	 * 
-	 * @field FIRE_WEAPON number 
-	 * For `Spring.UnitScript.EmitSfx`.
-	 * 
-	 * @field DETONATE_WEAPON number 
-	 * For `Spring.UnitScript.EmitSfx`.
-	 * 
-	 * @field GLOBAL number 
-	 * For `Spring.UnitScript.EmitSfx`.
+	 * @field SFX.SHATTER integer
+	 * @field SFX.EXPLODE integer
+	 * @field SFX.EXPLODE_ON_HIT integer
+	 * @field SFX.FALL integer
+	 * @field SFX.SMOKE integer
+	 * @field SFX.FIRE integer
+	 * @field SFX.NONE integer
+	 * @field SFX.NO_CEG_TRAIL integer
+	 * @field SFX.NO_HEATCLOUD integer
+	 * @field SFX.RECURSIVE integer
 	 */
 	LuaPushNamedNumber(L, "SHATTER", PF_Shatter);
 	LuaPushNamedNumber(L, "EXPLODE", PF_Explode);
@@ -274,12 +216,29 @@ bool LuaConstSFX::PushEntries(lua_State* L)
 	LuaPushNamedNumber(L, "NO_HEATCLOUD", PF_NoHeatCloud);
 	LuaPushNamedNumber(L, "RECURSIVE", PF_Recursive);
 
+	/***
+	 * Piece flag for `Spring.UnitScript.EmitSfx`.
+	 * @field SFX.VTOL integer
+	 * @field SFX.WAKE integer
+	 * @field SFX.REVERSE_WAKE integer
+	 */
 	LuaPushNamedNumber(L, "VTOL",            SFX_VTOL);
 	LuaPushNamedNumber(L, "WAKE",            SFX_WAKE);
 	LuaPushNamedNumber(L, "REVERSE_WAKE",    SFX_REVERSE_WAKE);
 	// no need for WAKE_2 and REVERSE_WAKE_2 as they are same as WAKE and REVERSE_WAKE
 	//LuaPushNamedNumber(L, "WAKE_2",          SFX_WAKE_2);
 	//LuaPushNamedNumber(L, "REVERSE_WAKE_2",  SFX_REVERSE_WAKE_2);
+
+	/***
+	 * Piece flag for `Spring.UnitScript.EmitSfx`.
+	 * @field SFX.WHITE_SMOKE integer
+	 * @field SFX.BLACK_SMOKE integer
+	 * @field SFX.BUBBLE integer
+	 * @field SFX.CEG integer
+	 * @field SFX.FIRE_WEAPON integer
+	 * @field SFX.DETONATE_WEAPON integer
+	 * @field SFX.GLOBAL integer
+	 */
 	LuaPushNamedNumber(L, "WHITE_SMOKE",     SFX_WHITE_SMOKE);
 	LuaPushNamedNumber(L, "BLACK_SMOKE",     SFX_BLACK_SMOKE);
 	LuaPushNamedNumber(L, "BUBBLE",          SFX_BUBBLE);
@@ -290,7 +249,3 @@ bool LuaConstSFX::PushEntries(lua_State* L)
 
 	return true;
 }
-
-
-/******************************************************************************/
-/******************************************************************************/

--- a/rts/Lua/LuaConstGL.cpp
+++ b/rts/Lua/LuaConstGL.cpp
@@ -9,10 +9,10 @@
 #include "Rendering/GL/myGL.h"
 
 
-/******************************************************************************
+/***
  * OpenGL Constants
- * @see rts/Lua/LuaConstGL.cpp
-******************************************************************************/
+ * @enum GL
+ */
 
 bool LuaConstGL::PushEntries(lua_State* L)
 {
@@ -22,10 +22,6 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	/***
 	 * Drawing Primitives
 	 * @section primitives
-	 */
-
-	/***
-	 * @enum GL
 	 */
 
 	/*** @field GL.POINTS integer */

--- a/rts/Lua/LuaConstGL.cpp
+++ b/rts/Lua/LuaConstGL.cpp
@@ -16,6 +16,7 @@
 
 bool LuaConstGL::PushEntries(lua_State* L)
 {
+/*** @field GL.cmd integer */
 #define PUSH_GL(cmd) LuaPushNamedNumber(L, #cmd, GL_ ## cmd)
 
 	/***
@@ -25,34 +26,38 @@ bool LuaConstGL::PushEntries(lua_State* L)
 
 	/***
 	 * @enum GL
-	 *
-	 * @field POINTS number
-	 * @field LINES number
-	 * @field LINE_LOOP number
-	 * @field LINE_STRIP number
-	 * @field TRIANGLES number
-	 * @field TRIANGLE_STRIP number
-	 * @field TRIANGLE_FAN number
-	 * @field QUADS number
-	 * @field QUAD_STRIP number
-	 * @field POLYGON number
-	 * @field PATCHES number
 	 */
+
+	/*** @field GL.POINTS integer */
 	PUSH_GL(POINTS);
+	/*** @field GL.LINES integer */
 	PUSH_GL(LINES);
+	/*** @field GL.LINE_LOOP integer */
 	PUSH_GL(LINE_LOOP);
+	/*** @field GL.LINE_STRIP integer */
 	PUSH_GL(LINE_STRIP);
+	/*** @field GL.TRIANGLES integer */
 	PUSH_GL(TRIANGLES);
+	/*** @field GL.TRIANGLE_STRIP integer */
 	PUSH_GL(TRIANGLE_STRIP);
+	/*** @field GL.TRIANGLE_FAN integer */
 	PUSH_GL(TRIANGLE_FAN);
+	/*** @field GL.QUADS integer */
 	PUSH_GL(QUADS);
+	/*** @field GL.QUAD_STRIP integer */
 	PUSH_GL(QUAD_STRIP);
+	/*** @field GL.POLYGON integer */
 	PUSH_GL(POLYGON);
 
+	/*** @field GL.LINE_STRIP_ADJACENCY integer */
 	PUSH_GL(LINE_STRIP_ADJACENCY);
+	/*** @field GL.LINES_ADJACENCY integer */
 	PUSH_GL(LINES_ADJACENCY);
+	/*** @field GL.TRIANGLE_STRIP_ADJACENCY integer */
 	PUSH_GL(TRIANGLE_STRIP_ADJACENCY);
+	/*** @field GL.TRIANGLES_ADJACENCY integer */
 	PUSH_GL(TRIANGLES_ADJACENCY);
+	/*** @field GL.PATCHES integer */
 	PUSH_GL(PATCHES);
 
 	/***
@@ -60,24 +65,21 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section blendingfactordest
 	 */
 
-	/*** @table GL
-	 *
-	 * @field ZERO number
-	 * @field ONE number
-	 * @field SRC_COLOR number
-	 * @field ONE_MINUS_SRC_COLOR number
-	 * @field SRC_ALPHA number
-	 * @field ONE_MINUS_SRC_ALPHA number
-	 * @field DST_ALPHA number
-	 * @field ONE_MINUS_DST_ALPHA number
-	 */
+	/*** @field GL.ZERO integer */
 	PUSH_GL(ZERO);
+	/*** @field GL.ONE integer */
 	PUSH_GL(ONE);
+	/*** @field GL.SRC_COLOR integer */
 	PUSH_GL(SRC_COLOR);
+	/*** @field GL.ONE_MINUS_SRC_COLOR integer */
 	PUSH_GL(ONE_MINUS_SRC_COLOR);
+	/*** @field GL.SRC_ALPHA integer */
 	PUSH_GL(SRC_ALPHA);
+	/*** @field GL.ONE_MINUS_SRC_ALPHA integer */
 	PUSH_GL(ONE_MINUS_SRC_ALPHA);
+	/*** @field GL.DST_ALPHA integer */
 	PUSH_GL(DST_ALPHA);
+	/*** @field GL.ONE_MINUS_DST_ALPHA integer */
 	PUSH_GL(ONE_MINUS_DST_ALPHA);
 
 /***
@@ -85,33 +87,22 @@ bool LuaConstGL::PushEntries(lua_State* L)
  * @section blendingfactorsrc
  */
 
-/***
- * @table GL
- * @field ZERO number
- * @field ONE number
- * @field SRC_COLOR number
- * @field ONE_MINUS_SRC_COLOR number
- * @field SRC_ALPHA number
- * @field ONE_MINUS_SRC_ALPHA number
- * @field DST_ALPHA number
- * @field ONE_MINUS_DST_ALPHA number
- * @field DST_COLOR number
- * @field ONE_MINUS_DST_COLOR number
- * @field SRC_ALPHA_SATURATE number
- * @field FUNC_ADD number
- * @field FUNC_SUBTRACT number
- * @field FUNC_REVERSE_SUBTRACT number
- * @field MIN number
- * @field MAX number
- */
+	/*** @field GL.DST_COLOR integer */
 	PUSH_GL(DST_COLOR);
+	/*** @field GL.ONE_MINUS_DST_COLOR integer */
 	PUSH_GL(ONE_MINUS_DST_COLOR);
+	/*** @field GL.SRC_ALPHA_SATURATE integer */
 	PUSH_GL(SRC_ALPHA_SATURATE);
 
+	/*** @field GL.FUNC_ADD integer */
 	PUSH_GL(FUNC_ADD);
+	/*** @field GL.FUNC_SUBTRACT integer */
 	PUSH_GL(FUNC_SUBTRACT);
+	/*** @field GL.FUNC_REVERSE_SUBTRACT integer */
 	PUSH_GL(FUNC_REVERSE_SUBTRACT);
+	/*** @field GL.MIN integer */
 	PUSH_GL(MIN);
+	/*** @field GL.MAX integer */
 	PUSH_GL(MAX);
 
 /***
@@ -119,24 +110,21 @@ bool LuaConstGL::PushEntries(lua_State* L)
  * @section alphadepth
  */
 
-/*** @table GL
- *
- * @field NEVER number
- * @field LESS number
- * @field EQUAL number
- * @field LEQUAL number
- * @field GREATER number
- * @field NOTEQUAL number
- * @field GEQUAL number
- * @field ALWAYS number
- */
+	/*** @field GL.NEVER integer */
 	PUSH_GL(NEVER);
+	/*** @field GL.LESS integer */
 	PUSH_GL(LESS);
+	/*** @field GL.EQUAL integer */
 	PUSH_GL(EQUAL);
+	/*** @field GL.LEQUAL integer */
 	PUSH_GL(LEQUAL);
+	/*** @field GL.GREATER integer */
 	PUSH_GL(GREATER);
+	/*** @field GL.NOTEQUAL integer */
 	PUSH_GL(NOTEQUAL);
+	/*** @field GL.GEQUAL integer */
 	PUSH_GL(GEQUAL);
+	/*** @field GL.ALWAYS integer */
 	PUSH_GL(ALWAYS);
 
 /***
@@ -144,40 +132,37 @@ bool LuaConstGL::PushEntries(lua_State* L)
  * @section logicop
  */
 
-/***
- * @table GL
- * @field CLEAR number
- * @field AND number
- * @field AND_REVERSE number
- * @field COPY number
- * @field AND_INVERTED number
- * @field NOOP number
- * @field XOR number
- * @field OR number
- * @field NOR number
- * @field EQUIV number
- * @field INVERT number
- * @field OR_REVERSE number
- * @field COPY_INVERTED number
- * @field OR_INVERTED number
- * @field NAND number
- * @field SET number
- */
+	/*** @field GL.CLEAR integer */
 	PUSH_GL(CLEAR);
+	/*** @field GL.AND integer */
 	PUSH_GL(AND);
+	/*** @field GL.AND_REVERSE integer */
 	PUSH_GL(AND_REVERSE);
+	/*** @field GL.COPY integer */
 	PUSH_GL(COPY);
+	/*** @field GL.AND_INVERTED integer */
 	PUSH_GL(AND_INVERTED);
+	/*** @field GL.NOOP integer */
 	PUSH_GL(NOOP);
+	/*** @field GL.XOR integer */
 	PUSH_GL(XOR);
+	/*** @field GL.OR integer */
 	PUSH_GL(OR);
+	/*** @field GL.NOR integer */
 	PUSH_GL(NOR);
+	/*** @field GL.EQUIV integer */
 	PUSH_GL(EQUIV);
+	/*** @field GL.INVERT integer */
 	PUSH_GL(INVERT);
+	/*** @field GL.OR_REVERSE integer */
 	PUSH_GL(OR_REVERSE);
+	/*** @field GL.COPY_INVERTED integer */
 	PUSH_GL(COPY_INVERTED);
+	/*** @field GL.OR_INVERTED integer */
 	PUSH_GL(OR_INVERTED);
+	/*** @field GL.NAND integer */
 	PUSH_GL(NAND);
+	/*** @field GL.SET integer */
 	PUSH_GL(SET);
 
 	/***
@@ -185,14 +170,11 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section culling
 	 */
 
-	/***
-	 * @table GL
-	 * @field BACK number
-	 * @field FRONT number
-	 * @field FRONT_AND_BACK number
-	 */
+	/*** @field GL.BACK integer */
 	PUSH_GL(BACK);
+	/*** @field GL.FRONT integer */
 	PUSH_GL(FRONT);
+	/*** @field GL.FRONT_AND_BACK integer */
 	PUSH_GL(FRONT_AND_BACK);
 
 	/***
@@ -200,14 +182,11 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section polygonmode
 	 */
 
-	/***
-	 * @table GL
-	 * @field POINT number
-	 * @field LINE number
-	 * @field FILL number
-	 */
+	/*** @field GL.POINT integer */
 	PUSH_GL(POINT);
+	/*** @field GL.LINE integer */
 	PUSH_GL(LINE);
+	/*** @field GL.FILL integer */
 	PUSH_GL(FILL);
 
 	/***
@@ -215,16 +194,13 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section clearbits
 	 */
 
-	/***
-	 * @table GL
-	 * @field DEPTH_BUFFER_BIT number
-	 * @field ACCUM_BUFFER_BIT number
-	 * @field STENCIL_BUFFER_BIT number
-	 * @field COLOR_BUFFER_BIT number
-	 */
+	/*** @field GL.DEPTH_BUFFER_BIT integer */
 	PUSH_GL(DEPTH_BUFFER_BIT);
+	/*** @field GL.ACCUM_BUFFER_BIT integer */
 	PUSH_GL(ACCUM_BUFFER_BIT);
+	/*** @field GL.STENCIL_BUFFER_BIT integer */
 	PUSH_GL(STENCIL_BUFFER_BIT);
+	/*** @field GL.COLOR_BUFFER_BIT integer */
 	PUSH_GL(COLOR_BUFFER_BIT);
 
 	/***
@@ -232,12 +208,9 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section shademodel
 	 */
 
-	/***
-	 * @table GL
-	 * @field FLAT number
-	 * @field SMOOTH number
-	 */
+	/*** @field GL.FLAT integer */
 	PUSH_GL(FLAT);
+	/*** @field GL.SMOOTH integer */
 	PUSH_GL(SMOOTH);
 
 	/***
@@ -245,14 +218,11 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section matrixmode
 	 */
 
-	/***
-	 * @table GL
-	 * @field MODELVIEW number
-	 * @field PROJECTION number
-	 * @field TEXTURE number
-	 */
+	/*** @field GL.MODELVIEW integer */
 	PUSH_GL(MODELVIEW);
+	/*** @field GL.PROJECTION integer */
 	PUSH_GL(PROJECTION);
+	/*** @field GL.TEXTURE integer */
 	PUSH_GL(TEXTURE);
 
 	/***
@@ -260,20 +230,17 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section texturefiltering
 	 */
 
-	/***
-	 * @table GL
-	 * @field NEAREST number
-	 * @field LINEAR number
-	 * @field NEAREST_MIPMAP_NEAREST number
-	 * @field LINEAR_MIPMAP_NEAREST number
-	 * @field NEAREST_MIPMAP_LINEAR number
-	 * @field LINEAR_MIPMAP_LINEAR number
-	 */
+	/*** @field GL.NEAREST integer */
 	PUSH_GL(NEAREST);
+	/*** @field GL.LINEAR integer */
 	PUSH_GL(LINEAR);
+	/*** @field GL.NEAREST_MIPMAP_NEAREST integer */
 	PUSH_GL(NEAREST_MIPMAP_NEAREST);
+	/*** @field GL.LINEAR_MIPMAP_NEAREST integer */
 	PUSH_GL(LINEAR_MIPMAP_NEAREST);
+	/*** @field GL.NEAREST_MIPMAP_LINEAR integer */
 	PUSH_GL(NEAREST_MIPMAP_LINEAR);
+	/*** @field GL.LINEAR_MIPMAP_LINEAR integer */
 	PUSH_GL(LINEAR_MIPMAP_LINEAR);
 
 	/***
@@ -281,18 +248,15 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section textureclamping
 	 */
 
-	/***
-	 * @table GL
-	 * @field REPEAT number
-	 * @field MIRRORED_REPEAT number
-	 * @field CLAMP number
-	 * @field CLAMP_TO_EDGE number
-	 * @field CLAMP_TO_BORDER number
-	 */
+	/*** @field GL.REPEAT integer */
 	PUSH_GL(REPEAT);
+	/*** @field GL.MIRRORED_REPEAT integer */
 	PUSH_GL(MIRRORED_REPEAT);
+	/*** @field GL.CLAMP integer */
 	PUSH_GL(CLAMP);
+	/*** @field GL.CLAMP_TO_EDGE integer */
 	PUSH_GL(CLAMP_TO_EDGE);
+	/*** @field GL.CLAMP_TO_BORDER integer */
 	PUSH_GL(CLAMP_TO_BORDER);
 
 	/***
@@ -300,27 +264,24 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section textureenvironment
 	 */
 
-	/***
-	 * @table GL
-	 * @field TEXTURE_ENV number
-	 * @field TEXTURE_ENV_MODE number
-	 * @field TEXTURE_ENV_COLOR number
-	 * @field MODULATE number
-	 * @field DECAL number
-	 * @field BLEND number
-	 * @field REPLACE number
-	 */
+	/*** @field GL.TEXTURE_ENV integer */
 	PUSH_GL(TEXTURE_ENV);
+	/*** @field GL.TEXTURE_ENV_MODE integer */
 	PUSH_GL(TEXTURE_ENV_MODE);
+	/*** @field GL.TEXTURE_ENV_COLOR integer */
 	PUSH_GL(TEXTURE_ENV_COLOR);
+	/*** @field GL.MODULATE integer */
 	PUSH_GL(MODULATE);
+	/*** @field GL.DECAL integer */
 	PUSH_GL(DECAL);
+	/*** @field GL.BLEND integer */
 	PUSH_GL(BLEND);
+	/*** @field GL.REPLACE integer */
 	PUSH_GL(REPLACE);
 
-	/// @field GL_TEXTURE_FILTER_CONTROL
+	/*** @field GL.TEXTURE_FILTER_CONTROL integer */
 	PUSH_GL(TEXTURE_FILTER_CONTROL);
-	/// @field GL_TEXTURE_LOD_BIAS
+	/*** @field GL.TEXTURE_LOD_BIAS integer */
 	PUSH_GL(TEXTURE_LOD_BIAS);
 
 	/***
@@ -328,32 +289,29 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section texturegeneration
 	 */
 
-	/***
-	 * @table GL
-	 * @field TEXTURE_GEN_MODE number
-	 * @field EYE_PLANE number
-	 * @field OBJECT_PLANE number
-	 * @field EYE_LINEAR number
-	 * @field OBJECT_LINEAR number
-	 * @field SPHERE_MAP number
-	 * @field NORMAL_MAP number
-	 * @field REFLECTION_MAP number
-	 * @field S number
-	 * @field T number
-	 * @field R number
-	 * @field Q number
-	 */
+	/*** @field GL.TEXTURE_GEN_MODE integer */
 	PUSH_GL(TEXTURE_GEN_MODE);
+	/*** @field GL.EYE_PLANE integer */
 	PUSH_GL(EYE_PLANE);
+	/*** @field GL.OBJECT_PLANE integer */
 	PUSH_GL(OBJECT_PLANE);
+	/*** @field GL.EYE_LINEAR integer */
 	PUSH_GL(EYE_LINEAR);
+	/*** @field GL.OBJECT_LINEAR integer */
 	PUSH_GL(OBJECT_LINEAR);
+	/*** @field GL.SPHERE_MAP integer */
 	PUSH_GL(SPHERE_MAP);
+	/*** @field GL.NORMAL_MAP integer */
 	PUSH_GL(NORMAL_MAP);
+	/*** @field GL.REFLECTION_MAP integer */
 	PUSH_GL(REFLECTION_MAP);
+	/*** @field GL.S integer */
 	PUSH_GL(S);
+	/*** @field GL.T integer */
 	PUSH_GL(T);
+	/*** @field GL.R integer */
 	PUSH_GL(R);
+	/*** @field GL.Q integer */
 	PUSH_GL(Q);
 
 	/***
@@ -361,50 +319,47 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section glpushattribbits
 	 */
 
-	/***
-	 * @table GL
-	 * @field CURRENT_BIT number
-	 * @field POINT_BIT number
-	 * @field LINE_BIT number
-	 * @field POLYGON_BIT number
-	 * @field POLYGON_STIPPLE_BIT number
-	 * @field PIXEL_MODE_BIT number
-	 * @field LIGHTING_BIT number
-	 * @field FOG_BIT number
-	 * @field DEPTH_BUFFER_BIT number
-	 * @field ACCUM_BUFFER_BIT number
-	 * @field STENCIL_BUFFER_BIT number
-	 * @field VIEWPORT_BIT number
-	 * @field TRANSFORM_BIT number
-	 * @field ENABLE_BIT number
-	 * @field COLOR_BUFFER_BIT number
-	 * @field HINT_BIT number
-	 * @field EVAL_BIT number
-	 * @field LIST_BIT number
-	 * @field TEXTURE_BIT number
-	 * @field SCISSOR_BIT number
-	 * @field ALL_ATTRIB_BITS number
-	 */
+	/*** @field GL.CURRENT_BIT integer */
 	PUSH_GL(CURRENT_BIT);
+	/*** @field GL.POINT_BIT integer */
 	PUSH_GL(POINT_BIT);
+	/*** @field GL.LINE_BIT integer */
 	PUSH_GL(LINE_BIT);
+	/*** @field GL.POLYGON_BIT integer */
 	PUSH_GL(POLYGON_BIT);
+	/*** @field GL.POLYGON_STIPPLE_BIT integer */
 	PUSH_GL(POLYGON_STIPPLE_BIT);
+	/*** @field GL.PIXEL_MODE_BIT integer */
 	PUSH_GL(PIXEL_MODE_BIT);
+	/*** @field GL.LIGHTING_BIT integer */
 	PUSH_GL(LIGHTING_BIT);
+	/*** @field GL.FOG_BIT integer */
 	PUSH_GL(FOG_BIT);
+	/*** @field GL.DEPTH_BUFFER_BIT integer */
 	PUSH_GL(DEPTH_BUFFER_BIT);
+	/*** @field GL.ACCUM_BUFFER_BIT integer */
 	PUSH_GL(ACCUM_BUFFER_BIT);
+	/*** @field GL.STENCIL_BUFFER_BIT integer */
 	PUSH_GL(STENCIL_BUFFER_BIT);
+	/*** @field GL.VIEWPORT_BIT integer */
 	PUSH_GL(VIEWPORT_BIT);
+	/*** @field GL.TRANSFORM_BIT integer */
 	PUSH_GL(TRANSFORM_BIT);
+	/*** @field GL.ENABLE_BIT integer */
 	PUSH_GL(ENABLE_BIT);
+	/*** @field GL.COLOR_BUFFER_BIT integer */
 	PUSH_GL(COLOR_BUFFER_BIT);
+	/*** @field GL.HINT_BIT integer */
 	PUSH_GL(HINT_BIT);
+	/*** @field GL.EVAL_BIT integer */
 	PUSH_GL(EVAL_BIT);
+	/*** @field GL.LIST_BIT integer */
 	PUSH_GL(LIST_BIT);
+	/*** @field GL.TEXTURE_BIT integer */
 	PUSH_GL(TEXTURE_BIT);
+	/*** @field GL.SCISSOR_BIT integer */
 	PUSH_GL(SCISSOR_BIT);
+	/*** @field GL.ALL_ATTRIB_BITS integer */
 	//PUSH_GL(ALL_ATTRIB_BITS);  // floating point clip
 	LuaPushNamedNumber(L, "ALL_ATTRIB_BITS", -1.0f);
 
@@ -413,15 +368,9 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section glhinttargets
 	 */
 
-	/***
-	 * @table GL
-	 * @field FOG_HINT number
-	 * @field LINE_SMOOTH_HINT number
-	 * @field POINT_SMOOTH_HINT number
-	 * @field POLYGON_SMOOTH_HINT number
-	 * @field PERSPECTIVE_CORRECTION_HINT number
-	 */
+	/*** @field GL.FOG_HINT integer */
 	PUSH_GL(FOG_HINT);
+	/*** @field GL.PERSPECTIVE_CORRECTION_HINT integer */
 	PUSH_GL(PERSPECTIVE_CORRECTION_HINT);
 
 	/***
@@ -429,14 +378,11 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section glhintmodes
 	 */
 
-	/***
-	 * @table GL
-	 * @field DONT_CARE number
-	 * @field FASTEST number
-	 * @field NICEST number
-	 */
+	/*** @field GL.DONT_CARE integer */
 	PUSH_GL(DONT_CARE);
+	/*** @field GL.FASTEST integer */
 	PUSH_GL(FASTEST);
+	/*** @field GL.NICEST integer */
 	PUSH_GL(NICEST);
 
 	/***
@@ -444,28 +390,25 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section lightspecification
 	 */
 
-	/***
-	 * @table GL
-	 * @field AMBIENT number
-	 * @field DIFFUSE number
-	 * @field SPECULAR number
-	 * @field POSITION number
-	 * @field SPOT_DIRECTION number
-	 * @field SPOT_EXPONENT number
-	 * @field SPOT_CUTOFF number
-	 * @field CONSTANT_ATTENUATION number
-	 * @field LINEAR_ATTENUATION number
-	 * @field QUADRATIC_ATTENUATION number
-	 */
+	/*** @field GL.AMBIENT integer */
 	PUSH_GL(AMBIENT);
+	/*** @field GL.DIFFUSE integer */
 	PUSH_GL(DIFFUSE);
+	/*** @field GL.SPECULAR integer */
 	PUSH_GL(SPECULAR);
+	/*** @field GL.POSITION integer */
 	PUSH_GL(POSITION);
+	/*** @field GL.SPOT_DIRECTION integer */
 	PUSH_GL(SPOT_DIRECTION);
+	/*** @field GL.SPOT_EXPONENT integer */
 	PUSH_GL(SPOT_EXPONENT);
+	/*** @field GL.SPOT_CUTOFF integer */
 	PUSH_GL(SPOT_CUTOFF);
+	/*** @field GL.CONSTANT_ATTENUATION integer */
 	PUSH_GL(CONSTANT_ATTENUATION);
+	/*** @field GL.LINEAR_ATTENUATION integer */
 	PUSH_GL(LINEAR_ATTENUATION);
+	/*** @field GL.QUADRATIC_ATTENUATION integer */
 	PUSH_GL(QUADRATIC_ATTENUATION);
 
 	/***
@@ -473,18 +416,15 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section shadertypes
 	 */
 
-	/***
-	 * @table GL
-	 * @field VERTEX_SHADER number
-	 * @field TESS_CONTROL_SHADER number
-	 * @field TESS_EVALUATION_SHADER number
-	 * @field GEOMETRY_SHADER number
-	 * @field FRAGMENT_SHADER number
-	 */
+	/*** @field GL.VERTEX_SHADER integer */
 	PUSH_GL(VERTEX_SHADER);
+	/*** @field GL.TESS_CONTROL_SHADER integer */
 	PUSH_GL(TESS_CONTROL_SHADER);
+	/*** @field GL.TESS_EVALUATION_SHADER integer */
 	PUSH_GL(TESS_EVALUATION_SHADER);
+	/*** @field GL.GEOMETRY_SHADER_EXT integer */
 	PUSH_GL(GEOMETRY_SHADER_EXT);
+	/*** @field GL.FRAGMENT_SHADER integer */
 	PUSH_GL(FRAGMENT_SHADER);
 
 	/***
@@ -492,14 +432,11 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section geometryshaderparameters
 	 */
 
-	/***
-	 * @table GL
-	 * @field GEOMETRY_INPUT_TYPE number
-	 * @field GEOMETRY_OUTPUT_TYPE number
-	 * @field GEOMETRY_VERTICES_OUT number
-	 */
+	/*** @field GL.GEOMETRY_INPUT_TYPE_EXT integer */
 	PUSH_GL(GEOMETRY_INPUT_TYPE_EXT);
+	/*** @field GL.GEOMETRY_OUTPUT_TYPE_EXT integer */
 	PUSH_GL(GEOMETRY_OUTPUT_TYPE_EXT);
+	/*** @field GL.GEOMETRY_VERTICES_OUT_EXT integer */
 	PUSH_GL(GEOMETRY_VERTICES_OUT_EXT);
 
 	/***
@@ -507,14 +444,11 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section tesselationcontrolshaderparameters
 	 */
 
-	/***
-	 * @table GL
-	 * @field PATCH_VERTICES number
-	 * @field PATCH_DEFAULT_OUTER_LEVEL number
-	 * @field PATCH_DEFAULT_INNER_LEVEL number
-	 */
+	/*** @field GL.PATCH_VERTICES integer */
 	PUSH_GL(PATCH_VERTICES);
+	/*** @field GL.PATCH_DEFAULT_OUTER_LEVEL integer */
 	PUSH_GL(PATCH_DEFAULT_OUTER_LEVEL);
+	/*** @field GL.PATCH_DEFAULT_INNER_LEVEL integer */
 	PUSH_GL(PATCH_DEFAULT_INNER_LEVEL);
 
 	/***
@@ -522,30 +456,27 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section OpenGL_Data_Types
 	 */
 
-	/***
-	 * @table GL
-	 * @field BYTE number
-	 * @field UNSIGNED_BYTE number
-	 * @field SHORT number
-	 * @field UNSIGNED_SHORT number
-	 * @field INT number
-	 * @field UNSIGNED_INT number
-	 * @field FLOAT number
-	 * @field FLOAT_VEC4 number
-	 * @field INT_VEC4 number
-	 * @field UNSIGNED_INT_VEC4 number
-	 * @field FLOAT_MAT4 number
-	 */
+	/*** @field GL.BYTE integer */
 	PUSH_GL(BYTE);
+	/*** @field GL.UNSIGNED_BYTE integer */
 	PUSH_GL(UNSIGNED_BYTE);
+	/*** @field GL.SHORT integer */
 	PUSH_GL(SHORT);
+	/*** @field GL.UNSIGNED_SHORT integer */
 	PUSH_GL(UNSIGNED_SHORT);
+	/*** @field GL.INT integer */
 	PUSH_GL(INT);
+	/*** @field GL.UNSIGNED_INT integer */
 	PUSH_GL(UNSIGNED_INT);
+	/*** @field GL.FLOAT integer */
 	PUSH_GL(FLOAT);
+	/*** @field GL.FLOAT_VEC4 integer */
 	PUSH_GL(FLOAT_VEC4);
+	/*** @field GL.INT_VEC4 integer */
 	PUSH_GL(INT_VEC4);
+	/*** @field GL.UNSIGNED_INT_VEC4 integer */
 	PUSH_GL(UNSIGNED_INT_VEC4);
+	/*** @field GL.FLOAT_MAT4 integer */
 	PUSH_GL(FLOAT_MAT4);
 
 	/***
@@ -553,109 +484,190 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section OpenGL_Buffer_Types
 	 */
 
-	/***
-	 * @table GL
-	 * @field ELEMENT_ARRAY_BUFFER number
-	 * @field ARRAY_BUFFER number
-	 * @field UNIFORM_BUFFER number
-	 * @field SHADER_STORAGE_BUFFER number
-	 *
-	 */
+	/*** @field GL.ELEMENT_ARRAY_BUFFER integer */
 	PUSH_GL(ELEMENT_ARRAY_BUFFER);
+	/*** @field GL.ARRAY_BUFFER integer */
 	PUSH_GL(ARRAY_BUFFER);
+	/*** @field GL.UNIFORM_BUFFER integer */
 	PUSH_GL(UNIFORM_BUFFER);
+	/*** @field GL.SHADER_STORAGE_BUFFER integer */
 	PUSH_GL(SHADER_STORAGE_BUFFER);
 
 	//Texture targets
+	/*** @field GL.TEXTURE_1D integer */
 	PUSH_GL(TEXTURE_1D);
+	/*** @field GL.TEXTURE_2D integer */
 	PUSH_GL(TEXTURE_2D);
+	/*** @field GL.TEXTURE_3D integer */
 	PUSH_GL(TEXTURE_3D);
+	/*** @field GL.TEXTURE_CUBE_MAP integer */
 	PUSH_GL(TEXTURE_CUBE_MAP);
+	/*** @field GL.TEXTURE_2D_MULTISAMPLE integer */
 	PUSH_GL(TEXTURE_2D_MULTISAMPLE);
 
 	//Image formats
+	/*** @field GL.RGBA32F integer */
 	PUSH_GL(RGBA32F);
+	/*** @field GL.RGBA16F integer */
 	PUSH_GL(RGBA16F);
+	/*** @field GL.RG32F integer */
 	PUSH_GL(RG32F);
+	/*** @field GL.RG16F integer */
 	PUSH_GL(RG16F);
+	/*** @field GL.R11F_G11F_B10F integer */
 	PUSH_GL(R11F_G11F_B10F);
+	/*** @field GL.R32F integer */
 	PUSH_GL(R32F);
+	/*** @field GL.R16F integer */
 	PUSH_GL(R16F);
+	/*** @field GL.RGBA32UI integer */
 	PUSH_GL(RGBA32UI);
+	/*** @field GL.RGBA16UI integer */
 	PUSH_GL(RGBA16UI);
+	/*** @field GL.RGB10_A2UI integer */
 	PUSH_GL(RGB10_A2UI);
+	/*** @field GL.RGBA8UI integer */
 	PUSH_GL(RGBA8UI);
+	/*** @field GL.RG32UI integer */
 	PUSH_GL(RG32UI);
+	/*** @field GL.RG16UI integer */
 	PUSH_GL(RG16UI);
+	/*** @field GL.RG8UI integer */
 	PUSH_GL(RG8UI);
+	/*** @field GL.R32UI integer */
 	PUSH_GL(R32UI);
+	/*** @field GL.R16UI integer */
 	PUSH_GL(R16UI);
+	/*** @field GL.R8UI integer */
 	PUSH_GL(R8UI);
+	/*** @field GL.RGBA32I integer */
 	PUSH_GL(RGBA32I);
+	/*** @field GL.RGBA16I integer */
 	PUSH_GL(RGBA16I);
+	/*** @field GL.RGBA8I integer */
 	PUSH_GL(RGBA8I);
+	/*** @field GL.RG32I integer */
 	PUSH_GL(RG32I);
+	/*** @field GL.RG16I integer */
 	PUSH_GL(RG16I);
+	/*** @field GL.RG8I integer */
 	PUSH_GL(RG8I);
+	/*** @field GL.R32I integer */
 	PUSH_GL(R32I);
+	/*** @field GL.R16I integer */
 	PUSH_GL(R16I);
+	/*** @field GL.R8I integer */
 	PUSH_GL(R8I);
+	/*** @field GL.RGBA16 integer */
 	PUSH_GL(RGBA16);
+	/*** @field GL.RGB10_A2 integer */
 	PUSH_GL(RGB10_A2);
+	/*** @field GL.RGBA8 integer */
 	PUSH_GL(RGBA8);
+	/*** @field GL.RG16 integer */
 	PUSH_GL(RG16);
+	/*** @field GL.RG8 integer */
 	PUSH_GL(RG8);
+	/*** @field GL.R16 integer */
 	PUSH_GL(R16);
+	/*** @field GL.R8 integer */
 	PUSH_GL(R8);
+	/*** @field GL.RGBA16_SNORM integer */
 	PUSH_GL(RGBA16_SNORM);
+	/*** @field GL.RGBA8_SNORM integer */
 	PUSH_GL(RGBA8_SNORM);
+	/*** @field GL.RG16_SNORM integer */
 	PUSH_GL(RG16_SNORM);
+	/*** @field GL.RG8_SNORM integer */
 	PUSH_GL(RG8_SNORM);
+	/*** @field GL.R16_SNORM integer */
 	PUSH_GL(R16_SNORM);
+	/*** @field GL.R8_SNORM integer */
 	PUSH_GL(R8_SNORM);
+	/*** @field GL.DEPTH_COMPONENT16 integer */
 	PUSH_GL(DEPTH_COMPONENT16);
+	/*** @field GL.DEPTH_COMPONENT24 integer */
 	PUSH_GL(DEPTH_COMPONENT24);
+	/*** @field GL.DEPTH_COMPONENT32 integer */
 	PUSH_GL(DEPTH_COMPONENT32);
+	/*** @field GL.DEPTH_COMPONENT32F integer */
 	PUSH_GL(DEPTH_COMPONENT32F);
 
 	//access specifiers
+
+	/*** @field GL.READ_ONLY integer */
 	PUSH_GL(READ_ONLY);
+	/*** @field GL.WRITE_ONLY integer */
 	PUSH_GL(WRITE_ONLY);
+	/*** @field GL.READ_WRITE integer */
 	PUSH_GL(READ_WRITE);
 
 	//memory barrier bits
+
+	/*** @field GL.VERTEX_ATTRIB_ARRAY_BARRIER_BIT integer */
 	PUSH_GL(VERTEX_ATTRIB_ARRAY_BARRIER_BIT);
+	/*** @field GL.ELEMENT_ARRAY_BARRIER_BIT integer */
 	PUSH_GL(ELEMENT_ARRAY_BARRIER_BIT);
+	/*** @field GL.UNIFORM_BARRIER_BIT integer */
 	PUSH_GL(UNIFORM_BARRIER_BIT);
+	/*** @field GL.TEXTURE_FETCH_BARRIER_BIT integer */
 	PUSH_GL(TEXTURE_FETCH_BARRIER_BIT);
+	/*** @field GL.SHADER_IMAGE_ACCESS_BARRIER_BIT integer */
 	PUSH_GL(SHADER_IMAGE_ACCESS_BARRIER_BIT);
+	/*** @field GL.COMMAND_BARRIER_BIT integer */
 	PUSH_GL(COMMAND_BARRIER_BIT);
+	/*** @field GL.PIXEL_BUFFER_BARRIER_BIT integer */
 	PUSH_GL(PIXEL_BUFFER_BARRIER_BIT);
+	/*** @field GL.TEXTURE_UPDATE_BARRIER_BIT integer */
 	PUSH_GL(TEXTURE_UPDATE_BARRIER_BIT);
+	/*** @field GL.BUFFER_UPDATE_BARRIER_BIT integer */
 	PUSH_GL(BUFFER_UPDATE_BARRIER_BIT);
+	/*** @field GL.FRAMEBUFFER_BARRIER_BIT integer */
 	PUSH_GL(FRAMEBUFFER_BARRIER_BIT);
+	/*** @field GL.TRANSFORM_FEEDBACK_BARRIER_BIT integer */
 	PUSH_GL(TRANSFORM_FEEDBACK_BARRIER_BIT);
+	/*** @field GL.ATOMIC_COUNTER_BARRIER_BIT integer */
 	PUSH_GL(ATOMIC_COUNTER_BARRIER_BIT);
+	/*** @field GL.SHADER_STORAGE_BARRIER_BIT integer */
 	PUSH_GL(SHADER_STORAGE_BARRIER_BIT);
+	/*** @field GL.ALL_BARRIER_BITS integer */
 	PUSH_GL(ALL_BARRIER_BITS);
 
+	/*** @field GL.COLOR_ATTACHMENT0 integer */
 	PUSH_GL(COLOR_ATTACHMENT0);
+	/*** @field GL.COLOR_ATTACHMENT1 integer */
 	PUSH_GL(COLOR_ATTACHMENT1);
+	/*** @field GL.COLOR_ATTACHMENT2 integer */
 	PUSH_GL(COLOR_ATTACHMENT2);
+	/*** @field GL.COLOR_ATTACHMENT3 integer */
 	PUSH_GL(COLOR_ATTACHMENT3);
+	/*** @field GL.COLOR_ATTACHMENT4 integer */
 	PUSH_GL(COLOR_ATTACHMENT4);
+	/*** @field GL.COLOR_ATTACHMENT5 integer */
 	PUSH_GL(COLOR_ATTACHMENT5);
+	/*** @field GL.COLOR_ATTACHMENT6 integer */
 	PUSH_GL(COLOR_ATTACHMENT6);
+	/*** @field GL.COLOR_ATTACHMENT7 integer */
 	PUSH_GL(COLOR_ATTACHMENT7);
+	/*** @field GL.COLOR_ATTACHMENT8 integer */
 	PUSH_GL(COLOR_ATTACHMENT8);
+	/*** @field GL.COLOR_ATTACHMENT9 integer */
 	PUSH_GL(COLOR_ATTACHMENT9);
+	/*** @field GL.COLOR_ATTACHMENT10 integer */
 	PUSH_GL(COLOR_ATTACHMENT10);
+	/*** @field GL.COLOR_ATTACHMENT11 integer */
 	PUSH_GL(COLOR_ATTACHMENT11);
+	/*** @field GL.COLOR_ATTACHMENT12 integer */
 	PUSH_GL(COLOR_ATTACHMENT12);
+	/*** @field GL.COLOR_ATTACHMENT13 integer */
 	PUSH_GL(COLOR_ATTACHMENT13);
+	/*** @field GL.COLOR_ATTACHMENT14 integer */
 	PUSH_GL(COLOR_ATTACHMENT14);
+	/*** @field GL.COLOR_ATTACHMENT15 integer */
 	PUSH_GL(COLOR_ATTACHMENT15);
+	/*** @field GL.DEPTH_ATTACHMENT integer */
 	PUSH_GL(DEPTH_ATTACHMENT);
+	/*** @field GL.STENCIL_ATTACHMENT integer */
 	PUSH_GL(STENCIL_ATTACHMENT);
 
 
@@ -665,42 +677,42 @@ bool LuaConstGL::PushEntries(lua_State* L)
  * @section fboattachments
 ******************************************************************************/
 
-	/// @field GL_COLOR_ATTACHMENT0_EXT 0x8CE0
+	/*** @field GL.COLOR_ATTACHMENT0_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT0_EXT);
-	/// @field GL_COLOR_ATTACHMENT1_EXT 0x8CE1
+	/*** @field GL.COLOR_ATTACHMENT1_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT1_EXT);
-	/// @field GL_COLOR_ATTACHMENT2_EXT 0x8CE2
+	/*** @field GL.COLOR_ATTACHMENT2_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT2_EXT);
-	/// @field GL_COLOR_ATTACHMENT3_EXT 0x8CE3
+	/*** @field GL.COLOR_ATTACHMENT3_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT3_EXT);
-	/// @field GL_COLOR_ATTACHMENT4_EXT 0x8CE4
+	/*** @field GL.COLOR_ATTACHMENT4_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT4_EXT);
-	/// @field GL_COLOR_ATTACHMENT5_EXT 0x8CE5
+	/*** @field GL.COLOR_ATTACHMENT5_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT5_EXT);
-	/// @field GL_COLOR_ATTACHMENT6_EXT 0x8CE6
+	/*** @field GL.COLOR_ATTACHMENT6_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT6_EXT);
-	/// @field GL_COLOR_ATTACHMENT7_EXT 0x8CE7
+	/*** @field GL.COLOR_ATTACHMENT7_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT7_EXT);
-	/// @field GL_COLOR_ATTACHMENT8_EXT 0x8CE8
+	/*** @field GL.COLOR_ATTACHMENT8_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT8_EXT);
-	/// @field GL_COLOR_ATTACHMENT9_EXT 0x8CE9
+	/*** @field GL.COLOR_ATTACHMENT9_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT9_EXT);
-	/// @field GL_COLOR_ATTACHMENT10_EXT 0x8CEA
+	/*** @field GL.COLOR_ATTACHMENT10_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT10_EXT);
-	/// @field GL_COLOR_ATTACHMENT11_EXT 0x8CEB
+	/*** @field GL.COLOR_ATTACHMENT11_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT11_EXT);
-	/// @field GL_COLOR_ATTACHMENT12_EXT 0x8CEC
+	/*** @field GL.COLOR_ATTACHMENT12_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT12_EXT);
-	/// @field GL_COLOR_ATTACHMENT13_EXT 0x8CED
+	/*** @field GL.COLOR_ATTACHMENT13_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT13_EXT);
-	/// @field GL_COLOR_ATTACHMENT14_EXT 0x8CEE
+	/*** @field GL.COLOR_ATTACHMENT14_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT14_EXT);
-	/// @field GL_COLOR_ATTACHMENT15_EXT 0x8CEF
+	/*** @field GL.COLOR_ATTACHMENT15_EXT integer */
 	PUSH_GL(COLOR_ATTACHMENT15_EXT);
 
-	/// @field GL_DEPTH_ATTACHMENT_EXT 0x8D00
+	/*** @field GL.DEPTH_ATTACHMENT_EXT integer */
 	PUSH_GL(DEPTH_ATTACHMENT_EXT);
-	/// @field GL_STENCIL_ATTACHMENT_EXT 0x8D20
+	/*** @field GL.STENCIL_ATTACHMENT_EXT integer */
 	PUSH_GL(STENCIL_ATTACHMENT_EXT);
 
 	return true;
@@ -710,23 +722,23 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	 * @section objecttypes
 	******************************************************************************/
 
-	/// @field GL_BUFFER 0x82E0
+	/*** @field GL.BUFFER integer */
 	PUSH_GL(BUFFER);
-	/// @field GL_SHADER 0x82E1
+	/*** @field GL.SHADER integer */
 	PUSH_GL(SHADER);
-	/// @field GL_PROGRAM 0x82E2
+	/*** @field GL.PROGRAM integer */
 	PUSH_GL(PROGRAM);
-	/// @field GL_VERTEX_ARRAY 0x8074
+	/*** @field GL.VERTEX_ARRAY integer */
 	PUSH_GL(VERTEX_ARRAY);
-	/// @field GL_QUERY 0x82E3
+	/*** @field GL.QUERY integer */
 	PUSH_GL(QUERY);
-	/// @field GL_PROGRAM_PIPELINE 0x82E4
+	/*** @field GL.PROGRAM_PIPELINE integer */
 	PUSH_GL(PROGRAM_PIPELINE);
-	/// @field GL_TRANSFORM_FEEDBACK 0x8E22
+	/*** @field GL.TRANSFORM_FEEDBACK integer */
 	PUSH_GL(TRANSFORM_FEEDBACK);
-	/// @field GL_RENDERBUFFER 0x8D41
+	/*** @field GL.RENDERBUFFER integer */
 	PUSH_GL(RENDERBUFFER);
-	/// @field GL_FRAMEBUFFER 0x8D40
+	/*** @field GL.FRAMEBUFFER integer */
 	PUSH_GL(FRAMEBUFFER);
 
 	return true;

--- a/rts/Lua/library/.luarc.json
+++ b/rts/Lua/library/.luarc.json
@@ -25,10 +25,6 @@
     "table.new": "disable",
     "utf8": "disable"
   },
-  "workspace.ignoreDir": [
-    "cont",
-    "lib"
-  ],
   "runtime.path": [
     "?",
     "?.lua"


### PR DESCRIPTION
- Document enums/fields with `/*** @field Enum.Entry */` (that I feel will be more maintainable).
- Update `@field` output to be compatible with `emmylua_doc_cli`, adding visible descriptions.
- Improve Lua API templates in general (remove excess HR elements).
- Improve Lua API enum template: Heading and markdown formatted description for each enum value.