### PR TITLE
Don't draw ghost worldview icons for 'iconsAsUI 0'.

### DIFF
--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -528,13 +528,6 @@ void CUnitDrawerGLSL::DrawUnitIcons() const
 
 			unit->iconRadius = DrawUnitIcon(rb, icon, unit->iconRadius, pos, color, unit->radius);
 		}
-		for (const auto& ghost : ghosts) {
-			float3 pos = ghost->midPos;
-
-			const uint8_t* color = teamHandler.Team(ghost->team)->color;
-
-			DrawUnitIcon(rb, icon, ghost->iconRadius, pos, color, ghost->radius);
-		}
 
 		rb.Submit(GL_TRIANGLES);
 	}


### PR DESCRIPTION
### Work done

- Remove drawing of ghost icons when ScreenIcons is disabled.


### Related issues

- https://github.com/beyond-all-reason/spring/issues/2031