### PR TITLE
rml svg plugin that can render dynamic svg

### DIFF
--- a/rts/Rml/CMakeLists.txt
+++ b/rts/Rml/CMakeLists.txt
@@ -4,6 +4,8 @@ set(sources_engine_Rml
 		"${CMAKE_CURRENT_SOURCE_DIR}/Backends/RmlUi_Renderer_GL3_Recoil.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Backends/RmlUi_VFSFileInterface.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Components/ElementLuaTexture.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/SVG/SVGPlugin.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/SVG/ElementSVG.cpp"
 		PARENT_SCOPE
 )
 

--- a/rts/Rml/SVG/ElementSVG.cpp
+++ b/rts/Rml/SVG/ElementSVG.cpp
@@ -1,0 +1,209 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019-2023 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "ElementSVG.h"
+#include "RmlUi/Config/Config.h"
+#include "RmlUi/Core/ComputedValues.h"
+#include "RmlUi/Core/ElementDocument.h"
+#include "RmlUi/Core/FileInterface.h"
+#include "RmlUi/Core/Math.h"
+#include "RmlUi/Core/PropertyIdSet.h"
+#include "RmlUi/Core/RenderManager.h"
+#include "RmlUi/Core/SystemInterface.h"
+#include "RmlUi/Core/MeshUtilities.h"
+#include <cmath>
+#include <lunasvg.h>
+#include <string.h>
+
+namespace Rml {
+
+ElementSVG::ElementSVG(const String& tag) : Element(tag) {}
+
+ElementSVG::~ElementSVG() {}
+
+bool ElementSVG::GetIntrinsicDimensions(Vector2f& dimensions, float& ratio)
+{
+	if (source_dirty)
+		LoadSource();
+
+	dimensions = intrinsic_dimensions;
+
+	if (HasAttribute("width"))
+	{
+		dimensions.x = GetAttribute<float>("width", -1);
+	}
+	if (HasAttribute("height"))
+	{
+		dimensions.y = GetAttribute<float>("height", -1);
+	}
+
+	if (dimensions.y > 0)
+		ratio = dimensions.x / dimensions.y;
+
+	return true;
+}
+
+void ElementSVG::OnRender()
+{
+	if (svg_document)
+	{
+		if (geometry_dirty)
+			GenerateGeometry();
+
+		UpdateTexture();
+		geometry.Render(GetAbsoluteOffset(BoxArea::Content), Texture(texture));
+	}
+}
+
+void ElementSVG::OnResize()
+{
+	geometry_dirty = true;
+	texture_dirty = true;
+}
+
+void ElementSVG::OnAttributeChange(const ElementAttributes& changed_attributes)
+{
+	Element::OnAttributeChange(changed_attributes);
+
+	if (changed_attributes.count("src"))
+	{
+		source_dirty = true;
+		DirtyLayout();
+	}
+
+	if (changed_attributes.find("width") != changed_attributes.end() || changed_attributes.find("height") != changed_attributes.end())
+	{
+		DirtyLayout();
+	}
+}
+
+void ElementSVG::OnPropertyChange(const PropertyIdSet& changed_properties)
+{
+	Element::OnPropertyChange(changed_properties);
+
+	if (changed_properties.Contains(PropertyId::ImageColor) || changed_properties.Contains(PropertyId::Opacity))
+	{
+		geometry_dirty = true;
+	}
+}
+
+void ElementSVG::GenerateGeometry()
+{
+	const ComputedValues& computed = GetComputedValues();
+	ColourbPremultiplied quad_colour = computed.image_color().ToPremultiplied(computed.opacity());
+
+	const Vector2f render_dimensions_f = GetBox().GetSize(BoxArea::Content).Round();
+	render_dimensions = Vector2i(render_dimensions_f);
+
+	Mesh mesh = geometry.Release(Geometry::ReleaseMode::ClearMesh);
+	MeshUtilities::GenerateQuad(mesh, Vector2f(0), render_dimensions_f, quad_colour, Vector2f(0), Vector2f(1));
+	geometry = GetRenderManager()->MakeGeometry(std::move(mesh));
+
+	geometry_dirty = false;
+}
+
+bool ElementSVG::LoadSource()
+{
+	source_dirty = false;
+	texture_dirty = true;
+	intrinsic_dimensions = Vector2f{};
+	texture = {};
+	svg_document.reset();
+
+	const String attribute_src = GetAttribute<String>("src", "");
+
+	if (attribute_src.empty())
+		return false;
+
+	String path = attribute_src;
+	String directory;
+	String svg_data;
+
+	if (path.starts_with("<")) {
+		svg_data = path;
+	} else {
+		if (ElementDocument* document = GetOwnerDocument())
+		{
+			const String document_source_url = StringUtilities::Replace(document->GetSourceURL(), '|', ':');
+			GetSystemInterface()->JoinPath(path, document_source_url, attribute_src);
+			GetSystemInterface()->JoinPath(directory, document_source_url, "");
+		}
+
+		if (path.empty() || !GetFileInterface()->LoadFile(path, svg_data))
+		{
+			Log::Message(Rml::Log::Type::LT_WARNING, "Could not load SVG file %s", path.c_str());
+			return false;
+		}
+	}
+	// We use a reset-release approach here in case clients use a non-std unique_ptr (lunasvg uses std::unique_ptr)
+	svg_document.reset(lunasvg::Document::loadFromData(svg_data).release());
+
+	if (!svg_document)
+	{
+		Log::Message(Rml::Log::Type::LT_WARNING, "Could not load SVG data from file %s", path.c_str());
+		return false;
+	}
+
+	intrinsic_dimensions.x = Math::Max(float(svg_document->width()), 1.0f);
+	intrinsic_dimensions.y = Math::Max(float(svg_document->height()), 1.0f);
+
+	return true;
+}
+
+void ElementSVG::UpdateTexture()
+{
+	if (!svg_document || !texture_dirty)
+		return;
+
+	RenderManager* render_manager = GetRenderManager();
+	if (!render_manager)
+		return;
+
+	// Callback for generating texture.
+	auto texture_callback = [this](const CallbackTextureInterface& texture_interface) -> bool {
+		RMLUI_ASSERT(svg_document);
+		lunasvg::Bitmap bitmap = svg_document->renderToBitmap(render_dimensions.x, render_dimensions.y);
+
+		// Swap red and blue channels, assuming LunaSVG v2.3.2 or newer, to convert to RmlUi's expected RGBA-ordering.
+		const size_t bitmap_byte_size = bitmap.width() * bitmap.height() * 4;
+		uint8_t* bitmap_data = bitmap.data();
+		for (size_t i = 0; i < bitmap_byte_size; i += 4)
+			std::swap(bitmap_data[i], bitmap_data[i + 2]);
+
+		if (!bitmap.valid() || !bitmap.data())
+			return false;
+		if (!texture_interface.GenerateTexture({reinterpret_cast<const Rml::byte*>(bitmap.data()), bitmap_byte_size}, render_dimensions))
+			return false;
+		return true;
+	};
+
+	texture = render_manager->MakeCallbackTexture(std::move(texture_callback));
+	texture_dirty = false;
+}
+
+} // namespace Rml

--- a/rts/Rml/SVG/ElementSVG.h
+++ b/rts/Rml/SVG/ElementSVG.h
@@ -1,0 +1,96 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019-2023 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef RMLUI_SVG_ELEMENT_SVG_H
+#define RMLUI_SVG_ELEMENT_SVG_H
+
+
+#include "RmlUi/Core/CallbackTexture.h"
+#include "RmlUi/Core/Element.h"
+#include "RmlUi/Core/Geometry.h"
+
+namespace lunasvg {
+class Document;
+}
+
+namespace Rml {
+
+class ElementSVG : public Element {
+public:
+	RMLUI_RTTI_DefineWithParent(ElementSVG, Element)
+
+	ElementSVG(const String& tag);
+	virtual ~ElementSVG();
+
+	/// Returns the element's inherent size.
+	bool GetIntrinsicDimensions(Vector2f& dimensions, float& ratio) override;
+
+protected:
+	/// Renders the image.
+	void OnRender() override;
+
+	/// Regenerates the element's geometry.
+	void OnResize() override;
+
+	/// Checks for changes to the image's source or dimensions.
+	/// @param[in] changed_attributes A list of attributes changed on the element.
+	void OnAttributeChange(const ElementAttributes& changed_attributes) override;
+
+	/// Called when properties on the element are changed.
+	/// @param[in] changed_properties The properties changed on the element.
+	void OnPropertyChange(const PropertyIdSet& changed_properties) override;
+
+private:
+	// Generates the element's geometry.
+	void GenerateGeometry();
+	// Loads the SVG document specified by the 'src' attribute.
+	bool LoadSource();
+	// Update the texture when necessary.
+	void UpdateTexture();
+
+	bool source_dirty = false;
+	bool geometry_dirty = false;
+	bool texture_dirty = false;
+
+	// The texture this element is rendering from.
+	CallbackTexture texture;
+
+	// The image's intrinsic dimensions.
+	Vector2f intrinsic_dimensions;
+	// The element's size for rendering.
+	Vector2i render_dimensions;
+
+	// The geometry used to render this element.
+	Geometry geometry;
+
+	UniquePtr<lunasvg::Document> svg_document;
+};
+
+} // namespace Rml
+
+#endif

--- a/rts/Rml/SVG/SVGPlugin.cpp
+++ b/rts/Rml/SVG/SVGPlugin.cpp
@@ -1,0 +1,36 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019-2023 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <RmlUi/Core.h>
+#include "./ElementSVG.h"
+
+namespace Rml {
+namespace SVG {
+
+} // namespace SVG
+} // namespace Rml

--- a/rts/Rml/SVG/SVGPlugin.h
+++ b/rts/Rml/SVG/SVGPlugin.h
@@ -1,0 +1,67 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019-2023 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef RMLUI_SVG_SVG_PLUGIN_H
+#define RMLUI_SVG_SVG_PLUGIN_H
+
+#include <RmlUi/Core.h>
+#include "./ElementSVG.h"
+
+namespace Rml {
+namespace SVG {
+
+	void Initialise();
+	class SVGPlugin : public Plugin {
+	public:
+		void OnInitialise() override
+		{
+			instancer = MakeUnique<ElementInstancerGeneric<ElementSVG>>();
+
+			Factory::RegisterElementInstancer("svg", instancer.get());
+
+			Log::Message(Log::LT_INFO, "SVG plugin initialised.");
+		}
+
+		void OnShutdown() override { delete this; }
+
+		int GetEventClasses() override { return Plugin::EVT_BASIC; }
+
+	private:
+		UniquePtr<ElementInstancerGeneric<ElementSVG>> instancer;
+	};
+
+	void Initialise()
+	{
+		RegisterPlugin(new SVGPlugin);
+	}
+
+
+}
+} // namespace Rml
+
+#endif

--- a/rts/lib/CMakeLists.txt
+++ b/rts/lib/CMakeLists.txt
@@ -85,7 +85,7 @@ if (TRACY_ENABLE)
 	option(RMLUI_TRACY_PROFILING "Enable RmlUi profiling with Tracy." ON)
 	# We have our own memory profiling, never enable RmlUi one.
 	set(RMLUI_TRACY_MEMORY_PROFILING OFF CACHE BOOL "Enable RmlUi tracy profiling")
-	
+
 	# Disable the additional RmlUI multiconfig configuration as it only applies to RmlUI
 	set(RMLUI_TRACY_CONFIGURATION OFF CACHE BOOL "" FORCE)
 endif()
@@ -103,5 +103,4 @@ set(CMAKE_CXX_FLAGS ${NEW_CMAKE_FLAGS})
 add_subdirectory(lunasvg)
 set(CMAKE_CXX_FLAGS ${SAVED_CMAKE_FLAGS})
 
-option(RMLUI_SVG_PLUGIN "RmlUi with SVG support" ON)
 add_subdirectory(RmlUi)


### PR DESCRIPTION
The builtin svg plugin can only render svg from files. There is a desire to render svg that is created inside the widget for graphs. So this is a copy of the builtin plugin with a change to allow for the svg string to be changed using the src attribute:
```cpp
if (path.starts_with("<")) {
        svg_data = path;
} else {
        // normal file import
```
usage:
```lua
<svg id="svgi" width="700" height="700"></svg>

local image = [[<svg>
  <path ...
]]
svgi = document:GetElementById("svgi")
svgi:SetAttribute("src", image)
```