### PR TITLE
Minor, but important debuggl QoL improvements.

### DIFF
--- a/rts/Rendering/GL/glDebugGroup.hpp
+++ b/rts/Rendering/GL/glDebugGroup.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <cstdint>
 #include "System/StringHash.h"
+#include "System/StringUtil.h"
 
 namespace GL {
 	class DebugGroup {
@@ -21,4 +22,4 @@ namespace GL {
 	};
 }
 
-#define SCOPED_GL_DEBUGGROUP(name) const auto __scopedGLDebugGroup = GL::DebugGroup::GetScoped(hashString(name) ,name)
+#define SCOPED_GL_DEBUGGROUP(name) const auto _UTIL_CONCAT(__scopedGLDebugGroup, __LINE__) = GL::DebugGroup::GetScoped(0x824A/*GL_DEBUG_SOURCE_APPLICATION*/ ,name)


### PR DESCRIPTION
Add some rigor into what kind of MsgID OpenGL debug push/pop groups end to the debug function, add possibility to enable/disable debug groups from the console and springsettings, and while on it hook DebugGLStacktraces to it as well