### PR TITLE
Extract Game as a target in cmake

### DIFF
--- a/rts/CMakeLists.txt
+++ b/rts/CMakeLists.txt
@@ -136,7 +136,6 @@ add_subdirectory(Sim)
 #add_subdirectory(System) # this is already added in ../
 
 make_global_var(engineSources
-		${sources_engine_Game}
 		${sources_engine_Net}
 		${sources_engine_Lua}
 		${sources_engine_Map}

--- a/rts/builds/headless/CMakeLists.txt
+++ b/rts/builds/headless/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(GameHeadless PRIVATE
 	SDL2::SDL2
 	RmlUi::RmlUi
 	prd::jsoncpp
+	streflop
 )
 ### Build the executable
 add_executable(engine-headless ${engineSources} ${ENGINE_ICON})

--- a/rts/builds/headless/CMakeLists.txt
+++ b/rts/builds/headless/CMakeLists.txt
@@ -16,7 +16,8 @@ set(OpenGL_GL_PREFERENCE LEGACY)
 find_package(OpenGL 3.0 REQUIRED)
 
 # NOTE(create_headless_target): We don't need to copy COMPILE_DEFINTIONS till the add_definitions are used.
-# The targets automatically acquire correct defintions if they are specified in directory with add_definitions chain.
+# We don't need to copy COMPILE_DEFINTIONS because the headless defines are defined at the folder level
+# and we don't want to inherit original ones
 function(create_headless_target_from targetName)
 	get_target_property(targetIncludes ${targetName} INCLUDE_DIRECTORIES)
 	get_target_property(targetSources ${targetName} SOURCES)
@@ -27,9 +28,6 @@ function(create_headless_target_from targetName)
 		target_include_directories(${newTargetName} PRIVATE ${targetIncludes})
 	endif()
 	target_sources(${newTargetName} PRIVATE ${targetSources})
-	if (targetLinks)
-		target_link_libraries(${newTargetName} PRIVATE ${targetLinks})
-  endif()
 endfunction()
 
 
@@ -55,8 +53,8 @@ include_directories(${ENGINE_SRC_ROOT_DIR}/lib/cereal/include)
 create_headless_target_from(Game)
 target_link_libraries(GameHeadless PRIVATE
 	Tracy::TracyClient
-	SDL2::SDL2
-	RmlUi::RmlUi
+	headlessStubs
+	RmlUi::Core
 	prd::jsoncpp
 	streflop
 )

--- a/rts/builds/headless/CMakeLists.txt
+++ b/rts/builds/headless/CMakeLists.txt
@@ -15,6 +15,24 @@ set(OpenGL_GL_PREFERENCE LEGACY)
 
 find_package(OpenGL 3.0 REQUIRED)
 
+# NOTE(create_headless_target): We don't need to copy COMPILE_DEFINTIONS till the add_definitions are used.
+# The targets automatically acquire correct defintions if they are specified in directory with add_definitions chain.
+function(create_headless_target_from targetName)
+	get_target_property(targetIncludes ${targetName} INCLUDE_DIRECTORIES)
+	get_target_property(targetSources ${targetName} SOURCES)
+
+	set(newTargetName "${targetName}Headless")
+	add_library(${newTargetName} STATIC)
+	if (targetIncludes)
+		target_include_directories(${newTargetName} PRIVATE ${targetIncludes})
+	endif()
+	target_sources(${newTargetName} PRIVATE ${targetSources})
+	if (targetLinks)
+		target_link_libraries(${newTargetName} PRIVATE ${targetLinks})
+  endif()
+endfunction()
+
+
 # headlessstubs are our stubs that replace libGL, libGLU, libGLEW, libSDL (yes really!)
 list(APPEND engineHeadlessLibraries headlessStubs)
 list(APPEND engineHeadlessLibraries ${SPRING_SIM_LIBRARIES})
@@ -34,10 +52,15 @@ include_directories(${ENGINE_SRC_ROOT_DIR}/lib/asio/include)
 include_directories(${ENGINE_SRC_ROOT_DIR}/lib/slimsig/include)
 include_directories(${ENGINE_SRC_ROOT_DIR}/lib/cereal/include)
 
-
+create_headless_target_from(Game)
+target_link_libraries(GameHeadless PRIVATE
+	Tracy::TracyClient
+	SDL2::SDL2
+	RmlUi::RmlUi
+)
 ### Build the executable
 add_executable(engine-headless ${engineSources} ${ENGINE_ICON})
-target_link_libraries(engine-headless no-sound ${engineHeadlessLibraries} no-sound)
+target_link_libraries(engine-headless no-sound ${engineHeadlessLibraries} GameHeadless no-sound)
 
 if    (MINGW)
 	# To enable console output/force a console window to open

--- a/rts/builds/headless/CMakeLists.txt
+++ b/rts/builds/headless/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries(GameHeadless PRIVATE
 	Tracy::TracyClient
 	SDL2::SDL2
 	RmlUi::RmlUi
+	prd::jsoncpp
 )
 ### Build the executable
 add_executable(engine-headless ${engineSources} ${ENGINE_ICON})

--- a/rts/builds/legacy/CMakeLists.txt
+++ b/rts/builds/legacy/CMakeLists.txt
@@ -7,6 +7,16 @@
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
+add_library(Game STATIC)
+target_sources(Game PRIVATE ${sources_engine_Game})
+add_dependencies(Game generateVersionFiles)
+target_include_directories(Game PRIVATE "${CMAKE_BINARY_DIR}/src-generated/engine")
+target_link_libraries(Game PRIVATE
+	 Tracy::TracyClient
+	 SDL2::SDL2
+	 RmlUi::RmlUi
+	 ${sound-impl}
+)
 
 ### Assemble libraries
 find_package(SDL2 MODULE REQUIRED)
@@ -33,6 +43,7 @@ list(APPEND engineLibraries Freetype::Freetype)
 
 if    (UNIX)
 	find_package(X11 REQUIRED)
+	target_link_libraries(Game PRIVATE X11::Xcursor)
 	list(APPEND engineLibraries ${X11_Xcursor_LIB} ${X11_X11_LIB})
 endif (UNIX)
 
@@ -63,7 +74,7 @@ include_directories(${engineIncludes})
 
 ### Build the executable
 add_executable(engine-legacy ${EXE_FLAGS} ${engineSources} ${ENGINE_ICON} ${engineHeaders})
-target_link_libraries(engine-legacy ${engineLibraries})
+target_link_libraries(engine-legacy ${engineLibraries} Game)
 
 
 ### Install the executable

--- a/rts/builds/legacy/CMakeLists.txt
+++ b/rts/builds/legacy/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(Game PRIVATE
 	 RmlUi::RmlUi
 	 ${sound-impl}
 	 prd::jsoncpp
+	 streflop
 )
 
 ### Assemble libraries

--- a/rts/builds/legacy/CMakeLists.txt
+++ b/rts/builds/legacy/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(Game PRIVATE
 	 SDL2::SDL2
 	 RmlUi::RmlUi
 	 ${sound-impl}
+	 prd::jsoncpp
 )
 
 ### Assemble libraries


### PR DESCRIPTION
Refactor CMake files to incrementally introduce targets. The initial attempt using the blank card approach proved challenging and error-prone - #2043. This commit adopts a step-by-step strategy, starting with the extraction of targets in phases. By the end of the process, each sub-directory containing source files will have its own dedicated target. This commit focuses on refactoring one of the largest source sets - 'Game'.