### PR TITLE
Add several config variables to control fontconfig inner workings.

### DIFF
--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -150,6 +150,10 @@ public:
 			ScopedOnceTimer timer(msg);
 			ZoneScopedNC("FtLibraryHandler::FontConfigInit", tracy::Color::Purple);
 
+			searchSystemFonts = configHandler->GetBool("UseFontConfigSystemFonts");
+			searchFontAttributes = configHandler->GetBool("FontConfigSearchAttributes");
+			searchApplySubstitutions = configHandler->GetBool("FontConfigApplySubstitutions");
+
 			FcBool res;
 			std::string errprefix = fmt::sprintf("[%s] Fontconfig(version %d.%d.%d) failed to initialize", __func__, FC_MAJOR, FC_MINOR, FC_REVISION);
 
@@ -286,6 +290,15 @@ public:
 		FcPatternDestroy(singleton->basePattern);
 		singleton->basePattern = FcPatternCreate();
 	}
+	static bool GetSearchSystemFonts() {
+		return singleton->searchSystemFonts;
+	}
+	static bool GetSearchFontAttributes() {
+		return singleton->searchFontAttributes;
+	}
+	static bool GetSearchApplySubstitutions() {
+		return singleton->searchApplySubstitutions;
+	}
 	#endif
 private:
 	FcConfig* config;
@@ -294,6 +307,9 @@ private:
 	FcFontSet *gameFontSet;
 	FcPattern *basePattern;
 	#endif
+	bool searchSystemFonts;
+	bool searchFontAttributes;
+	bool searchApplySubstitutions;
 
 	static inline std::unique_ptr<FtLibraryHandler> singleton = nullptr;
 };
@@ -485,19 +501,20 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 			[](FcBlanks* b) { if (b) FcBlanksDestroy(b); }
 		);
 
-		auto origPattern = spring::ScopedResource(
-			FcFreeTypeQueryFace(origFace, ftname, 0, blanks),
-			[](FcPattern* p) { if (p) FcPatternDestroy(p); }
-		);
+		if (FtLibraryHandler::GetSearchFontAttributes()) {
+			auto origPattern = spring::ScopedResource(
+				FcFreeTypeQueryFace(origFace, ftname, 0, blanks),
+				[](FcPattern* p) { if (p) FcPatternDestroy(p); }
+			);
 
-		if (origPattern != nullptr) {
-			FcPatternGetInteger(origPattern, FC_WEIGHT    , 0, &weight );
-			FcPatternGetInteger(origPattern, FC_SLANT     , 0, &slant  );
-			FcPatternGetBool(   origPattern, FC_OUTLINE   , 0, &outline);
-			FcPatternGetDouble( origPattern, FC_PIXEL_SIZE, 0, &pixelSize);
+			if (origPattern != nullptr) {
+				FcPatternGetInteger(origPattern, FC_WEIGHT    , 0, &weight );
+				FcPatternGetInteger(origPattern, FC_SLANT     , 0, &slant  );
+				FcPatternGetBool(   origPattern, FC_OUTLINE   , 0, &outline);
+				FcPatternGetDouble( origPattern, FC_PIXEL_SIZE, 0, &pixelSize);
 
-			FcPatternGetString( origPattern, FC_FAMILY , 0, &family );
-
+				FcPatternGetString( origPattern, FC_FAMILY , 0, &family );
+			}
 		}
 
 		FcPatternAddInteger(pattern, FC_WEIGHT, weight);
@@ -512,7 +529,7 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 	}
 
 	FcDefaultSubstitute(pattern);
-	if (!FcConfigSubstitute(FtLibraryHandler::GetFCConfig(), pattern, FcMatchPattern))
+	if (FtLibraryHandler::GetSearchApplySubstitutions() && !FcConfigSubstitute(FtLibraryHandler::GetFCConfig(), pattern, FcMatchPattern))
 	{
 		return nullptr;
 	}
@@ -521,7 +538,7 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 	typedef std::unique_ptr<FcFontSet, decltype(&FcFontSetDestroy)> ScopedFcFontSet;
 
 	int nFonts = 0;
-	bool loadMore = true;
+	bool loadMore = FtLibraryHandler::GetSearchSystemFonts();
 	FcResult res;
 
 	// first search game fonts

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -107,6 +107,9 @@ CONFIG(unsigned, TextureMemPoolSize).defaultValue(512).minimumValue(0).descripti
 CONFIG(bool, UseLuaMemPools).defaultValue(true).description("Whether Lua VM memory allocations are made from pools.");
 CONFIG(bool, UseHighResTimer).defaultValue(false).description("On Windows, sets whether Spring will use low- or high-resolution timer functions for tasks like graphical interpolation between game frames.");
 CONFIG(bool, UseFontConfigLib).defaultValue(true).description("Whether the system fontconfig library (if present and enabled at compile-time) should be used for handling fonts.");
+CONFIG(bool, UseFontConfigSystemFonts).defaultValue(true).description("Whether the system fonts will be searched by fontconfig.");
+CONFIG(bool, FontConfigSearchAttributes).defaultValue(true).description("Whether the font characteristics will used to refine the search by fontconfig.");
+CONFIG(bool, FontConfigApplySubstitutions).defaultValue(true).description("Whether fontconfig config substitutions will take place while searching.");
 CONFIG(int, MaxFontTries).defaultValue(5).description("Represents the maximum number of attempts to search for a glyph replacement using the FontConfig library (lower = foreign glyphs may fail to render, higher = searching for foreign glyphs can lag the game).");
 
 CONFIG(std::string, name).defaultValue(UnnamedPlayerName).description("Sets your name in the game. Since this is overridden by lobbies with your lobby username when playing, it usually only comes up when viewing replays or starting the engine directly for testing purposes.");


### PR DESCRIPTION
### Work done

Added the following bool config variables:
- UseFontConfigSystemFonts: Search system fonts for fallbacks.
- FontConfigSearchAttributes: Try to match provided font attributes for fallbacks.
- FontConfigApplySubstitutions: Apply pattern config substitutions.

### Remarks

- These control expensive parts of the fallback search mechanism.
- The idea is to allow more granular control over different more expensive mechanisms so in case of some critical bug, functionality can be disabled in parts, preserving critical parts (game fallbacks).

### Rationale

My idea here is to allow an alternative to blanket UseFontConfigLib=0. Using that will make the engine unable to load game defined fallbacks, thus rendering some (theoretically supported by the application) languages completely unusable.

While investigating long processing time while rendering certain texts, I noticed these take the most time:

1. FT_New_Memory_Face (order A, 38%)
2. FcFontSort (order A, 28%)
3. FcFreeTypeQueryFace (order A*B, 16%)
4. FcConfigSubstitute (order A*B, 15%)

Ideas for each of them from the perspective of this PR:

* For (1), there is now #2011 aiming to fix that.
* (2) is used when searching over the system fonts. UseFontConfigSystemFonts above controls access to this.
* (3) and (4) are used when refining font patterns to search for when looking for fallback fonts.
  * I'm not really sure these two are actually providing any actual value.
  * (3) was actually broken until yesterday due to #2009
  * (4) is an obscure part of the fontconfig api, and honestly don't really know if we need it due to our usage. Having config control over this can help in testing.

### Other problems not tackled yet

Note there is another problem exacerbating all of these, specially (3) and (4), and that is, the way the api is currently used means while looking for fallback glyphs, the code is recreating the pattern and searching again on each iteration in the loop.

For example, if it searches 3 fonts before reaching the right one, it's going to run (3) and (4) 3 times, and (2) could be run more times too, but just when game fallback fonts have been exhausted. This what "order B" above refers to (usually will be low, but will increase as more fallback fonts are added).

Additionally, on a higher level, some methods like CTextWrap::SplitTextInWords incrementally build text strings, adding a character at a time inside a loop, this results in calling LoadWantedGlyphs many times, each time with one extra character.  This is "order A" (results in a number of calls equal to the distinct new glyphs in the given text).