### PR TITLE
Make sure recently/often used fonts don't get evicted from cache.

### DIFF
--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -811,6 +811,7 @@ bool CFontTexture::AddFallbackFont(const std::string& fontfile)
  */
 void CFontTexture::ClearFallbackFonts()
 {
+	pinnedRecentFonts.clear();
 #if defined(USE_FONTCONFIG) && !defined(HEADLESS)
 	if (!FtLibraryHandler::CanUseFontConfig())
 		return;

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -863,6 +863,7 @@ bool CFontTexture::ClearGlyphs() {
 
 		// clear all glyps
 		glyphs.clear();
+		fallbackFonts.clear();
 
 		// clear atlases
 		ClearAtlases(32, 32);
@@ -1166,6 +1167,15 @@ void CFontTexture::LoadGlyph(std::shared_ptr<FontFace>& f, char32_t ch, unsigned
 	if (slot->bitmap.pitch != width) {
 		LOG_L(L_ERROR, "invalid pitch");
 		return;
+	}
+
+	if (shFace->face != f->face) {
+		auto it = std::find_if(fallbackFonts.begin(), fallbackFonts.end(), [&](std::shared_ptr<FontFace> const& p) {
+			return p->face == f->face;
+		});
+		if (it == fallbackFonts.end()) {
+			fallbackFonts.emplace_back(f);
+		}
 	}
 
 	// store glyph bitmap (index) in allocator until the next LoadWantedGlyphs call

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -75,7 +75,7 @@ typedef unsigned char FT_Byte;
 #endif
 
 constexpr int MAX_RECENT_FONTS = 10;
-static spring::unordered_map<std::pair<std::string, int>, std::pair<std::shared_ptr<FontFace>, float>> recentFontCache;
+static spring::unordered_map<std::pair<std::string, int>, std::pair<std::shared_ptr<FontFace>, float>> pinnedRecentFonts;
 
 static spring::unordered_map<std::string, std::weak_ptr<FontFace>> fontFaceCache;
 static spring::unordered_map<std::string, std::weak_ptr<FontFileBytes>> fontMemCache;
@@ -87,23 +87,23 @@ static void RememberFont(std::shared_ptr<FontFace>& face, const std::string& fil
 
 	float time = spring_gettime().toMilliSecsf();
 
-	auto cached = recentFontCache.find(fontKey);
+	auto cached = pinnedRecentFonts.find(fontKey);
 
-	if (cached != recentFontCache.end()) {
+	if (cached != pinnedRecentFonts.end()) {
 		cached->second.second = time;
 	} else {
-		if (recentFontCache.size() >= MAX_RECENT_FONTS) {
+		if (pinnedRecentFonts.size() >= MAX_RECENT_FONTS) {
 			std::pair<string, int>* oldest;
 			float oldestTime = time;
-			for(auto &it: recentFontCache) {
+			for(auto &it: pinnedRecentFonts) {
 				if (it.second.second <= oldestTime) {
 					oldest = &it.first;
 					oldestTime = it.second.second;
 				}
 			}
-			recentFontCache.erase(*oldest);
+			pinnedRecentFonts.erase(*oldest);
 		}
-		recentFontCache[fontKey] = std::pair<std::shared_ptr<FontFace>, float>(face, time);
+		pinnedRecentFonts[fontKey] = std::pair<std::shared_ptr<FontFace>, float>(face, time);
 	}
 }
 

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -82,7 +82,7 @@ static spring::unordered_map<std::string, std::weak_ptr<FontFileBytes>> fontMemC
 static spring::unordered_set<std::pair<std::string, int>, spring::synced_hash<std::pair<std::string, int>>> invalidFonts;
 static auto cacheMutexes = spring::WrappedSyncRecursiveMutex{};
 
-static void RememberFont(std::shared_ptr<FontFace> &face, const std::string &filename, const int size) {
+static void RememberFont(std::shared_ptr<FontFace>& face, const std::string& filename, const int size) {
 	const auto fontKey = std::make_pair(filename, size);
 
 	float time = spring_gettime().toMilliSecsf();

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -74,13 +74,15 @@
 typedef unsigned char FT_Byte;
 #endif
 
-constexpr int MAX_RECENT_FONTS = 10;
-static spring::unordered_map<std::pair<std::string, int>, std::pair<std::shared_ptr<FontFace>, float>> pinnedRecentFonts;
-
 static spring::unordered_map<std::string, std::weak_ptr<FontFace>> fontFaceCache;
 static spring::unordered_map<std::string, std::weak_ptr<FontFileBytes>> fontMemCache;
 static spring::unordered_set<std::pair<std::string, int>, spring::synced_hash<std::pair<std::string, int>>> invalidFonts;
 static auto cacheMutexes = spring::WrappedSyncRecursiveMutex{};
+
+constexpr int MAX_RECENT_FONTS = 10;
+/* pinnedRecentFonts maintains shared_ptrs to the weak_ptrs from fontFaceCache. This prevents the weak_ptr from expiring
+ * when no other part of the code holds a shared_ptr, as is the case when searching game and system fallback fonts. */
+static spring::unordered_map<std::pair<std::string, int>, std::pair<std::shared_ptr<FontFace>, float>> pinnedRecentFonts;
 
 static void RememberFont(std::shared_ptr<FontFace>& face, const std::string& filename, const int size) {
 	const auto fontKey = std::make_pair(filename, size);

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -74,8 +74,8 @@
 typedef unsigned char FT_Byte;
 #endif
 
-constexpr int MAX_TEMPORAL_FONTS = 10;
-static spring::unordered_map<std::string, std::pair<std::shared_ptr<FontFace>, float>> temporalFontCache;
+constexpr int MAX_RECENT_FONTS = 10;
+static spring::unordered_map<std::string, std::pair<std::shared_ptr<FontFace>, float>> recentFontCache;
 
 static spring::unordered_map<std::string, std::weak_ptr<FontFace>> fontFaceCache;
 static spring::unordered_map<std::string, std::weak_ptr<FontFileBytes>> fontMemCache;
@@ -87,23 +87,23 @@ static void RememberFont(std::shared_ptr<FontFace> &face, const std::string &fil
 
 	float time = spring_gettime().toMilliSecsf();
 
-	auto cached = temporalFontCache.find(fontKey);
+	auto cached = recentFontCache.find(fontKey);
 
-	if (cached != temporalFontCache.end()) {
+	if (cached != recentFontCache.end()) {
 		cached->second.second = time;
 	} else {
-		temporalFontCache[fontKey] = std::pair<std::shared_ptr<FontFace>, float>(face, time);
+		recentFontCache[fontKey] = std::pair<std::shared_ptr<FontFace>, float>(face, time);
 
-		if (temporalFontCache.size() > MAX_TEMPORAL_FONTS) {
+		if (recentFontCache.size() > MAX_RECENT_FONTS) {
 			std::string *oldest;
 			float oldestTime = time;
-			for(auto &it: temporalFontCache) {
+			for(auto &it: recentFontCache) {
 				if (it.second.second < oldestTime) {
 					oldest = &it.first;
 					oldestTime = it.second.second;
 				}
 			}
-			temporalFontCache.erase(*oldest);
+			recentFontCache.erase(*oldest);
 		}
 	}
 }

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -92,19 +92,18 @@ static void RememberFont(std::shared_ptr<FontFace>& face, const std::string& fil
 	if (cached != recentFontCache.end()) {
 		cached->second.second = time;
 	} else {
-		recentFontCache[fontKey] = std::pair<std::shared_ptr<FontFace>, float>(face, time);
-
-		if (recentFontCache.size() > MAX_RECENT_FONTS) {
+		if (recentFontCache.size() >= MAX_RECENT_FONTS) {
 			std::pair<string, int>* oldest;
 			float oldestTime = time;
 			for(auto &it: recentFontCache) {
-				if (it.second.second < oldestTime) {
+				if (it.second.second <= oldestTime) {
 					oldest = &it.first;
 					oldestTime = it.second.second;
 				}
 			}
 			recentFontCache.erase(*oldest);
 		}
+		recentFontCache[fontKey] = std::pair<std::shared_ptr<FontFace>, float>(face, time);
 	}
 }
 

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -138,6 +138,7 @@ public:
 	}
 
 	~FtLibraryHandler() {
+		pinnedRecentFonts.clear();
 		FT_Done_FreeType(lib);
 
 		#ifdef USE_FONTCONFIG

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -79,7 +79,7 @@ static spring::unordered_map<std::string, std::weak_ptr<FontFileBytes>> fontMemC
 static spring::unordered_set<std::pair<std::string, int>, spring::synced_hash<std::pair<std::string, int>>> invalidFonts;
 static auto cacheMutexes = spring::WrappedSyncRecursiveMutex{};
 
-constexpr int MAX_RECENT_FONTS = 10;
+constexpr int MAX_PINNED_FONTS = 10;
 struct TimestampedFont { std::shared_ptr<FontFace> fontFace; float timestamp; };
 
 /* pinnedRecentFonts maintains shared_ptrs to the weak_ptrs from fontFaceCache. This prevents the weak_ptr from expiring
@@ -96,7 +96,7 @@ static void PinFont(std::shared_ptr<FontFace>& face, const std::string& filename
 	if (cached != pinnedRecentFonts.end()) {
 		cached->second.timestamp = time;
 	} else {
-		if (pinnedRecentFonts.size() >= MAX_RECENT_FONTS) {
+		if (pinnedRecentFonts.size() >= MAX_PINNED_FONTS) {
 			std::pair<string, int>* oldest;
 			float oldestTime = time;
 			for(auto &[key, timestampedFont]: pinnedRecentFonts) {

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -82,7 +82,7 @@ static spring::unordered_map<std::string, std::weak_ptr<FontFileBytes>> fontMemC
 static spring::unordered_set<std::pair<std::string, int>, spring::synced_hash<std::pair<std::string, int>>> invalidFonts;
 static auto cacheMutexes = spring::WrappedSyncRecursiveMutex{};
 
-static void RememberFont(std::shared_ptr<FontFace> face, const std::string &filename, const int size) {
+static void RememberFont(std::shared_ptr<FontFace> &face, const std::string &filename, const int size) {
 	const auto fontKey = filename + IntToString(size);
 
 	float time = spring_gettime().toMilliSecsf();

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -97,10 +97,10 @@ static void RememberFont(std::shared_ptr<FontFace>& face, const std::string& fil
 		if (pinnedRecentFonts.size() >= MAX_RECENT_FONTS) {
 			std::pair<string, int>* oldest;
 			float oldestTime = time;
-			for(auto &it: pinnedRecentFonts) {
-				if (it.second.second <= oldestTime) {
-					oldest = &it.first;
-					oldestTime = it.second.second;
+			for(auto &[key, timestamp]: pinnedRecentFonts) {
+				if (timestamp.second <= oldestTime) {
+					oldest = &key;
+					oldestTime = timestamp.second;
 				}
 			}
 			pinnedRecentFonts.erase(*oldest);

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -86,7 +86,7 @@ struct TimestampedFont { std::shared_ptr<FontFace> fontFace; float timestamp; };
  * when no other part of the code holds a shared_ptr, as is the case when searching game and system fallback fonts. */
 static spring::unordered_map<std::pair<std::string, int>, TimestampedFont> pinnedRecentFonts;
 
-static void RememberFont(std::shared_ptr<FontFace>& face, const std::string& filename, const int size) {
+static void PinFont(std::shared_ptr<FontFace>& face, const std::string& filename, const int size) {
 	const auto fontKey = std::make_pair(filename, size);
 
 	float time = spring_gettime().toMilliSecsf();
@@ -593,7 +593,7 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 			if (blackList.find(GetFaceKey(*face)) != blackList.cend())
 				continue;
 
-			RememberFont(face, filename, origSize);
+			PinFont(face, filename, origSize);
 
 			#ifdef _DEBUG
 			{

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -75,7 +75,7 @@ typedef unsigned char FT_Byte;
 #endif
 
 constexpr int MAX_RECENT_FONTS = 10;
-static spring::unordered_map<std::string, std::pair<std::shared_ptr<FontFace>, float>> recentFontCache;
+static spring::unordered_map<std::pair<std::string, int>, std::pair<std::shared_ptr<FontFace>, float>> recentFontCache;
 
 static spring::unordered_map<std::string, std::weak_ptr<FontFace>> fontFaceCache;
 static spring::unordered_map<std::string, std::weak_ptr<FontFileBytes>> fontMemCache;
@@ -83,7 +83,7 @@ static spring::unordered_set<std::pair<std::string, int>, spring::synced_hash<st
 static auto cacheMutexes = spring::WrappedSyncRecursiveMutex{};
 
 static void RememberFont(std::shared_ptr<FontFace> &face, const std::string &filename, const int size) {
-	const auto fontKey = filename + IntToString(size);
+	const auto fontKey = std::make_pair(filename, size);
 
 	float time = spring_gettime().toMilliSecsf();
 
@@ -95,7 +95,7 @@ static void RememberFont(std::shared_ptr<FontFace> &face, const std::string &fil
 		recentFontCache[fontKey] = std::pair<std::shared_ptr<FontFace>, float>(face, time);
 
 		if (recentFontCache.size() > MAX_RECENT_FONTS) {
-			std::string *oldest;
+			std::pair<string, int>* oldest;
 			float oldestTime = time;
 			for(auto &it: recentFontCache) {
 				if (it.second.second < oldestTime) {

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -864,7 +864,6 @@ bool CFontTexture::ClearGlyphs() {
 
 		// clear all glyps
 		glyphs.clear();
-		fallbackFonts.clear();
 
 		// clear atlases
 		ClearAtlases(32, 32);
@@ -1168,15 +1167,6 @@ void CFontTexture::LoadGlyph(std::shared_ptr<FontFace>& f, char32_t ch, unsigned
 	if (slot->bitmap.pitch != width) {
 		LOG_L(L_ERROR, "invalid pitch");
 		return;
-	}
-
-	if (shFace->face != f->face) {
-		auto it = std::find_if(fallbackFonts.begin(), fallbackFonts.end(), [&](std::shared_ptr<FontFace> const& p) {
-			return p->face == f->face;
-		});
-		if (it == fallbackFonts.end()) {
-			fallbackFonts.emplace_back(f);
-		}
 	}
 
 	// store glyph bitmap (index) in allocator until the next LoadWantedGlyphs call

--- a/rts/Rendering/Fonts/CFontTexture.h
+++ b/rts/Rendering/Fonts/CFontTexture.h
@@ -200,7 +200,6 @@ private:
 	CBitmap atlasUpdateShadow;
 
 	static std::vector<char32_t> nonPrintableRanges;
-	std::vector<std::shared_ptr<FontFace>> fallbackFonts;
 public:
 	auto GetGlyphs() const -> const decltype(glyphs) { return glyphs; }
 	auto GetGlyphs()       ->       decltype(glyphs) { return glyphs; }

--- a/rts/Rendering/Fonts/CFontTexture.h
+++ b/rts/Rendering/Fonts/CFontTexture.h
@@ -200,6 +200,7 @@ private:
 	CBitmap atlasUpdateShadow;
 
 	static std::vector<char32_t> nonPrintableRanges;
+	std::vector<std::shared_ptr<FontFace>> fallbackFonts;
 public:
 	auto GetGlyphs() const -> const decltype(glyphs) { return glyphs; }
 	auto GetGlyphs()       ->       decltype(glyphs) { return glyphs; }


### PR DESCRIPTION
### Work Done

- Add a general list of recently used FontFace references.

### Rationale

- At the moment non-main fonts don't get any shared_ptr stored, so they get immediately evicted from LoadFontFace caches.
   - happens to game fallback fonts, that get used to load extra glyphs.
   - and also other fonts (system fallbacks) that don't get used, but get loaded while searching.
- This is very bad since some methods like SplitTextInWords call GetTextWidth, eventually loading fonts all the time when needing new glyphs (and doing so incrementally: increasing the sentence by 1 char each time, in a worst case scenario kind of usage relative to fallback searches).
   - loading fonts is an expensive operation
- Caching infrastructure is already in place, but need to pin the shared_ptr somewhere, either while we expect the font to still be used, or keeping a number of "hot" fonts, otherwise the weak_ptrs expire.

### Remarks

- I introduce a constant to control how many fonts we are temporarily force-caching, this can be made into a config option, but for now I want to make sure the approach is ok, if so let me know here and I will add the config option.
- I had to implement my own LRU strategy, I noticed we have LRUClockCache, but didn't seem to fit too well here, let me know if you would prefer that one to be used, or can think of some other alternative way.