### PR TITLE
Deprecate AdvUnitShading setting and /AdvModelShading runtime switch.

### DIFF
--- a/cont/base/springcontent/shaders/GLSL/ModelFragProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ModelFragProg.glsl
@@ -26,10 +26,6 @@
 	varying vec4 vertexWorldPos;
 	varying vec3 cameraDir;
 	varying float fogFactor;
-#ifdef use_normalmapping
-	uniform sampler2D normalMap;
-	varying mat3 tbnMatrix;
-#else
 	varying vec3 normalv;
 #endif
 
@@ -74,8 +70,8 @@ vec3 DynamicLighting(vec3 normal, vec3 diffuse, vec3 specular) {
 
 		lightScale *= float(vectorDot >= cutoffDot);
 
-		rgb += (lightScale *                                  gl_LightSource[BASE_DYNAMIC_MODEL_LIGHT + i].ambient.rgb);
-		rgb += (lightScale * lightAttenuation * (diffuse.rgb * gl_LightSource[BASE_DYNAMIC_MODEL_LIGHT + i].diffuse.rgb * lightCosAngDiff));
+		rgb += (lightScale *                                    gl_LightSource[BASE_DYNAMIC_MODEL_LIGHT + i].ambient.rgb);
+		rgb += (lightScale * lightAttenuation * (diffuse.rgb  * gl_LightSource[BASE_DYNAMIC_MODEL_LIGHT + i].diffuse.rgb * lightCosAngDiff));
 		rgb += (lightScale * lightAttenuation * (specular.rgb * gl_LightSource[BASE_DYNAMIC_MODEL_LIGHT + i].specular.rgb * pow(lightCosAngSpec, 4.0)));
 	}
 

--- a/cont/base/springcontent/shaders/GLSL/ModelVertProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ModelVertProg.glsl
@@ -6,7 +6,6 @@
 varying vec4 vertexWorldPos;
 varying vec3 cameraDir;
 varying float fogFactor;
-
 varying vec3 normalv;
 
 #if (USE_SHADOWS == 1)

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -403,31 +403,6 @@ public:
 	}
 };
 
-
-
-class AdvModelShadingActionExecutor : public IUnsyncedActionExecutor {
-public:
-	AdvModelShadingActionExecutor() : IUnsyncedActionExecutor("AdvModelShading",
-			"Control advanced model shading mode",
-			false, {
-			{"", "Toggles advanced model shading mode"},
-			{"<on|off>", "Set advanced model shading mode <on|off>"},
-			}) {}
-
-	bool Execute(const UnsyncedAction& action) const {
-		static bool canUseShaders = unitDrawer->UseAdvShading();
-
-		if (!canUseShaders)
-			return false;
-
-		InverseOrSetBool(unitDrawer->UseAdvShadingRef(), action.GetArgs());
-		LogSystemStatus("model shaders", unitDrawer->UseAdvShading());
-		return true;
-	}
-};
-
-
-
 class AdvMapShadingActionExecutor : public IUnsyncedActionExecutor {
 public:
 	AdvMapShadingActionExecutor() : IUnsyncedActionExecutor("AdvMapShading",
@@ -3939,7 +3914,6 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<MapMeshDrawerActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<MapBorderActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<WaterActionExecutor>());
-	AddActionExecutor(AllocActionExecutor<AdvModelShadingActionExecutor>()); // [maint]
 	AddActionExecutor(AllocActionExecutor<AdvMapShadingActionExecutor>()); // [maint]
 	AddActionExecutor(AllocActionExecutor<UnitDrawerTypeActionExecutor>()); // [maint]
 	AddActionExecutor(AllocActionExecutor<FeatureDrawerTypeActionExecutor>()); // [maint]

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -2479,7 +2479,7 @@ int LuaUnsyncedRead::HaveShadows(lua_State* L)
  */
 int LuaUnsyncedRead::HaveAdvShading(lua_State* L)
 {
-	lua_pushboolean(L, unitDrawer->UseAdvShading());
+	lua_pushboolean(L, true);
 	lua_pushboolean(L, readMap->GetGroundDrawer()->UseAdvShading());
 	return 2;
 }

--- a/rts/Rendering/Common/ModelDrawer.cpp
+++ b/rts/Rendering/Common/ModelDrawer.cpp
@@ -14,7 +14,7 @@ void CModelDrawerConcept::InitStatic()
 	if (initialized)
 		return;
 
-	advShading = configHandler->GetBool("AdvUnitShading") && cubeMapHandler.Init();
+	cubeMapHandler.Init();
 	wireFrameMode = false;
 
 	lightHandler.Init(2U, configHandler->GetInt("MaxDynamicModelLights"));

--- a/rts/Rendering/Common/ModelDrawer.h
+++ b/rts/Rendering/Common/ModelDrawer.h
@@ -37,7 +37,6 @@ public:
 	static void InitStatic();
 	static void KillStatic(bool reload);
 public:
-	static bool  UseAdvShading() { return advShading; }
 	static bool  DeferredAllowed() { return deferredAllowed; }
 	static bool& WireFrameModeRef() { return wireFrameMode; }
 public:
@@ -48,10 +47,7 @@ public:
 	static GL::GeometryBuffer* GetGeometryBuffer() { return geomBuffer; }
 protected:
 	inline static bool initialized = false;
-
-	inline static bool advShading = false;
 	inline static bool wireFrameMode = false;
-
 	inline static bool deferredAllowed = false;
 protected:
 	inline static GL::LightHandler lightHandler;
@@ -86,7 +82,6 @@ public:
 	}
 public:
 	// Set/Get state from outside
-	static bool& UseAdvShadingRef() { reselectionRequested = true; return advShading; }
 	static bool& WireFrameModeRef() { return wireFrameMode; }
 
 	static int  PreferedDrawerType() { return preferedDrawerType; }
@@ -250,11 +245,6 @@ inline void CModelDrawerBase<TDrawerData, TDrawer>::SelectImplementation(bool fo
 {
 	if (!forceReselection)
 		return;
-
-	if (!advShading) {
-		SelectImplementation(ModelDrawerTypes::MODEL_DRAWER_GLSL);
-		return;
-	}
 
 	const auto qualifyDrawerFunc = [legacy, modern](const TDrawer* d, const IModelDrawerState* s) -> bool {
 		if (d == nullptr || s == nullptr)

--- a/rts/Rendering/Common/ModelDrawerHelpers.cpp
+++ b/rts/Rendering/Common/ModelDrawerHelpers.cpp
@@ -48,15 +48,13 @@ void CModelDrawerHelper::EnableTexturesCommon()
 		glActiveTexture(GL_TEXTURE3); glBindTexture(GL_TEXTURE_2D, shadowHandler.GetColorTextureID());
 	}
 
-	if (CModelDrawerConcept::UseAdvShading()) {
-		glActiveTexture(GL_TEXTURE4);
-		glEnable(GL_TEXTURE_CUBE_MAP);
-		glBindTexture(GL_TEXTURE_CUBE_MAP, cubeMapHandler.GetEnvReflectionTextureID());
+	glActiveTexture(GL_TEXTURE4);
+	glEnable(GL_TEXTURE_CUBE_MAP);
+	glBindTexture(GL_TEXTURE_CUBE_MAP, cubeMapHandler.GetEnvReflectionTextureID());
 
-		glActiveTexture(GL_TEXTURE5);
-		glEnable(GL_TEXTURE_CUBE_MAP);
-		glBindTexture(GL_TEXTURE_CUBE_MAP, cubeMapHandler.GetSpecularTextureID());
-	}
+	glActiveTexture(GL_TEXTURE5);
+	glEnable(GL_TEXTURE_CUBE_MAP);
+	glBindTexture(GL_TEXTURE_CUBE_MAP, cubeMapHandler.GetSpecularTextureID());
 
 	glActiveTexture(GL_TEXTURE0);
 	glEnable(GL_TEXTURE_2D);
@@ -71,13 +69,11 @@ void CModelDrawerHelper::DisableTexturesCommon()
 	if (shadowHandler.ShadowsLoaded())
 		shadowHandler.ResetShadowTexSampler(GL_TEXTURE2, true);
 
-	if (CModelDrawerConcept::UseAdvShading()) {
-		glActiveTexture(GL_TEXTURE3);
-		glDisable(GL_TEXTURE_CUBE_MAP);
+	glActiveTexture(GL_TEXTURE3);
+	glDisable(GL_TEXTURE_CUBE_MAP);
 
-		glActiveTexture(GL_TEXTURE4);
-		glDisable(GL_TEXTURE_CUBE_MAP);
-	}
+	glActiveTexture(GL_TEXTURE4);
+	glDisable(GL_TEXTURE_CUBE_MAP);
 
 	glActiveTexture(GL_TEXTURE0);
 	glDisable(GL_TEXTURE_2D);

--- a/rts/Rendering/Common/ModelDrawerState.cpp
+++ b/rts/Rendering/Common/ModelDrawerState.cpp
@@ -13,7 +13,6 @@
 #include "Rendering/Env/SkyLight.h"
 #include "Rendering/GL/GeometryBuffer.h"
 #include "Rendering/GL/myGL.h"
-#include "Rendering/Common/ModelDrawer.h"
 #include "Rendering/Common/ModelDrawerHelpers.h"
 #include "Rendering/Shaders/ShaderHandler.h"
 #include "Rendering/Shaders/Shader.h"
@@ -102,10 +101,10 @@ void IModelDrawerState::ResetAlphaDrawing(bool deferredPass) const
 CModelDrawerStateGLSL::CModelDrawerStateGLSL()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	// if (!CanEnable())
-	// 	return;
+	if (!CanEnable())
+		return;
 
-	#define sh shaderHandler
+	auto* sh = shaderHandler;
 
 	const GL::LightHandler* lightHandler = CModelDrawerConcept::GetLightHandler();
 	static const std::string shaderNames[MODEL_SHADER_COUNT] = {
@@ -159,8 +158,6 @@ CModelDrawerStateGLSL::CModelDrawerStateGLSL()
 
 	// make the active shader non-NULL
 	SetActiveShader(shadowHandler.ShadowsLoaded(), false);
-
-	#undef sh
 }
 
 CModelDrawerStateGLSL::~CModelDrawerStateGLSL()
@@ -171,7 +168,7 @@ CModelDrawerStateGLSL::~CModelDrawerStateGLSL()
 	shaderHandler->ReleaseProgramObjects(PO_CLASS);
 }
 
-bool CModelDrawerStateGLSL::CanEnable() const { return CModelDrawerConcept::UseAdvShading(); }
+bool CModelDrawerStateGLSL::CanEnable() const { return true; }
 bool CModelDrawerStateGLSL::CanDrawDeferred() const { return CModelDrawerConcept::DeferredAllowed(); }
 
 bool CModelDrawerStateGLSL::SetTeamColor(int team, float alpha) const
@@ -241,9 +238,9 @@ CModelDrawerStateGL4::CModelDrawerStateGL4()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (!CanEnable())
-	return;
+		return;
 
-	#define sh shaderHandler
+	auto* sh = shaderHandler;
 
 	static const std::string shaderNames[MODEL_SHADER_COUNT] = {
 		"ModelShaderGL4-NoShadowStandard",
@@ -286,7 +283,7 @@ CModelDrawerStateGL4::~CModelDrawerStateGL4()
 	shaderHandler->ReleaseProgramObjects(PO_CLASS);
 }
 
-bool CModelDrawerStateGL4::CanEnable() const { return globalRendering->haveGL4 && CModelDrawerConcept::UseAdvShading(); }
+bool CModelDrawerStateGL4::CanEnable() const { return globalRendering->haveGL4; }
 bool CModelDrawerStateGL4::CanDrawDeferred() const { return CModelDrawerConcept::DeferredAllowed(); }
 
 bool CModelDrawerStateGL4::SetTeamColor(int team, float alpha) const

--- a/rts/Rendering/Env/CubeMapHandler.cpp
+++ b/rts/Rendering/Env/CubeMapHandler.cpp
@@ -135,8 +135,6 @@ void CubeMapHandler::Free() {
 void CubeMapHandler::UpdateReflectionTexture()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (!unitDrawer->UseAdvShading() && !readMap->GetGroundDrawer()->UseAdvShading())
-		return;
 
 	// NOTE:
 	//   we unbind later in WorldDrawer::GenerateIBLTextures() to save render
@@ -250,8 +248,6 @@ void CubeMapHandler::CreateReflectionFace(unsigned int glFace, bool skyOnly)
 void CubeMapHandler::UpdateSpecularTexture()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (!unitDrawer->UseAdvShading())
-		return;
 
 	glBindTexture(GL_TEXTURE_CUBE_MAP, specularTexID);
 

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -66,7 +66,7 @@ CONFIG(int, MaxDynamicModelLights)
 	.defaultValue(1)
 	.minimumValue(0);
 
-CONFIG(bool, AdvUnitShading).defaultValue(true).headlessValue(false).safemodeValue(false).description("Determines whether specular highlights and other lighting effects are rendered for units.");
+CONFIG(bool, AdvUnitShading).deprecated(true);
 
 /***********************************************************************/
 


### PR DESCRIPTION
There is practically very little perf difference between the two states.
Fixes https://github.com/beyond-all-reason/spring/issues/2027