### PR TITLE
Lua: Clean up use of Facing enum

### DIFF
--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -651,7 +651,7 @@ bool CSyncedLuaHandle::AllowCommand(const CUnit* unit, const Command& cmd, int p
  * @param x number
  * @param y number
  * @param z number
- * @param facing number
+ * @param facing FacingInteger
  * @return boolean allow, boolean dropOrder
  */
 std::pair <bool, bool> CSyncedLuaHandle::AllowUnitCreation(

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -1394,7 +1394,7 @@ int LuaSyncedRead::GetVectorFromHeading(lua_State* L)
 /***
  * @function Spring.GetFacingFromHeading
  * @param heading number
- * @return number facing
+ * @return FacingInteger facing
  */
 int LuaSyncedRead::GetFacingFromHeading(lua_State* L)
 {
@@ -1404,7 +1404,7 @@ int LuaSyncedRead::GetFacingFromHeading(lua_State* L)
 
 /***
  * @function Spring.GetHeadingFromFacing
- * @param facing number
+ * @param facing FacingInteger
  * @return number heading
  */
 int LuaSyncedRead::GetHeadingFromFacing(lua_State* L)

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -1020,7 +1020,7 @@ int LuaUnsyncedCtrl::AddWorldText(lua_State* L)
  * @param posY number
  * @param posZ number
  * @param teamID integer
- * @param facing number
+ * @param facing FacingInteger
  * @return nil
  */
 int LuaUnsyncedCtrl::AddWorldUnit(lua_State* L)
@@ -3588,7 +3588,7 @@ int LuaUnsyncedCtrl::SetBuildSpacing(lua_State* L)
 /***
  *
  * @function Spring.SetBuildFacing
- * @param facing number
+ * @param facing FacingInteger
  * @return nil
  */
 int LuaUnsyncedCtrl::SetBuildFacing(lua_State* L)

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3431,7 +3431,11 @@ int LuaUnsyncedRead::GetCmdDescIndex(lua_State* L)
 /******************************************************************************/
 
 /***
- * @alias Facing
+ * Facing direction represented as an integer only.
+ * 
+ * @see Facing
+ * 
+ * @alias FacingInteger
  * | 0 # South
  * | 1 # East
  * | 2 # North
@@ -3441,7 +3445,7 @@ int LuaUnsyncedRead::GetCmdDescIndex(lua_State* L)
 /***
  *
  * @function Spring.GetBuildFacing
- * @return Facing buildFacing
+ * @return FacingInteger buildFacing
  */
 int LuaUnsyncedRead::GetBuildFacing(lua_State* L)
 {

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -1157,6 +1157,10 @@ void LuaUtils::ParseCommandArray(
 }
 
 /***
+ * Facing direction represented by a string or number.
+ * 
+ * @see FacingInteger
+ * 
  * @alias Facing
  * | 0 # South
  * | 1 # East
@@ -1181,11 +1185,10 @@ int LuaUtils::ParseFacing(lua_State* L, const char* caller, int index)
 		const char* dir = lua_tostring(L, index);
 
 		switch (dir[0]) {
-			case 'S': case 's': { return 0; } break;
-			case 'E': case 'e': { return 1; } break;
-			case 'N': case 'n': { return 2; } break;
-			case 'W': case 'w': { return 3; } break;
-			default           : {           } break;
+			case 'S': case 's': return FACING_SOUTH;
+			case 'E': case 'e': return FACING_EAST;
+			case 'N': case 'n': return FACING_NORTH;
+			case 'W': case 'w': return FACING_WEST;
 		}
 
 		luaL_error(L, "%s(): bad facing string \"%s\"", caller, dir);


### PR DESCRIPTION
- Fix duplicate `@alias Facing` definition:
  - Create `FacingInteger` with `0|1|2|3`.
  - Keep `Facing` alias which accepts various strings.
- Update Lua doc annotations to accept the correct aliases.
- Use C++ `FACING_*` enum in `ParseFacing`.
---
This one contains minor C++ cleanup so I'd prefer a review before merging.