### PR TITLE
Make maximum number of pinned fonts configurable through MaxPinnedFonts.

### DIFF
--- a/rts/Rendering/Fonts/CFontTexture.h
+++ b/rts/Rendering/Fonts/CFontTexture.h
@@ -116,6 +116,8 @@ public:
 	static void ClearFallbackFonts();
 	static void ClearAllGlyphs();
 
+	static void PinFont(std::shared_ptr<FontFace>& face, const std::string& filename, const int size);
+
 	inline static spring::WrappedSyncRecursiveMutex sync = {};
 protected:
 	CFontTexture(const std::string& fontfile, int size, int outlinesize, float  outlineweight);
@@ -185,6 +187,7 @@ private:
 	int lastTextureUpdate = 0;
 	bool needsTextureUpload = true;
 	inline static int maxFontTries = 0;
+	inline static float maxPinnedFonts = 0;
 #endif
 	std::shared_ptr<FontFace> shFace;
 

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -111,6 +111,7 @@ CONFIG(bool, UseFontConfigSystemFonts).defaultValue(true).description("Whether t
 CONFIG(bool, FontConfigSearchAttributes).defaultValue(true).description("Whether the font characteristics will used to refine the search by fontconfig. Results in better glyph matches in some cases, but has a nontrivial performance cost.");
 CONFIG(bool, FontConfigApplySubstitutions).defaultValue(true).description("[EXPERIMENTAL] In case it's disabled FcConfigSubstitute is not getting called, this might break non-ASCII font rendering.");
 CONFIG(int, MaxFontTries).defaultValue(5).description("Represents the maximum number of attempts to search for a glyph replacement using the FontConfig library (lower = foreign glyphs may fail to render, higher = searching for foreign glyphs can lag the game).");
+CONFIG(int, MaxPinnedFonts).defaultValue(10).description("Maximum number of fonts to pin to cache. Increasing this will eventually use more memory, but can alleviate processing spikes when rendering new glyphs.");
 
 CONFIG(std::string, name).defaultValue(UnnamedPlayerName).description("Sets your name in the game. Since this is overridden by lobbies with your lobby username when playing, it usually only comes up when viewing replays or starting the engine directly for testing purposes.");
 CONFIG(std::string, DefaultStartScript).defaultValue("").description("filename of script.txt to use when no command line parameters are specified.");


### PR DESCRIPTION
### Work done

- Introduce MaxPinnedFonts config variable to allow max pinned fonts to be tweaked.

### Remarks

- Should be configurable in case 10 is too low.
- Had to move PinFonts to CFontTexture statics.
  - Maybe should move cache itself as well as other recently introduced config variables there too since they probably fit better, but I think better to do incrementally, to make easier to review and also since making this configurable is still kind of critical, while code refactor can take longer to review, see https://github.com/beyond-all-reason/spring/issues/2066 for more details of the planned steps to be taken.