### PR TITLE
Perform an early glyph match with the fontconfig pattern glyphs.

### DIFF
--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -550,12 +550,11 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 		if (r != FcResultMatch || cFilename == nullptr)
 			continue;
 
-		FcCharSet *patternCharSet = FcCharSetCreate();
+		FcCharSet *patternCharSet;
 		r = FcPatternGetCharSet(font, FC_CHARSET, 0, &patternCharSet);
 		if (r != FcResultMatch || FcCharSetIntersectCount(cset, patternCharSet) == 0) {
 			continue;
 		}
-		FcCharSetDestroy(patternCharSet);
 
 		const std::string filename = std::string{ reinterpret_cast<char*>(cFilename) };
 

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -550,6 +550,13 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 		if (r != FcResultMatch || cFilename == nullptr)
 			continue;
 
+		FcCharSet *patternCharSet = FcCharSetCreate();
+		r = FcPatternGetCharSet(font, FC_CHARSET, 0, &patternCharSet);
+		if (r != FcResultMatch || FcCharSetIntersectCount(cset, patternCharSet) == 0) {
+			continue;
+		}
+		FcCharSetDestroy(patternCharSet);
+
 		const std::string filename = std::string{ reinterpret_cast<char*>(cFilename) };
 
 		if (invalidFonts.find(std::make_pair(filename, origSize)) != invalidFonts.end()) //this font is known to error out

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -552,9 +552,8 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 
 		FcCharSet *patternCharSet;
 		r = FcPatternGetCharSet(font, FC_CHARSET, 0, &patternCharSet);
-		if (r != FcResultMatch || FcCharSetIntersectCount(cset, patternCharSet) == 0) {
+		if (r != FcResultMatch || FcCharSetIntersectCount(cset, patternCharSet) == 0)
 			continue;
-		}
 
 		const std::string filename = std::string{ reinterpret_cast<char*>(cFilename) };
 


### PR DESCRIPTION
### Work done

- Perform an intersection of the searched glyphs against the fontconfig pattern glyphs


### Remarks

- This avoids expensive computations (like actually loading the font with freetype) just to see the glyph isn't there.
- The information is already present in the fontconfig pattern returned by FcFontSetSort and FcFontSort.
