### PR TITLE
Get rid of spatial check macros

### DIFF
--- a/rts/Lua/CMakeLists.txt
+++ b/rts/Lua/CMakeLists.txt
@@ -35,6 +35,7 @@ set(sources_engine_Lua
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaRBOs.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaRules.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaRulesParams.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/LuaReadCommon.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaScream.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaShaders.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaSyncedCtrl.cpp"

--- a/rts/Lua/LuaReadCommon.cpp
+++ b/rts/Lua/LuaReadCommon.cpp
@@ -1,0 +1,46 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "LuaReadCommon.h"
+#include "Lua/LuaUtils.h"
+#include "lua.h"
+
+/**
+ * @brief Gets a lambda which checks if a unit is disqualified from being
+ * returned by a spatial query.
+ *
+ * In particular, the lambda checks if the unit has the desired allegiance and
+ * if it is visible.
+ */
+std::function<bool(const CUnit *)> getIsUnitDisqualifiedTest(lua_State *L, int allegiance,
+                                                                    int readTeam, int readAllyTeam) {
+    switch(allegiance) {
+    case LuaUtils::AllUnits:
+        return [L](const CUnit *unit) -> bool {
+            return !LuaUtils::IsUnitVisible(L, unit);
+        };
+    case LuaUtils::MyUnits:
+        return [readTeam](const CUnit *unit) -> bool {
+            return unit->team != readTeam;
+        };
+    case LuaUtils::AllyUnits:
+        return [readAllyTeam](const CUnit *unit) -> bool {
+            return unit->allyteam != readAllyTeam;
+        };
+    case LuaUtils::EnemyUnits:
+        return [L, readAllyTeam](const CUnit *unit) -> bool {
+            return unit->allyteam == readAllyTeam || !LuaUtils::IsUnitVisible(L, unit);
+        };
+    default: {
+        if(LuaUtils::IsAlliedTeam(L, allegiance)) {
+            // Allied units are always visible so we don't need to check for visibility
+            return [allegiance](const CUnit *unit) -> bool {
+                return unit->team != allegiance;
+            };
+        } else {
+            return [allegiance, L](const CUnit *unit) -> bool {
+                return unit->team != allegiance || !LuaUtils::IsUnitVisible(L, unit);
+            };
+        }
+    }
+    }
+}

--- a/rts/Lua/LuaReadCommon.h
+++ b/rts/Lua/LuaReadCommon.h
@@ -1,0 +1,13 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef LUA_READ_COMMON_H
+#define LUA_READ_COMMON_H
+
+#include "Sim/Units/Unit.h"
+
+struct lua_State;
+
+std::function<bool(const CUnit *)> getIsUnitDisqualifiedTest(lua_State *L, int allegiance,
+                                                             int readTeam, int readAllyTeam);
+
+#endif // LUA_READ_COMMON_H

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -9,6 +9,7 @@
 #include "LuaHashString.h"
 #include "LuaMetalMap.h"
 #include "LuaPathFinder.h"
+#include "LuaReadCommon.h"
 #include "LuaRules.h"
 #include "LuaRulesParams.h"
 #include "LuaUtils.h"
@@ -2900,47 +2901,6 @@ void ApplyPlanarTeamError(lua_State* L, int allegiance, float3& mins, float3& ma
 		mins -= allyTeamError3;
 		maxs += allyTeamError3;
 	}
-}
-
-/**
- * @brief Gets a lambda which checks if a unit is disqualified from being
- * returned by a spatial query.
- *
- * In particular, the lambda checks if the unit has the desired allegiance and
- * if it is visible.
- */
-static std::function<bool(const CUnit *)> getIsUnitDisqualifiedTest(lua_State *L, int allegiance,
-                                                                    int readTeam, int readAllyTeam) {
-    switch(allegiance) {
-    case LuaUtils::AllUnits:
-        return [L](const CUnit *unit) -> bool {
-            return !LuaUtils::IsUnitVisible(L, unit);
-        };
-    case LuaUtils::MyUnits:
-        return [readTeam](const CUnit *unit) -> bool {
-            return unit->team != readTeam;
-        };
-    case LuaUtils::AllyUnits:
-        return [readAllyTeam](const CUnit *unit) -> bool {
-            return unit->allyteam != readAllyTeam;
-        };
-    case LuaUtils::EnemyUnits:
-        return [L, readAllyTeam](const CUnit *unit) -> bool {
-            return unit->allyteam == readAllyTeam || !LuaUtils::IsUnitVisible(L, unit);
-        };
-    default: {
-        if(LuaUtils::IsAlliedTeam(L, allegiance)) {
-            // Allied units are always visible so we don't need to check for visibility
-            return [allegiance](const CUnit *unit) -> bool {
-                return unit->team != allegiance;
-            };
-        } else {
-            return [allegiance, L](const CUnit *unit) -> bool {
-                return unit->team != allegiance || !LuaUtils::IsUnitVisible(L, unit);
-            };
-        }
-    }
-    }
 }
 
 /**

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -6,6 +6,7 @@
 #include "LuaInclude.h"
 #include "LuaHandle.h"
 #include "LuaHashString.h"
+#include "LuaReadCommon.h"
 #include "LuaUtils.h"
 #include "LuaRules.h"
 #include "Game/Camera.h"
@@ -2195,39 +2196,7 @@ int LuaUnsyncedRead::GetUnitsInScreenRectangle(lua_State* L)
 
 	const int allegiance = LuaUtils::ParseAllegiance(L, __func__, 5);
 
-	std::function<bool(const CUnit*)> disqualifierFunc;
-
-	switch (allegiance)
-	{
-	case LuaUtils::AllUnits:
-		disqualifierFunc = [L](const CUnit* unit) -> bool { return !LuaUtils::IsUnitVisible(L, unit); };
-		break;
-	case LuaUtils::MyUnits:
-		disqualifierFunc = [readTeam](const CUnit* unit) -> bool { return unit->team != readTeam; };
-		break;
-	case LuaUtils::AllyUnits:
-		disqualifierFunc = [readATeam](const CUnit* unit) -> bool { return unit->allyteam != readATeam; };
-		break;
-	case LuaUtils::EnemyUnits:
-		disqualifierFunc = [readATeam](const CUnit* unit) -> bool { return unit->allyteam == readATeam; };
-		break;
-	default: {
-		if (LuaUtils::IsAlliedTeam(L, allegiance)) {
-			disqualifierFunc = [allegiance](const CUnit* unit) -> bool { return unit->team != allegiance; };
-		}
-		else {
-			disqualifierFunc = [allegiance, L](const CUnit* unit) -> bool {
-				if (unit->team != allegiance)
-					return true;
-
-				if (!LuaUtils::IsUnitVisible(L, unit))
-					return true;
-
-				return false;
-			};
-		}
-	} break;
-	}
+    auto disqualifierFunc = getIsUnitDisqualifiedTest(L, allegiance, readTeam, readATeam);
 
 	// Even though we're in unsynced it's ok to use gs->tempNum since its exact value
 	// doesn't matter


### PR DESCRIPTION
Refactor synced read spatial queries
    
Refactor to use function instead of macros for spatial queries in synced read. For ease of implementation we now do more work than before:
 * I no longer check it is an allied unit before applying the radar errors. The radar errors will be zero in this case anyway and shouldn't be expensive to compute.
* I have made it always check the rectangle for allied units despite this check always passing (it will pass because the quad tree lookup already does this check). This makes the code easier te understand and simpler to write.

The check whether a unit should be disqualified from a spatial query is now was nearly completely duplicated between the synced and unsynced Lua read files. The only difference was the synced reads of enemy units checked if the unit was visible whereas the unsynced read didn't. This looks like a bug in the unsynced version since it checks visibility when getting all units. It would be good if someone could weigh in on whether this was intentional.