### PR TITLE
Apply optimizations for the innermost loop of QTPFS path searching

### DIFF
--- a/rts/System/float3.h
+++ b/rts/System/float3.h
@@ -12,6 +12,7 @@
 #include "lib/streflop/streflop_cond.h"
 #include "System/creg/creg_cond.h"
 #include "System/FastMath.h"
+#include "System/type2.h"
 #ifdef _MSC_VER
 #include "System/Platform/Win/win32.h"
 #endif
@@ -502,6 +503,23 @@ public:
 	float distance2D(const float3& f) const {
 		const float dx = x - f.x;
 		const float dz = z - f.z;
+		return math::sqrt(dx*dx + dz*dz);
+	}
+
+	/**
+	 * @brief distance2D between float3 and float2 (only x and z)
+	 * @param f float2 to compare against
+	 * @return 2D distance between float3s
+	 *
+	 * Calculates the distance between this float3
+	 * and another float2 2-dimensionally (that is,
+	 * only using the x and z components).  Sums the
+	 * differences in the x and z components, square
+	 * root for pythagorean theorem
+	 */
+	float distance2D(const float2& f) const {
+		const float dx = x - f.x;
+		const float dz = z - f.y;
 		return math::sqrt(dx*dx + dz*dz);
 	}
 


### PR DESCRIPTION
While it is hard to get an exact reading from a laptop, these changes are yielding a measurable performance improvement for long-distance QTPFS path finding requests. I'm seeing at least a 10% improvement, some measurements indicate maybe upto 25% improvement.

Note: I plan to do some separate clean up of the code. I haven't done it here because it involves clearing out other areas of the code at the same time, which would obfusicate the changes here.