### PR TITLE
Pass original font to GetFontForCharacters, instead of the latest tested font

### DIFF
--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -1014,7 +1014,7 @@ void CFontTexture::LoadWantedGlyphs(const std::vector<char32_t>& wanted)
 				++idx;
 			}
 		}
-		f = GetFontForCharacters(map, *f, fontSize, alreadyCheckedFonts);
+		f = GetFontForCharacters(map, *shFace, fontSize, alreadyCheckedFonts);
 	} while (!map.empty() && f);
 
 	// handle glyphs that didn't reach maxFontTries number of attempts, but nonetheless failed


### PR DESCRIPTION
### Work done

- Pass original font to GetFontForCharacters, instead of the latest tested font

### Remarks

- GetFontForCharacters is supposed to get the original font we're looking for alternatives for. Here we were passing the latest tested alternative instead.
- This shouldn't be a very big issue, but it's incorrect, and also seems like some fonts take a lot longer to query through `FcFreeTypeQueryFace`, this can make `LoadWantedGlyphs` take an order of magnitude longer.