### PR TITLE
Fix a printf format warning

### DIFF
--- a/rts/Game/PreGame.cpp
+++ b/rts/Game/PreGame.cpp
@@ -1,5 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
+#include <cinttypes>
 #include <cfloat>
 #include <functional>
 
@@ -327,7 +328,7 @@ void CPreGame::StartServer(const std::string& setupscript)
 		archiveScanner->WriteCache(); // write the cache, useful in case the game loading crashes afterwards
 
 		LOG("[PreGame::%s]\n\tmod-checksum=%s\n\tmap-checksum=%s", __func__, modChecksumHex.data(), mapChecksumHex.data());
-		LOG("[PreGame::%s] Game/Map archives checksum acquisition took = %ld microseconds", __func__, (spring_gettime() - connectTimer).toMilliSecsi());
+		LOG("[PreGame::%s] Game/Map archives checksum acquisition took = %" PRId64 " microseconds", __func__, (spring_gettime() - connectTimer).toMilliSecsi());
 
 		archiveScanner->WriteCache();
 	}


### PR DESCRIPTION
`std::int64_t` can be either `long` or `long long` depending on compiler etc., so cannot assume one or the other via `%ld` or `%lld`.