### PR TITLE
Correct lua typing of `xyz`, `rgb` etc.

### DIFF
--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -7710,7 +7710,7 @@ int LuaSyncedRead::GetSmoothMeshHeight(lua_State* L)
  * @function Spring.TestMoveOrder
  * @param unitDefID integer
  * @param pos float3
- * @param dir float3? (Default: `{ x: 0, y: 0, z: 0 }`)
+ * @param dir float3? (Default: `{ 0, 0, 0 }`)
  * @param testTerrain boolean? (Default: `true`)
  * @param testObjects boolean? (Default: `true`)
  * @param centerOnly boolean? (Default: `false`)

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -3027,11 +3027,13 @@ int LuaUnsyncedCtrl::SetLosViewColors(lua_State* L)
 	float jamColor[3];
 	float radarColor2[3];
 
-	if ((LuaUtils::ParseFloatArray(L, 1, alwaysColor, 3) != 3) ||
-	    (LuaUtils::ParseFloatArray(L, 2, losColor, 3) != 3) ||
-	    (LuaUtils::ParseFloatArray(L, 3, radarColor, 3) != 3) ||
+	if (
+		(LuaUtils::ParseFloatArray(L, 1, alwaysColor, 3) != 3) ||
+		(LuaUtils::ParseFloatArray(L, 2, losColor, 3) != 3) ||
+		(LuaUtils::ParseFloatArray(L, 3, radarColor, 3) != 3) ||
 		(LuaUtils::ParseFloatArray(L, 4, jamColor, 3) != 3) ||
-		(LuaUtils::ParseFloatArray(L, 5, radarColor2, 3) != 3)) {
+		(LuaUtils::ParseFloatArray(L, 5, radarColor2, 3) != 3)
+	) {
 		luaL_error(L, "Incorrect arguments to SetLosViewColors()");
 	}
 	const int scale = CBaseGroundDrawer::losColorScale;

--- a/rts/Lua/library/Types.lua
+++ b/rts/Lua/library/Types.lua
@@ -30,17 +30,17 @@
 ---Color triple (RGB)
 ---
 ---@class rgb
----@field r number
----@field g number
----@field b number
+---@field [1] number Red value.
+---@field [2] number Green value.
+---@field [3] number Blue value.
 
 ---Color quadruple (RGBA)
 ---
 ---@class rgba
----@field r number
----@field g number
----@field b number
----@field a number
+---@field [1] number Red value.
+---@field [2] number Green value.
+---@field [3] number Blue value.
+---@field [4] number Alpha value.
 
 ---Indicator bytes representing color code operations during font rendering
 ---

--- a/rts/Lua/library/Types.lua
+++ b/rts/Lua/library/Types.lua
@@ -16,10 +16,10 @@
 ---Cartesian quadruple (XYZW)
 ---
 ---@class xyzw
----@field x number
----@field y number
----@field z number
----@field w number
+---@field [1] number x
+---@field [2] number y
+---@field [3] number z
+---@field [4] number w
 
 ---@alias float4 xyzw
 

--- a/rts/Lua/library/Types.lua
+++ b/rts/Lua/library/Types.lua
@@ -7,9 +7,9 @@
 ---Cartesian triple (XYZ)
 ---
 ---@class xyz
----@field x number
----@field y number
----@field z number
+---@field [1] number x
+---@field [2] number y
+---@field [3] number z
 
 ---@alias float3 xyz
 


### PR DESCRIPTION
Closes #2007