### PR TITLE
Revert "setcameratarget must change camera controller"

### DIFF
--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -1158,7 +1158,7 @@ int LuaUnsyncedCtrl::SetCameraTarget(lua_State* L)
 	if (mouse == nullptr)
 		return 0;
 
-	float4 targetPos = {
+	const float4 targetPos = {
 		luaL_checkfloat(L, 1),
 		luaL_checkfloat(L, 2),
 		luaL_checkfloat(L, 3),
@@ -1170,12 +1170,16 @@ int LuaUnsyncedCtrl::SetCameraTarget(lua_State* L)
 		luaL_optfloat(L, 7, (camera->GetDir()).z),
 	};
 
-	if (targetPos.w < 0.0f) {
-		targetPos.w = 0.0f;
+	if (targetPos.w >= 0.0f) {
+		camHandler->CameraTransition(targetPos.w);
+		camHandler->GetCurrentController().SetPos(targetPos);
+		camHandler->GetCurrentController().SetDir(targetDir);
+	} else {
+		// no transition, bypass controller
+		camera->SetPos(targetPos);
+		camera->SetDir(targetDir);
+		// camera->Update();
 	}
-	camHandler->GetCurrentController().SetPos(targetPos);
-	camHandler->GetCurrentController().SetDir(targetDir);
-	camHandler->CameraTransition(targetPos.w);
 
 	return 0;
 }


### PR DESCRIPTION
Reverts beyond-all-reason/spring#1645

Reverting because gameside widgets are counting on the ability to set the camera state directly for intra-frame rendering.