### PR TITLE
Implement content cache cleanup and fix poolFiles being indexed by the content filename rather than pool filename (content filenames will get repeated in different SDPs)

### DIFF
--- a/rts/System/FileSystem/ArchiveScanner.cpp
+++ b/rts/System/FileSystem/ArchiveScanner.cpp
@@ -31,6 +31,7 @@
 #include "System/Log/ILog.h"
 #include "System/Threading/SpringThreading.h"
 #include "System/UnorderedMap.hpp"
+#include "System/UnorderedSet.hpp"
 
 #if !defined(DEDICATED) && !defined(UNITSYNC)
 	#include "System/TimeProfiler.h"
@@ -56,7 +57,7 @@ LOG_REGISTER_SECTION_GLOBAL(LOG_SECTION_ARCHIVESCANNER)
  * but mapping them all, every time to make the list is)
  */
 
-constexpr static int INTERNAL_VER = 19;
+constexpr static int INTERNAL_VER = 20;
 
 
 /*
@@ -574,16 +575,16 @@ bool CArchiveScanner::CheckCompression(const IArchive* ar, const std::string& fu
 		if (ar->HasLowReadingCost(fid))
 			continue;
 
-		auto fi = ar->FileInfo(fid);
+		const auto& fn = ar->FileName(fid);
 
-		switch (GetMetaFileClass(StringToLower(fi.fileName))) {
+		switch (GetMetaFileClass(StringToLower(fn))) {
 			case 1: {
-				error += "reading primary meta-file " + fi.fileName + " too expensive; ";
+				error += "reading primary meta-file " + fn + " too expensive; ";
 				error += "please repack this archive with non-solid compression";
 				return false;
 			} break;
 			case 2: {
-				LOG_SL(LOG_SECTION_ARCHIVESCANNER, L_WARNING, "Archive %s: reading secondary meta-file %s too expensive", fullName.c_str(), fi.fileName.c_str());
+				LOG_SL(LOG_SECTION_ARCHIVESCANNER, L_WARNING, "Archive %s: reading secondary meta-file %s too expensive", fullName.c_str(), fn.c_str());
 			} break;
 			case 0:
 			default: {
@@ -601,11 +602,11 @@ std::string CArchiveScanner::SearchMapFile(const IArchive* ar, std::string& erro
 
 	// check for smf and if the uncompression of important files is too costy
 	for (uint32_t fid = 0; fid != ar->NumFiles(); ++fid) {
-		auto fi = ar->FileInfo(fid);
-		const std::string& ext = FileSystem::GetExtension(StringToLower(fi.fileName));
+		const auto& fn = ar->FileName(fid);
+		const std::string ext = FileSystem::GetExtension(StringToLower(fn));
 
 		if (ext == "smf")
-			return fi.fileName;
+			return fn;
 	}
 
 	return "";
@@ -622,14 +623,27 @@ void CArchiveScanner::ReadCache()
 		// Try to save initial scanning of assets, but will have to redo hashing
 		// as the previous version had bugs in that area
 		// probe two previous versions
-		const auto vm1CacheFile = FileSystem::EnsurePathSepAtEnd(FileSystem::GetCacheDir()) + IntToString(INTERNAL_VER - 1, "ArchiveCache%i.lua");
-		const auto vm2CacheFile = FileSystem::EnsurePathSepAtEnd(FileSystem::GetCacheDir()) + IntToString(INTERNAL_VER - 2, "ArchiveCache%i.lua");
-		if (ReadCacheData(vm1CacheFile, true) || ReadCacheData(vm2CacheFile, true)) {
-			// nullify hashes
+		std::array prevCacheFiles{
+			FileSystem::EnsurePathSepAtEnd(FileSystem::GetCacheDir()) + IntToString(INTERNAL_VER - 1, "ArchiveCache%i.lua"),
+			FileSystem::EnsurePathSepAtEnd(FileSystem::GetCacheDir()) + IntToString(INTERNAL_VER - 2, "ArchiveCache%i.lua"),
+			FileSystem::EnsurePathSepAtEnd(FileSystem::GetCacheDir()) + IntToString(INTERNAL_VER - 3, "ArchiveCache%i.lua")
+		};
+
+		for (const auto& prevCacheFile : prevCacheFiles) {
+			if (!ReadCacheData(prevCacheFile, true))
+				continue;
+
+			// nullify hashes && filesInfo
 			for (auto& ai : archiveInfos) {
 				ai.checksum = sha512::NULL_RAW_DIGEST;
+				ai.filesInfo.clear();
 				isDirty = true;
 			}
+
+			// Also nullify pool info
+			poolFilesInfo.clear();
+
+			break; // on first success
 		}
 	}
 
@@ -793,7 +807,7 @@ void CArchiveScanner::ScanArchive(const std::string& fullName, bool doChecksum)
 
 	// Store modinfo.lua/mapinfo.lua modified timestamp for directory archives, as only they can change.
 	if (ar->GetType() == ARCHIVE_TYPE_SDD && !luaInfoFile.empty()) {
-		ai.archiveDataPath = ar->GetArchiveFile() + "/" + static_cast<const CDirArchive*>(ar.get())->GetOrigFileName(ar->FindFile(luaInfoFile));
+		ai.archiveDataPath = ar->GetArchiveFile() + "/" + static_cast<const CDirArchive*>(ar.get())->FileName(ar->FindFile(luaInfoFile));
 		ai.modifiedArchiveData = FileSystemAbstraction::GetFileModificationTime(ai.archiveDataPath);
 	}
 
@@ -996,52 +1010,66 @@ bool CArchiveScanner::GetArchiveChecksum(const std::string& archiveName, Archive
 
 	numParallelFileReads = std::min(numParallelFileReads, ThreadPool::GetNumThreads());
 
-	bool sdpArchive = (ar->GetType() == ARCHIVE_TYPE_SDP);
+	const bool sdpArchive = (ar->GetType() == ARCHIVE_TYPE_SDP);
+	const bool compressedArchive = (ar->GetType() == ARCHIVE_TYPE_SD7 || ar->GetType() == ARCHIVE_TYPE_SDZ);
+
+	// limit the number of simultaneous IO operations
+	std::counting_semaphore sem(numParallelFileReads);
+
+	// load ignore list, and insert all files to check in lowercase format
+	std::unique_ptr<IFileFilter> ignore(CreateIgnoreFilter(ar.get()));
+
+	// warm up and actually force retrieval of some archive data with ar->FileInfo(fid)
+	std::atomic_uint32_t numFiles = {0};
+	for_mt(0, ar->NumFiles(), [&sem, &numFiles, &ar = std::as_const(ar), &ignore = std::as_const(ignore)](int fid) {
+		const auto fn = ar->FileName(fid);
+
+		if (ignore->Match(fn))
+			return;
+
+		sem.acquire();
+		const auto volatile fi = ar->FileInfo(fid); // volatile to force execution
+		sem.release();
+		++numFiles;
+	});
 
 	// store relevant lowercased filenames from the archive
 	std::vector<std::string> fileNames;
 
-	fileNames.reserve(ar->NumFiles());
-	archiveInfo.filesInfo.reserve(ar->NumFiles());
+	fileNames.reserve(numFiles.load());
+	archiveInfo.filesInfo.reserve(numFiles.load());
 
-	// load ignore list, and insert all files to check in lowercase format
-	std::unique_ptr<IFileFilter> ignore(CreateIgnoreFilter(ar.get()));
 	for (uint32_t fid = 0; fid < ar->NumFiles(); ++fid) {
 		auto fi = ar->FileInfo(fid);
 
 		if (ignore->Match(fi.fileName))
 			continue;
 
-		// create case-insensitive hashes
-		auto lcFn = StringToLower(fi.fileName);
-		fileNames.emplace_back(lcFn);
-
 		// special treatment of SDP archives: insert information from poolFilesInfo
 		if (sdpArchive) {
-			auto it = poolFilesInfo.find(lcFn);
+			auto it = poolFilesInfo.find(fi.specialFileName); // fi.specialFileName contains pool file path
 			if (it != poolFilesInfo.end()) {
-				archiveInfo.filesInfo[it->first] = it->second;
+				archiveInfo.filesInfo[fi.fileName] = it->second;
 			}
 		}
 
-		auto it = archiveInfo.filesInfo.find(lcFn);
+		auto it = archiveInfo.filesInfo.find(fi.fileName);
 		if (it == archiveInfo.filesInfo.end())
-			it = archiveInfo.filesInfo.emplace(std::move(lcFn), {}).first;
+			it = archiveInfo.filesInfo.emplace(fi.fileName, {}).first;
 
 		if (fi.modTime != it->second.modTime || fi.size != it->second.size) {
 			it->second.modTime = fi.modTime;
 			it->second.size = fi.size;
 			it->second.checksum = sha512::NULL_RAW_DIGEST;
 		}
-	}
 
-	// limit number of simultaneous IO operations
-	std::counting_semaphore sem(numParallelFileReads);
+		fileNames.emplace_back(std::move(fi.fileName));
+	}
 
 	std::array<std::vector<uint8_t>, ThreadPool::MAX_THREADS> fileBuffers;
 
-	auto ComputeHashesTask = [&ar, &fileNames = std::as_const(fileNames), &fileBuffers, &filesInfo = archiveInfo.filesInfo, &sem, this](size_t i) -> void {
-		const auto& fileName = fileNames[i]; // note generally (i != fid) due to sorting and filtering
+	for_mt(0, fileNames.size(), [&ar, &fileNames = std::as_const(fileNames), &fileBuffers, &filesInfo = archiveInfo.filesInfo, &sem, this](int i) {
+		const auto& fileName = fileNames[i]; // note generally (i != fid) due to ignore->Match(fi.fileName) filtering
 
 		const auto it = filesInfo.find(fileName);
 		assert(it != filesInfo.end());
@@ -1052,48 +1080,33 @@ bool CArchiveScanner::GetArchiveChecksum(const std::string& archiveName, Archive
 		fileBuffer.clear();
 
 		sem.acquire();
+		// note ar->FindFile() converts to lowercase
 		numFilesHashed.fetch_add(static_cast<uint32_t>(ar->CalcHash(ar->FindFile(fileName), it->second.checksum, fileBuffer)));
 		sem.release();
-	};
+	});
 
-	std::vector<std::shared_future<void>> tasks;
-	tasks.reserve(fileNames.size());
-
-	for (size_t i = 0; i < fileNames.size(); ++i) {
-		tasks.emplace_back(ThreadPool::Enqueue(ComputeHashesTask, i));
-	}
-
-	const auto erasePredicate = [](decltype(tasks)::value_type& item) {
-		using namespace std::chrono_literals;
-		const auto taskStatus = item.wait_for(0us);
-		if (taskStatus == std::future_status::deferred) {
-			item.get();
-			return true;
-		}
-		else {
-			return (taskStatus == std::future_status::ready);
-		}
-	};
-
-	while (!tasks.empty()) {
-		std::erase_if(tasks, erasePredicate);
-		spring_sleep(spring_msecs(1));
-	}
-
-	// sort by filename
-	std::stable_sort(fileNames.begin(), fileNames.end());
+	// stable sort by filename
+	std::stable_sort(fileNames.begin(), fileNames.end(), [](const auto& lhs, const auto& rhs) {
+		const auto lcLhs = StringToLower(lhs);
+		const auto lcRhs = StringToLower(rhs);
+		return lcLhs < lcRhs;
+	});
 
 	// combine individual hashes, initialize to hash(name)
 	for (size_t i = 0; i < fileNames.size(); i++) {
-		const auto& fileName = fileNames[i];
-		const auto& fileHash = archiveInfo.filesInfo[fileName].checksum;
+		const auto& fileNameOC = fileNames[i];
+		// we want the filename based hashing below to be case-independent
+		const auto  fileNameLC = StringToLower(fileNameOC);
+		// but we still index on the original filename
+		const auto  filesInfoIt = archiveInfo.filesInfo.find(fileNameOC);
+		assert(filesInfoIt != archiveInfo.filesInfo.end());
 
-		sha512::raw_digest fileNameHash {0};
-		sha512::calc_digest(reinterpret_cast<const uint8_t*>(fileName.c_str()), fileName.size(), fileNameHash.data());
+		sha512::raw_digest fileNameHash{ 0 };
+		sha512::calc_digest(reinterpret_cast<const uint8_t*>(fileNameLC.c_str()), fileNameLC.size(), fileNameHash.data());
 
 		for (uint8_t j = 0; j < sha512::SHA_LEN; j++) {
 			archiveInfo.checksum[j] ^= fileNameHash[j];
-			archiveInfo.checksum[j] ^= fileHash[j];
+			archiveInfo.checksum[j] ^= filesInfoIt->second.checksum[j];
 		}
 
 		#if !defined(DEDICATED) && !defined(UNITSYNC)
@@ -1103,11 +1116,39 @@ bool CArchiveScanner::GetArchiveChecksum(const std::string& archiveName, Archive
 
 	if (sdpArchive) {
 		// makes no sense to store archiveInfo.filesInfo in the SDP index
-		// copy to poolFilesInfo and empty archiveInfo.filesInfo
-		for (const auto& [fn, fi] : archiveInfo.filesInfo) {
-			poolFilesInfo[fn] = fi;
+		// so copy to poolFilesInfo and empty archiveInfo.filesInfo
+		for (uint32_t fid = 0; fid < ar->NumFiles(); ++fid) {
+			const auto fi = ar->FileInfo(fid);
+
+			if (ignore->Match(fi.fileName))
+				continue;
+
+			poolFilesInfo[fi.specialFileName] = archiveInfo.filesInfo[fi.fileName]; // populate the updated information back to poolFilesInfo
 		}
-		archiveInfo.filesInfo = {};
+		archiveInfo.filesInfo.clear();
+	}
+	else if (compressedArchive) {
+		// makes no sense to to store archiveInfo.filesInfo for 7z/zip based archives
+		// as these archives are likely immutable, so per file info is useless
+		// in rare case of updating/overwriting the archive we will do full checksumming
+		archiveInfo.filesInfo.clear();
+	}
+	else {
+		for (auto it = archiveInfo.filesInfo.begin(); it != archiveInfo.filesInfo.end(); /*NOOP*/) {
+			// cleanup files that got removed since the last cache update
+			const auto fid = ar->FindFile(it->first);
+			if (fid == ar->NumFiles()) {
+				it = archiveInfo.filesInfo.erase(it);
+			}
+			// should never happen: read error?
+			else if (const auto fi = ar->FileInfo(fid); fi.size == -1 || fi.modTime == 0) {
+				it = archiveInfo.filesInfo.erase(it);
+				assert(false);
+			}
+			else {
+				++it;
+			}
+		}
 	}
 
 	return true;
@@ -1233,18 +1274,12 @@ void CArchiveScanner::WriteCacheData(const std::string& filename)
 	if (!isDirty)
 		return;
 
-	FILE* out = fopen(filename.c_str(), "wt");
-	if (out == nullptr) {
-		LOG_L(L_ERROR, "[AS::%s] failed to write to \"%s\"!", __func__, filename.c_str());
-		return;
-	}
-
 	// First delete all outdated information
 	{
-		std::stable_sort(archiveInfos.begin(), archiveInfos.end(), [](const ArchiveInfo& a, const ArchiveInfo& b) { return (a.origName < b.origName); });
+		std::stable_sort(  archiveInfos.begin(),   archiveInfos.end(), [](const ArchiveInfo& a, const ArchiveInfo& b) { return (a.origName < b.origName); });
 		std::stable_sort(brokenArchives.begin(), brokenArchives.end(), [](const BrokenArchive& a, const BrokenArchive& b) { return (a.name < b.name); });
 
-		std::erase_if(archiveInfos, [](const ArchiveInfo& i) { return (!i.updated); });
+		std::erase_if(  archiveInfos, [](const ArchiveInfo& i)   { return (!i.updated); });
 		std::erase_if(brokenArchives, [](const BrokenArchive& i) { return (!i.updated); });
 
 		archiveInfosIndex.clear();
@@ -1257,6 +1292,41 @@ void CArchiveScanner::WriteCacheData(const std::string& filename)
 		for (const BrokenArchive& bi: brokenArchives) {
 			brokenArchivesIndex.emplace(bi.name, &bi - &brokenArchives[0]);
 		}
+	}
+	// see if the cache contains pool files that don't exist anymore
+	{
+		// we go the complicated way, because we don't want to store pool root path in poolFilesInfo key
+		// (to not blow up the size of the cache file)
+		spring::unordered_set<std::string> allPoolRootDirs;
+		for (const ArchiveInfo& ai : archiveInfos) {
+			// lame way of detecting the archive type, that is not stored in ArchiveInfo
+			if (ai.origName.find(".sdp") == std::string::npos)
+				continue;
+
+			allPoolRootDirs.emplace(CPoolArchive::GetPoolRootDirectory(ai.path + ai.origName));
+		}
+
+		for (auto it = poolFilesInfo.begin(); it != poolFilesInfo.end(); /*NOOP*/) {
+			// cleanup files that got deleted in the meantime
+			bool found = false;
+			for (const auto& poolRootDir : allPoolRootDirs) {
+				if (FileSystem::FileExists(CPoolArchive::GetPoolFilePath(poolRootDir, it->first))) {
+					found = true;
+					break;
+				}
+			}
+
+			if (!found)
+				it = poolFilesInfo.erase(it);
+			else
+				++it;
+		}
+	}
+
+	FILE* out = fopen(filename.c_str(), "wt");
+	if (out == nullptr) {
+		LOG_L(L_ERROR, "[AS::%s] failed to write to \"%s\"!", __func__, filename.c_str());
+		return;
 	}
 
 	auto WriteFileInfoMapBody = [out](const spring::unordered_map<std::string, FileInfo>& filesInfoMap, size_t numTabs) {

--- a/rts/System/FileSystem/Archives/CMakeLists.txt
+++ b/rts/System/FileSystem/Archives/CMakeLists.txt
@@ -13,6 +13,8 @@ set(archives_sources
 	${SOURCE_ROOT}/System/TimeUtil.cpp
 )
 
+include_directories(${SOURCE_ROOT}/rts/lib)
+
 # Can't remove definitions per target
 remove_definitions(-DTHREADPOOL)
 

--- a/rts/System/FileSystem/Archives/CMakeLists.txt
+++ b/rts/System/FileSystem/Archives/CMakeLists.txt
@@ -13,7 +13,7 @@ set(archives_sources
 	${SOURCE_ROOT}/System/TimeUtil.cpp
 )
 
-include_directories(${SOURCE_ROOT}/rts/lib)
+include_directories(${Spring_SOURCE_DIR}/rts/lib)
 
 # Can't remove definitions per target
 remove_definitions(-DTHREADPOOL)

--- a/rts/System/FileSystem/Archives/DirArchive.cpp
+++ b/rts/System/FileSystem/Archives/DirArchive.cpp
@@ -1,7 +1,4 @@
-#include "DirArchive.h"
-#include "DirArchive.h"
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
-
 
 #include "DirArchive.h"
 

--- a/rts/System/FileSystem/Archives/DirArchive.cpp
+++ b/rts/System/FileSystem/Archives/DirArchive.cpp
@@ -73,12 +73,10 @@ int32_t CDirArchive::FileSize(uint32_t fid) const
 	assert(IsFileId(fid));
 	auto& file = files[fid];
 
-	// check if already cached
-	if (file.size > -1) {
-		return file.size;
-	}
-
-	file.size = FileSystem::GetFileSize(files[fid].rawFileName);
+	// check if not cached
+	if (file.size == -1) {
+		file.size = FileSystem::GetFileSize(files[fid].rawFileName);
+	}	
 
 	return file.size;
 }
@@ -90,16 +88,12 @@ IArchive::SFileInfo CDirArchive::FileInfo(uint32_t fid) const
 	auto& file = files[fid];
 	fi.fileName = file.fileName;
 
-	// check if already cached
-	if (file.modTime > 0 && file.size > -1) {
-		fi.size = file.size;
-		fi.modTime = file.modTime;
-		return fi;
-	}
+	// check if not cached, file.size and file.modTime are mutable
+	if (file.size == -1)
+		file.size = FileSystem::GetFileSize(file.rawFileName);
 
-	// file.size and file.modTime are mutable
-	file.size = FileSystem::GetFileSize(file.rawFileName);
-	file.modTime = FileSystemAbstraction::GetFileModificationTime(file.rawFileName);
+	if (file.modTime == 0)
+		file.modTime = FileSystemAbstraction::GetFileModificationTime(file.rawFileName);
 
 	fi.specialFileName = file.rawFileName;
 	fi.size = file.size;

--- a/rts/System/FileSystem/Archives/DirArchive.h
+++ b/rts/System/FileSystem/Archives/DirArchive.h
@@ -3,7 +3,7 @@
 #ifndef _DIR_ARCHIVE_H
 #define _DIR_ARCHIVE_H
 
-#include <map>
+#include <vector>
 
 #include "IArchiveFactory.h"
 #include "IArchive.h"
@@ -35,16 +35,23 @@ public:
 
 	bool IsOpen() override { return true; }
 
-	uint32_t NumFiles() const override { return (searchFiles.size()); }
+	uint32_t NumFiles() const override { return (files.size()); }
 	bool GetFile(uint32_t fid, std::vector<std::uint8_t>& buffer) override;
+	const std::string& FileName(uint32_t fid) const override;
+	int32_t FileSize(uint32_t fid) const override;
 	SFileInfo FileInfo(uint32_t fid) const override;
-	const std::string& GetOrigFileName(uint32_t fid) const { return searchFiles[fid]; }
-
 private:
 	/// "ExampleArchive.sdd/"
 	const std::string dirName;
 
-	std::vector<std::string> searchFiles;
+	struct Files {
+		std::string fileName;
+		std::string rawFileName;
+		mutable int32_t size = -1;
+		mutable uint32_t modTime = 0;
+	};
+
+	std::vector<Files> files;
 };
 
 #endif // _DIR_ARCHIVE_H

--- a/rts/System/FileSystem/Archives/IArchive.cpp
+++ b/rts/System/FileSystem/Archives/IArchive.cpp
@@ -4,7 +4,7 @@
 
 #include "System/StringUtil.h"
 
-unsigned int IArchive::FindFile(const std::string& filePath) const
+uint32_t IArchive::FindFile(const std::string& filePath) const
 {
 	const std::string& normalizedFilePath = StringToLower(filePath);
 	const auto it = lcNameIndex.find(normalizedFilePath);
@@ -17,7 +17,7 @@ unsigned int IArchive::FindFile(const std::string& filePath) const
 
 bool IArchive::GetFile(const std::string& name, std::vector<std::uint8_t>& buffer)
 {
-	const unsigned int fid = FindFile(name);
+	const uint32_t fid = FindFile(name);
 
 	if (!IsFileId(fid))
 		return false;

--- a/rts/System/FileSystem/Archives/IArchive.h
+++ b/rts/System/FileSystem/Archives/IArchive.h
@@ -24,6 +24,7 @@ class IArchive
 public:
 	struct SFileInfo {
 		std::string fileName;
+		std::string specialFileName; // overloaded meaning
 		int32_t size = -1;
 		uint32_t modTime = 0;
 	};
@@ -93,15 +94,25 @@ public:
 
 		// no archive should be larger than 4GB when extracted
 		for (uint32_t fid = 0; fid < NumFiles(); fid++) {
-			auto fi = FileInfo(fid);
-			size += (fi.size);
+			auto fs = FileSize(fid);
+			size += fs;
 		}
 
 		return size;
 	}
 
 	/**
-	 * Fetches the name and size in bytes of a file by its ID.
+	 * Fetches the name of a file by its ID.
+	 */
+	virtual const std::string& FileName(uint32_t fid) const = 0;
+
+	/**
+	 * Fetches the size of a file by its ID.
+	 */
+	virtual int32_t FileSize(uint32_t fid) const = 0;
+
+	/**
+	 * Fetches the name, size and modTime of a file by its ID.
 	 */
 	virtual SFileInfo FileInfo(uint32_t fid) const = 0;
 

--- a/rts/System/FileSystem/Archives/PoolArchive.cpp
+++ b/rts/System/FileSystem/Archives/PoolArchive.cpp
@@ -137,9 +137,8 @@ IArchive::SFileInfo CPoolArchive::FileInfo(uint32_t fid) const
 	assert(IsFileId(fid));
 	auto& file = files[fid];
 
-	if (file.modTime == 0) {
+	if (file.modTime == 0)
 		file.modTime = FileSystemAbstraction::GetFileModificationTime(GetPoolFilePath(poolRootDir, file.md5sum)); // file.modTime is mutable
-	}
 
 	return IArchive::SFileInfo{
 		.fileName = file.name,

--- a/rts/System/FileSystem/Archives/PoolArchive.cpp
+++ b/rts/System/FileSystem/Archives/PoolArchive.cpp
@@ -10,6 +10,8 @@
 #include <cstring>
 #include <iostream>
 
+#include <fmt/format.h>
+
 #include "System/FileSystem/DataDirsAccess.h"
 #include "System/FileSystem/FileSystem.h"
 #include "System/Threading/SpringThreading.h"
@@ -71,10 +73,8 @@ CPoolArchive::CPoolArchive(const std::string& name)
 		if (!gz_really_read(in, &c_crc32, 4)) break;
 		if (!gz_really_read(in, &c_size, 4)) break;
 
-		files.emplace_back();
-		stats.emplace_back();
-		FileData& f = files.back();
-		FileStat& s = stats.back();
+		FileData& f = files.emplace_back();
+		FileStat& s = stats.emplace_back();
 
 		f.name = std::string(c_name, length);
 
@@ -120,21 +120,47 @@ CPoolArchive::~CPoolArchive()
 	}
 }
 
+const std::string& CPoolArchive::FileName(uint32_t fid) const
+{
+	assert(IsFileId(fid));
+	return files[fid].name;
+}
+
+int32_t CPoolArchive::FileSize(uint32_t fid) const
+{
+	assert(IsFileId(fid));
+	return files[fid].size;
+}
+
 IArchive::SFileInfo CPoolArchive::FileInfo(uint32_t fid) const
 {
 	assert(IsFileId(fid));
 	auto& file = files[fid];
 
 	if (file.modTime == 0) {
-		const auto poolFn = GetPoolFileName(poolRootDir, file.md5sum);
-		file.modTime = FileSystemAbstraction::GetFileModificationTime(poolFn); // file.modTime is mutable
+		file.modTime = FileSystemAbstraction::GetFileModificationTime(GetPoolFilePath(poolRootDir, file.md5sum)); // file.modTime is mutable
 	}
 
 	return IArchive::SFileInfo{
 		.fileName = file.name,
+		.specialFileName = GetPoolFileName(file.md5sum),
 		.size = static_cast<int32_t>(file.size),
 		.modTime = file.modTime
 	};
+}
+
+bool CPoolArchive::CalcHash(uint32_t fid, sha512::raw_digest& hash, std::vector<std::uint8_t>& fb)
+{
+	assert(IsFileId(fid));
+
+	const FileData& fd = files[fid];
+
+	// pool-entry hashes are not calculated until GetFileImpl, must check JIT
+	if (fd.shasum == sha512::NULL_RAW_DIGEST)
+		GetFileImpl(fid, fb);
+
+	hash = fd.shasum;
+	return (fd.shasum != sha512::NULL_RAW_DIGEST);
 }
 
 std::string CPoolArchive::GetPoolRootDirectory(const std::string& sdpName)
@@ -147,7 +173,7 @@ std::string CPoolArchive::GetPoolRootDirectory(const std::string& sdpName)
 	return poolRootDir;
 }
 
-std::string CPoolArchive::GetPoolFileName(const std::string& poolRootDir, const std::array<uint8_t, 16>& md5Sum)
+std::string CPoolArchive::GetPoolFileName(const std::array<uint8_t, 16>& md5Sum)
 {
 	static constexpr const char table[] = "0123456789abcdef";
 	char c_hex[32];
@@ -159,9 +185,18 @@ std::string CPoolArchive::GetPoolFileName(const std::string& poolRootDir, const 
 
 	const std::string prefix(c_hex    ,  2);
 	const std::string pstfix(c_hex + 2, 30);
+	return fmt::format("{}/{}.gz", prefix, pstfix);
+}
 
-	std::string rpath = poolRootDir + "/pool/" + prefix + "/" + pstfix + ".gz";
+std::string CPoolArchive::GetPoolFilePath(const std::string& poolRootDir, const std::string& poolFile)
+{
+	std::string rpath = fmt::format("{}/pool/{}", poolRootDir, poolFile);
 	return FileSystem::FixSlashes(rpath);
+}
+
+std::string CPoolArchive::GetPoolFilePath(const std::string& poolRootDir, const std::array<uint8_t, 16>& md5Sum)
+{
+	return GetPoolFilePath(poolRootDir, GetPoolFileName(md5Sum));
 }
 
 int CPoolArchive::GetFileImpl(uint32_t fid, std::vector<std::uint8_t>& buffer)
@@ -171,7 +206,7 @@ int CPoolArchive::GetFileImpl(uint32_t fid, std::vector<std::uint8_t>& buffer)
 	auto& f = files[fid];
 	auto& s = stats[fid];
 
-	const auto path = GetPoolFileName(poolRootDir, f.md5sum);
+	const auto path = GetPoolFilePath(poolRootDir, f.md5sum);
 
 	const spring_time startTime = spring_now();
 

--- a/rts/System/FileSystem/Archives/PoolArchive.h
+++ b/rts/System/FileSystem/Archives/PoolArchive.h
@@ -84,21 +84,14 @@ public:
 	bool IsOpen() override { return isOpen; }
 
 	unsigned NumFiles() const override { return (files.size()); }
+	const std::string& FileName(uint32_t fid) const override;
+	int32_t FileSize(uint32_t fid) const override;
 	SFileInfo FileInfo(uint32_t fid) const override;
-	bool CalcHash(uint32_t fid, sha512::raw_digest& hash, std::vector<std::uint8_t>& fb) override {
-		assert(IsFileId(fid));
-
-		const FileData& fd = files[fid];
-
-		// pool-entry hashes are not calculated until GetFileImpl, must check JIT
-		if (fd.shasum == sha512::NULL_RAW_DIGEST)
-			GetFileImpl(fid, fb);
-
-		hash = fd.shasum;
-		return (fd.shasum != sha512::NULL_RAW_DIGEST);
-	}
+	bool CalcHash(uint32_t fid, sha512::raw_digest& hash, std::vector<std::uint8_t>& fb) override;
 	static std::string GetPoolRootDirectory(const std::string& sdpName);
-	static std::string GetPoolFileName(const std::string& poolRootDir, const std::array<uint8_t, 16>& md5Sum);
+	static std::string GetPoolFileName(const std::array<uint8_t, 16>& md5Sum);
+	static std::string GetPoolFilePath(const std::string& poolRootDir, const std::string& poolFile);
+	static std::string GetPoolFilePath(const std::string& poolRootDir, const std::array<uint8_t, 16>& md5Sum);
 protected:
 	int GetFileImpl(uint32_t fid, std::vector<std::uint8_t>& buffer) override;
 private:

--- a/rts/System/FileSystem/Archives/SevenZipArchive.cpp
+++ b/rts/System/FileSystem/Archives/SevenZipArchive.cpp
@@ -1,3 +1,5 @@
+#include "SevenZipArchive.h"
+#include "SevenZipArchive.h"
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "SevenZipArchive.h"
@@ -227,12 +229,25 @@ int CSevenZipArchive::GetFileImpl(uint32_t fid, std::vector<std::uint8_t>& buffe
 	return 1;
 }
 
+const std::string& CSevenZipArchive::FileName(uint32_t fid) const
+{
+	assert(IsFileId(fid));
+	return fileEntries[fid].origName;
+}
+
+int32_t CSevenZipArchive::FileSize(uint32_t fid) const
+{
+	assert(IsFileId(fid));
+	return fileEntries[fid].size;
+}
+
 IArchive::SFileInfo CSevenZipArchive::FileInfo(uint32_t fid) const
 {
 	assert(IsFileId(fid));
 	const auto& fe = fileEntries[fid];
 	return IArchive::SFileInfo{
 		.fileName = fe.origName,
+		.specialFileName = "",
 		.size = fe.size,
 		.modTime = fe.modTime
 	};

--- a/rts/System/FileSystem/Archives/SevenZipArchive.cpp
+++ b/rts/System/FileSystem/Archives/SevenZipArchive.cpp
@@ -1,5 +1,3 @@
-#include "SevenZipArchive.h"
-#include "SevenZipArchive.h"
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "SevenZipArchive.h"

--- a/rts/System/FileSystem/Archives/SevenZipArchive.h
+++ b/rts/System/FileSystem/Archives/SevenZipArchive.h
@@ -42,6 +42,8 @@ public:
 	bool IsOpen() override { return isOpen.any(); }
 
 	uint32_t NumFiles() const override { return (fileEntries.size()); }
+	const std::string& FileName(uint32_t fid) const override;
+	int32_t FileSize(uint32_t fid) const override;
 	SFileInfo FileInfo(uint32_t fid) const override;
 
 	bool CheckForSolid() const override { return considerSolid; }

--- a/rts/System/FileSystem/Archives/VirtualArchive.cpp
+++ b/rts/System/FileSystem/Archives/VirtualArchive.cpp
@@ -1,3 +1,6 @@
+#include "VirtualArchive.h"
+#include "VirtualArchive.h"
+#include "VirtualArchive.h"
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "VirtualArchive.h"
@@ -59,6 +62,16 @@ bool CVirtualArchiveOpen::GetFile( uint32_t fid, std::vector<std::uint8_t>& buff
 	return archive->GetFile(fid, buffer);
 }
 
+const std::string& CVirtualArchiveOpen::FileName(uint32_t fid) const
+{
+	return archive->FileName(fid);
+}
+
+int32_t CVirtualArchiveOpen::FileSize(uint32_t fid) const
+{
+	return archive->FileSize(fid);
+}
+
 IArchive::SFileInfo CVirtualArchiveOpen::FileInfo(uint32_t fid) const
 {
 	return archive->FileInfo(fid);
@@ -81,12 +94,25 @@ bool CVirtualArchive::GetFile(uint32_t fid, std::vector<std::uint8_t>& buffer)
 	return true;
 }
 
+const std::string& CVirtualArchive::FileName(uint32_t fid) const
+{
+	assert(fid < files.size());
+	return files[fid].name;
+}
+
+int32_t CVirtualArchive::FileSize(uint32_t fid) const
+{
+	assert(fid < files.size());
+	return static_cast<int32_t>(files[fid].buffer.size());
+}
+
 IArchive::SFileInfo CVirtualArchive::FileInfo(uint32_t fid) const
 {
 	assert(fid < files.size());
 	const auto& fe = files[fid];
 	return IArchive::SFileInfo{
 		.fileName = fe.name,
+		.specialFileName = "",
 		.size = static_cast<int32_t>(fe.buffer.size()),
 		.modTime = 0
 	};

--- a/rts/System/FileSystem/Archives/VirtualArchive.cpp
+++ b/rts/System/FileSystem/Archives/VirtualArchive.cpp
@@ -1,6 +1,3 @@
-#include "VirtualArchive.h"
-#include "VirtualArchive.h"
-#include "VirtualArchive.h"
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "VirtualArchive.h"

--- a/rts/System/FileSystem/Archives/VirtualArchive.h
+++ b/rts/System/FileSystem/Archives/VirtualArchive.h
@@ -70,6 +70,8 @@ public:
 	bool IsOpen() override { return true; }
 	uint32_t NumFiles() const override;
 	bool GetFile(uint32_t fid, std::vector<std::uint8_t>& buffer) override;
+	const std::string& FileName(uint32_t fid) const override;
+	int32_t FileSize(uint32_t fid) const override;
 	SFileInfo FileInfo(uint32_t fid) const override;
 
 private:
@@ -92,6 +94,8 @@ public:
 	uint32_t NumFiles() const { return (files.size()); }
 
 	bool GetFile(uint32_t fid, std::vector<std::uint8_t>& buffer);
+	const std::string& FileName(uint32_t fid) const;
+	int32_t FileSize(uint32_t fid) const;
 	IArchive::SFileInfo FileInfo(uint32_t fid) const;
 
 	const std::string& GetFileName() const { return fileName; }

--- a/rts/System/FileSystem/Archives/ZipArchive.cpp
+++ b/rts/System/FileSystem/Archives/ZipArchive.cpp
@@ -1,7 +1,4 @@
-#include "ZipArchive.h"
-#include "ZipArchive.h"
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
-
 
 #include "ZipArchive.h"
 

--- a/rts/System/FileSystem/Archives/ZipArchive.cpp
+++ b/rts/System/FileSystem/Archives/ZipArchive.cpp
@@ -1,3 +1,5 @@
+#include "ZipArchive.h"
+#include "ZipArchive.h"
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 
@@ -84,12 +86,25 @@ CZipArchive::~CZipArchive()
 }
 
 
+const std::string& CZipArchive::FileName(uint32_t fid) const
+{
+	assert(IsFileId(fid));
+	return fileEntries[fid].origName;
+}
+
+int32_t CZipArchive::FileSize(uint32_t fid) const
+{
+	assert(IsFileId(fid));
+	return fileEntries[fid].size;
+}
+
 IArchive::SFileInfo CZipArchive::FileInfo(uint32_t fid) const
 {
 	assert(IsFileId(fid));
 	const auto& fe = fileEntries[fid];
 	return IArchive::SFileInfo {
 		.fileName = fe.origName,
+		.specialFileName = "",
 		.size = fe.size,
 		.modTime = fe.modTime
 	};

--- a/rts/System/FileSystem/Archives/ZipArchive.h
+++ b/rts/System/FileSystem/Archives/ZipArchive.h
@@ -38,6 +38,8 @@ public:
 	bool IsOpen() override { return (zipPerThread[0] != nullptr); }
 
 	uint32_t NumFiles() const override { return (fileEntries.size()); }
+	const std::string& FileName(uint32_t fid) const override;
+	int32_t FileSize(uint32_t fid) const override;
 	SFileInfo FileInfo(uint32_t fid) const override;
 
 	#if 0

--- a/rts/System/FileSystem/FileSystemInitializer.cpp
+++ b/rts/System/FileSystem/FileSystemInitializer.cpp
@@ -20,6 +20,7 @@ void ErrorMessageBox(const char*, const char*, unsigned int) { throw; } // pass 
 static void SetupThreadReg() {
 	Threading::SetFileSysThread();
 	Watchdog::RegisterThread(WDT_VFSI);
+	Threading::SetThreadName("vfsi");
 }
 static void ClearThreadReg() {
 	Watchdog::DeregisterThread(WDT_VFSI);

--- a/rts/System/FileSystem/VFSHandler.cpp
+++ b/rts/System/FileSystem/VFSHandler.cpp
@@ -176,8 +176,8 @@ bool CVFSHandler::AddArchive(const std::string& archiveName, bool overwrite)
 	files[Section::Temp].reserve(ar->NumFiles());
 
 	for (unsigned fid = 0; fid != ar->NumFiles(); ++fid) {
-		auto fi = ar->FileInfo(fid);
-		std::string name = StringToLower(fi.fileName);
+		std::string name = StringToLower(ar->FileName(fid));
+		const auto size = ar->FileSize(fid);
 
 		if (!overwrite) {
 			const auto pred = [](const FileEntry& a, const FileEntry& b) { return (a.first < b.first); };
@@ -195,7 +195,7 @@ bool CVFSHandler::AddArchive(const std::string& archiveName, bool overwrite)
 
 		// can not add directly to files[section], would break lower_bound
 		// note: this means an archive can *internally* contain duplicates
-		files[Section::Temp].emplace_back(name, FileData{ar, fi.size});
+		files[Section::Temp].emplace_back(name, FileData{ ar, size });
 	}
 
 	for (FileEntry& fileEntry: files[Section::Temp]) {
@@ -479,13 +479,13 @@ std::string CVFSHandler::GetFileAbsolutePath(const std::string& filePath, Sectio
 	const std::string& normalizedPath = GetNormalizedPath(filePath);
 	const FileData& fileData = GetFileData(normalizedPath, section);
 
-	// Only directory archives have an absolute path on disk
-	const auto dirArchive = dynamic_cast<const CDirArchive*>(fileData.ar);
-
-	if (dirArchive == nullptr)
+	if (fileData.ar->GetType() != ARCHIVE_TYPE_SDD)
 		return "";
 
-	const std::string& origFilePath = dirArchive->GetOrigFileName(dirArchive->FindFile(filePath));
+	// Only directory archives have an absolute path on disk
+	const auto* dirArchive = static_cast<const CDirArchive*>(fileData.ar);
+
+	const std::string& origFilePath = dirArchive->FileName(dirArchive->FindFile(filePath));
 	return (fileData.ar->GetArchiveFile() + "/" + origFilePath);
 }
 

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -253,6 +253,8 @@ bool SpringApp::Init()
 		return false;
 	}
 
+	Threading::SetThreadName("recoil-main"); // set default threadname for pstree
+
 	// Init OpenGL
 	globalRendering->PostInit();
 	globalRendering->UpdateGLConfigs();
@@ -270,8 +272,7 @@ bool SpringApp::Init()
 	if (!InitFileSystem())
 		return false;
 
-	// Multithreading & Affinity
-	Threading::SetThreadName("spring-main"); // set default threadname for pstree
+	// Affinity
 	Threading::SetThreadScheduler();
 
 	CInfoConsole::InitStatic();

--- a/tools/unitsync/unitsync.cpp
+++ b/tools/unitsync/unitsync.cpp
@@ -2164,11 +2164,12 @@ EXPORT(int) FindFilesArchive(int archive, int file, char* nameBuf, int* size)
 
 		if (file < arch->NumFiles()) {
 			const int nameBufSize = *size;
-			const auto fi = arch->FileInfo(file);
-			*size = fi.size;
+			const auto& fn = arch->FileName(file);
+			const auto  fs = arch->FileSize(file);
+			*size = fs;
 
-			if (nameBufSize > fi.fileName.length()) {
-				STRCPY(nameBuf, fi.fileName.c_str());
+			if (nameBufSize > fn.length()) {
+				STRCPY(nameBuf, fn.c_str());
 				return ++file;
 			}
 
@@ -2232,8 +2233,8 @@ EXPORT(int) SizeArchiveFile(int archive, int file)
 		CheckArchiveHandle(archive);
 
 		IArchive* a = openArchives[archive];
-		const auto fi = a->FileInfo(file);
-		return fi.size;
+		const auto fs = a->FileSize(file);
+		return fs;
 	}
 	UNITSYNC_CATCH_BLOCKS;
 	return -1;


### PR DESCRIPTION
Lite version of https://github.com/beyond-all-reason/spring/pull/2016