### PR TITLE
Ghost icons fixes 2

### DIFF
--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -358,6 +358,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 
 	SColor currentColor;
 	const auto allyTeam = gu->myAllyTeam;
+	const auto isFullView = gu->spectatingFullView;
 	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 
 	if (!minimap->UseUnitIcons())
@@ -405,7 +406,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 					currentColor = teamHandler.Team(unit->team)->color;
 				}
 
-				if (!gu->spectatingFullView && !(unit->losStatus[allyTeam] & LOS_INRADAR)) {
+				if (!isFullView && !(unit->losStatus[allyTeam] & LOS_INRADAR)) {
 					if (ghostIconDimming == 0.0f)
 						continue;
 
@@ -416,14 +417,14 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 			}
 
 			const float iconScale = CUnitDrawerHelper::GetUnitIconScale(unit);
-			const float3& pos = (!gu->spectatingFullView) ?
+			const float3& pos = (!isFullView) ?
 				unit->GetObjDrawErrorPos(allyTeam) :
 				unit->GetObjDrawMidPos();
 
 			DrawUnitMiniMapIcon(rb, iconScale, pos, currentColor);
 		}
 
-		if (!gu->spectatingFullView && ghostIconDimming > 0.0f) {
+		if (!isFullView && ghostIconDimming > 0.0f) {
 			for (const auto& ghost : ghosts) {
 				if (minimap->UseSimpleColors())
 					currentColor = minimap->GetEnemyTeamIconColor();
@@ -609,8 +610,9 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 	sh.Enable();
 	sh.SetUniform("alphaCtrl", 0.05f, 1.0f, 0.0f, 0.0f); // GL_GREATER > 0.05
 
-	const auto allyTeam = gu->myAllyTeam;
 	SColor currentColor;
+	const auto allyTeam = gu->myAllyTeam;
+	const auto isFullView = gu->spectatingFullView;
 	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 
 	for (const auto& [icon, objects] : modelDrawerData->GetUnitsByIcon()) {
@@ -629,7 +631,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			if (!unit->drawIcon)
 				continue;
 
-			const bool canSee = gu->spectatingFullView || (unit->losStatus[allyTeam] && (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS) == (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS));
+			const bool canSee = isFullView || (unit->losStatus[allyTeam] && (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS) == (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS));
 			if (!canSee)
 				continue;
 
@@ -638,7 +640,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			assert(!unit->IsInVoid());
 
 			// drawMidPos is auto-calculated now; can wobble on its own as pieces move
-			float3 pos = (!gu->spectatingFullView) ?
+			float3 pos = (!isFullView) ?
 				unit->GetObjDrawErrorPos(allyTeam) :
 				unit->GetObjDrawMidPos();
 
@@ -650,7 +652,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 				currentColor = color4::white; // selected color
 			} else {
 				currentColor = teamHandler.Team(unit->team)->color;
-				if (!gu->spectatingFullView && !(unit->losStatus[allyTeam] & LOS_INRADAR)) {
+				if (!isFullView && !(unit->losStatus[allyTeam] & LOS_INRADAR)) {
 					if (ghostIconDimming == 0.0f)
 						continue;
 					currentColor.r *= ghostIconDimming;
@@ -662,7 +664,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			DrawUnitIconScreen(rb, icon, pos, currentColor, unit->radius, unit->GetIsIcon());
 		}
 
-		if (!gu->spectatingFullView && ghostIconDimming > 0.0f) {
+		if (!isFullView && ghostIconDimming > 0.0f) {
 			for (const auto& ghost : ghosts) {
 				float3 pos = ghost->midPos;
 

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -661,9 +661,6 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			for (const auto& ghost : ghosts) {
 				float3 pos = ghost->midPos;
 
-				if (gu->spectatingFullView)
-					continue;
-
 				pos = camera->CalcViewPortCoordinates(pos);
 				if (pos.z > 1.0f || pos.z < 0.0f)
 					continue;

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -61,6 +61,7 @@ CONFIG(float, UnitIconFadeVanish).defaultValue(1000.0f).minimumValue(1.0f).maxim
 CONFIG(float, UnitTransparency).defaultValue(0.7f);
 CONFIG(bool, UnitIconsAsUI).defaultValue(false).description("Draw unit icons like it is an UI element and not like unit's LOD.");
 CONFIG(bool, UnitIconsHideWithUI).defaultValue(false).description("Hide unit icons when UI is hidden.");
+CONFIG(float, UnitGhostIconsDimming).defaultValue(0.5).minimumValue(0.0f).maximumValue(1.0f).description("Dimming multiplier for out of radar ghost icons.");
 
 CONFIG(int, MaxDynamicModelLights)
 	.defaultValue(1)
@@ -356,6 +357,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 	sh.SetUniform("alphaCtrl", 0.0f, 1.0f, 0.0f, 0.0f); // GL_GREATER > 0.0
 
 	static constexpr uint8_t defaultColor[4] = { 255, 255, 255, 255 };
+	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 
 	if (!minimap->UseUnitIcons())
 		icon::iconHandler.GetDefaultIconData()->BindTexture();
@@ -404,7 +406,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 				}
 			}
 			if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
-				useColor = SColor{uint8_t(color[0]*0.5), uint8_t(color[1]*0.5), uint8_t(color[2]*0.5), color[3]};
+				useColor = SColor{uint8_t(color[0]*ghostIconDimming), uint8_t(color[1]*ghostIconDimming), uint8_t(color[2]*ghostIconDimming), color[3]};
 				color = useColor;
 			}
 
@@ -423,7 +425,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 				color = minimap->GetEnemyTeamIconColor();
 			else
 				color = teamHandler.Team(ghost->team)->color;
-			color = SColor{uint8_t(color[0]*0.5), uint8_t(color[1]*0.5), uint8_t(color[2]*0.5), color[3]};
+			color = SColor{uint8_t(color[0]*ghostIconDimming), uint8_t(color[1]*ghostIconDimming), uint8_t(color[2]*ghostIconDimming), color[3]};
 
 			const float iconScale = ghost->myIcon->GetSize();
 			const float3& pos = ghost->midPos;
@@ -603,6 +605,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 	sh.SetUniform("alphaCtrl", 0.05f, 1.0f, 0.0f, 0.0f); // GL_GREATER > 0.05
 
 	const auto allyTeam = gu->myAllyTeam;
+	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 
 	for (const auto& [icon, objects] : modelDrawerData->GetUnitsByIcon()) {
 		if (icon == nullptr)
@@ -641,9 +644,9 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			// use white for selected units
 			SColor color = unit->isSelected ? color4::white : SColor{ teamHandler.Team(unit->team)->color };
 			if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
-				color.r = color.r*0.5;
-				color.g = color.g*0.5;
-				color.b = color.b*0.5;
+				color.r = color.r*ghostIconDimming;
+				color.g = color.g*ghostIconDimming;
+				color.b = color.b*ghostIconDimming;
 			}
 
 			DrawUnitIconScreen(rb, icon, pos, color, unit->radius, unit->GetIsIcon());
@@ -659,9 +662,9 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 				continue;
 
 			SColor color = SColor{ teamHandler.Team(ghost->team)->color };
-			color.r = color.r*0.5;
-			color.g = color.g*0.5;
-			color.b = color.b*0.5;
+			color.r = color.r*ghostIconDimming;
+			color.g = color.g*ghostIconDimming;
+			color.b = color.b*ghostIconDimming;
 
 			DrawUnitIconScreen(rb, icon, pos, color, ghost->radius, false);
 		}

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -357,7 +357,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 	sh.SetUniform("alphaCtrl", 0.0f, 1.0f, 0.0f, 0.0f); // GL_GREATER > 0.0
 
 	SColor currentColor;
-	const auto allyTeam = gu->myAllyTeam;
+	const auto myAllyTeam = gu->myAllyTeam;
 	const auto isFullView = gu->spectatingFullView;
 	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 
@@ -395,7 +395,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 					if (unit->team == gu->myTeam) {
 						currentColor = minimap->GetMyTeamIconColor();
 					}
-					else if (teamHandler.Ally(allyTeam, unit->allyteam)) {
+					else if (teamHandler.Ally(myAllyTeam, unit->allyteam)) {
 						currentColor = minimap->GetAllyTeamIconColor();
 					}
 					else {
@@ -406,7 +406,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 					currentColor = teamHandler.Team(unit->team)->color;
 				}
 
-				if (!isFullView && !(unit->losStatus[allyTeam] & LOS_INRADAR)) {
+				if (!isFullView && !(unit->losStatus[myAllyTeam] & LOS_INRADAR)) {
 					if (ghostIconDimming == 0.0f)
 						continue;
 
@@ -418,7 +418,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 
 			const float iconScale = CUnitDrawerHelper::GetUnitIconScale(unit);
 			const float3& pos = (!isFullView) ?
-				unit->GetObjDrawErrorPos(allyTeam) :
+				unit->GetObjDrawErrorPos(myAllyTeam) :
 				unit->GetObjDrawMidPos();
 
 			DrawUnitMiniMapIcon(rb, iconScale, pos, currentColor);
@@ -611,7 +611,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 	sh.SetUniform("alphaCtrl", 0.05f, 1.0f, 0.0f, 0.0f); // GL_GREATER > 0.05
 
 	SColor currentColor;
-	const auto allyTeam = gu->myAllyTeam;
+	const auto myAllyTeam = gu->myAllyTeam;
 	const auto isFullView = gu->spectatingFullView;
 	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 
@@ -631,7 +631,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			if (!unit->drawIcon)
 				continue;
 
-			const bool canSee = isFullView || (unit->losStatus[allyTeam] && (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS) == (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS));
+			const bool canSee = isFullView || (unit->losStatus[myAllyTeam] && (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS) == (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS));
 			if (!canSee)
 				continue;
 
@@ -641,7 +641,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 
 			// drawMidPos is auto-calculated now; can wobble on its own as pieces move
 			float3 pos = (!isFullView) ?
-				unit->GetObjDrawErrorPos(allyTeam) :
+				unit->GetObjDrawErrorPos(myAllyTeam) :
 				unit->GetObjDrawMidPos();
 
 			pos = camera->CalcViewPortCoordinates(pos);
@@ -652,7 +652,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 				currentColor = color4::white; // selected color
 			} else {
 				currentColor = teamHandler.Team(unit->team)->color;
-				if (!isFullView && !(unit->losStatus[allyTeam] & LOS_INRADAR)) {
+				if (!isFullView && !(unit->losStatus[myAllyTeam] & LOS_INRADAR)) {
 					if (ghostIconDimming == 0.0f)
 						continue;
 					currentColor.r *= ghostIconDimming;

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -615,8 +615,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 		if (icon == nullptr)
 			continue;
 
-		const auto& units = objects.first;
-		const auto& ghosts = objects.second;
+		const auto& [units, ghosts] = objects;
 
 		if (units.empty() && ghosts.empty())
 			continue;
@@ -648,7 +647,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			// use white for selected units
 			SColor color = unit->isSelected ? color4::white : SColor{ teamHandler.Team(unit->team)->color };
 			if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
-				if (!ghostIconDimming)
+				if (ghostIconDimming == 0.0f)
 					continue;
 				if (!unit->isSelected) {
 					color.r *= ghostIconDimming;
@@ -660,7 +659,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			DrawUnitIconScreen(rb, icon, pos, color, unit->radius, unit->GetIsIcon());
 		}
 
-		if (!gu->spectatingFullView && ghostIconDimming) {
+		if (!gu->spectatingFullView && ghostIconDimming > 0.0f) {
 			for (const auto& ghost : ghosts) {
 				float3 pos = ghost->midPos;
 

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -385,6 +385,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 				continue;
 
 			const uint8_t* color = &defaultColor[0];
+			SColor useColor;
 
 			if (!unit->isSelected) {
 				if (minimap->UseSimpleColors()) {
@@ -402,6 +403,10 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 					color = teamHandler.Team(unit->team)->color;
 				}
 			}
+			if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
+				useColor = SColor{uint8_t(color[0]*0.5), uint8_t(color[1]*0.5), uint8_t(color[2]*0.5), color[3]};
+				color = useColor;
+			}
 
 			const float iconScale = CUnitDrawerHelper::GetUnitIconScale(unit);
 			const float3& pos = (!gu->spectatingFullView) ?
@@ -418,9 +423,13 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 				color = minimap->GetEnemyTeamIconColor();
 			else
 				color = teamHandler.Team(ghost->team)->color;
+			color = SColor{uint8_t(color[0]*0.5), uint8_t(color[1]*0.5), uint8_t(color[2]*0.5), color[3]};
 
 			const float iconScale = ghost->myIcon->GetSize();
 			const float3& pos = ghost->midPos;
+
+			if (gu->spectatingFullView)
+				continue;
 
 			DrawUnitMiniMapIcon(rb, iconScale, pos, color);
 		}
@@ -631,17 +640,28 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 
 			// use white for selected units
 			SColor color = unit->isSelected ? color4::white : SColor{ teamHandler.Team(unit->team)->color };
+			if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
+				color.r = color.r*0.5;
+				color.g = color.g*0.5;
+				color.b = color.b*0.5;
+			}
 
 			DrawUnitIconScreen(rb, icon, pos, color, unit->radius, unit->GetIsIcon());
 		}
 		for (const auto& ghost : ghosts) {
 			float3 pos = ghost->midPos;
 
+			if (gu->spectatingFullView)
+				continue;
+
 			pos = camera->CalcViewPortCoordinates(pos);
 			if (pos.z > 1.0f || pos.z < 0.0f)
 				continue;
 
 			SColor color = SColor{ teamHandler.Team(ghost->team)->color };
+			color.r = color.r*0.5;
+			color.g = color.g*0.5;
+			color.b = color.b*0.5;
 
 			DrawUnitIconScreen(rb, icon, pos, color, ghost->radius, false);
 		}

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -670,7 +670,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 				if (pos.z > 1.0f || pos.z < 0.0f)
 					continue;
 
-				currentColor = SColor{ teamHandler.Team(ghost->team)->color };
+				currentColor = teamHandler.Team(ghost->team)->color;
 				currentColor.r *= ghostIconDimming;
 				currentColor.g *= ghostIconDimming;
 				currentColor.b *= ghostIconDimming;

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -649,9 +649,9 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
 				if (!ghostIconDimming)
 					continue;
-				color.r = color.r*ghostIconDimming;
-				color.g = color.g*ghostIconDimming;
-				color.b = color.b*ghostIconDimming;
+				color.r *= ghostIconDimming;
+				color.g *= ghostIconDimming;
+				color.b *= ghostIconDimming;
 			}
 
 			DrawUnitIconScreen(rb, icon, pos, color, unit->radius, unit->GetIsIcon());
@@ -669,9 +669,9 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 					continue;
 
 				SColor color = SColor{ teamHandler.Team(ghost->team)->color };
-				color.r = color.r*ghostIconDimming;
-				color.g = color.g*ghostIconDimming;
-				color.b = color.b*ghostIconDimming;
+				color.r *= ghostIconDimming;
+				color.g *= ghostIconDimming;
+				color.b *= ghostIconDimming;
 
 				DrawUnitIconScreen(rb, icon, pos, color, ghost->radius, false);
 			}

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -357,6 +357,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 	sh.SetUniform("alphaCtrl", 0.0f, 1.0f, 0.0f, 0.0f); // GL_GREATER > 0.0
 
 	SColor currentColor;
+	const auto allyTeam = gu->myAllyTeam;
 	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 
 	if (!minimap->UseUnitIcons())
@@ -393,7 +394,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 					if (unit->team == gu->myTeam) {
 						currentColor = minimap->GetMyTeamIconColor();
 					}
-					else if (teamHandler.Ally(gu->myAllyTeam, unit->allyteam)) {
+					else if (teamHandler.Ally(allyTeam, unit->allyteam)) {
 						currentColor = minimap->GetAllyTeamIconColor();
 					}
 					else {
@@ -404,7 +405,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 					currentColor = teamHandler.Team(unit->team)->color;
 				}
 
-				if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
+				if (!gu->spectatingFullView && !(unit->losStatus[allyTeam] & LOS_INRADAR)) {
 					if (ghostIconDimming == 0.0f)
 						continue;
 
@@ -416,7 +417,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 
 			const float iconScale = CUnitDrawerHelper::GetUnitIconScale(unit);
 			const float3& pos = (!gu->spectatingFullView) ?
-				unit->GetObjDrawErrorPos(gu->myAllyTeam) :
+				unit->GetObjDrawErrorPos(allyTeam) :
 				unit->GetObjDrawMidPos();
 
 			DrawUnitMiniMapIcon(rb, iconScale, pos, currentColor);
@@ -628,7 +629,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			if (!unit->drawIcon)
 				continue;
 
-			const bool canSee = gu->spectatingFullView || (unit->losStatus[gu->myAllyTeam] && (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS) == (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS));
+			const bool canSee = gu->spectatingFullView || (unit->losStatus[allyTeam] && (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS) == (LOS_INLOS | LOS_CONTRADAR | LOS_PREVLOS));
 			if (!canSee)
 				continue;
 
@@ -638,7 +639,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 
 			// drawMidPos is auto-calculated now; can wobble on its own as pieces move
 			float3 pos = (!gu->spectatingFullView) ?
-				unit->GetObjDrawErrorPos(gu->myAllyTeam) :
+				unit->GetObjDrawErrorPos(allyTeam) :
 				unit->GetObjDrawMidPos();
 
 			pos = camera->CalcViewPortCoordinates(pos);
@@ -649,7 +650,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 				currentColor = color4::white; // selected color
 			} else {
 				currentColor = teamHandler.Team(unit->team)->color;
-				if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
+				if (!gu->spectatingFullView && !(unit->losStatus[allyTeam] & LOS_INRADAR)) {
 					if (ghostIconDimming == 0.0f)
 						continue;
 					currentColor.r *= ghostIconDimming;

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -403,14 +403,15 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 				else {
 					currentColor = teamHandler.Team(unit->team)->color;
 				}
-			}
-			if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
-				if (ghostIconDimming == 0.0f)
-					continue;
 
-				currentColor.r *= ghostIconDimming;
-				currentColor.g *= ghostIconDimming;
-				currentColor.b *= ghostIconDimming;
+				if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
+					if (ghostIconDimming == 0.0f)
+						continue;
+
+					currentColor.r *= ghostIconDimming;
+					currentColor.g *= ghostIconDimming;
+					currentColor.b *= ghostIconDimming;
+				}
 			}
 
 			const float iconScale = CUnitDrawerHelper::GetUnitIconScale(unit);
@@ -649,9 +650,11 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
 				if (!ghostIconDimming)
 					continue;
-				color.r *= ghostIconDimming;
-				color.g *= ghostIconDimming;
-				color.b *= ghostIconDimming;
+				if (!unit->isSelected) {
+					color.r *= ghostIconDimming;
+					color.g *= ghostIconDimming;
+					color.b *= ghostIconDimming;
+				}
 			}
 
 			DrawUnitIconScreen(rb, icon, pos, color, unit->radius, unit->GetIsIcon());

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -386,7 +386,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 				continue;
 
 			if (unit->isSelected) {
-				currentColor = SColor{ 255, 255, 255, 255 }; // selected color
+				currentColor = color4::white; // selected color
 			}
 			else {
 				if (minimap->UseSimpleColors()) {
@@ -609,6 +609,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 	sh.SetUniform("alphaCtrl", 0.05f, 1.0f, 0.0f, 0.0f); // GL_GREATER > 0.05
 
 	const auto allyTeam = gu->myAllyTeam;
+	SColor currentColor;
 	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 
 	for (const auto& [icon, objects] : modelDrawerData->GetUnitsByIcon()) {
@@ -644,19 +645,20 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			if (pos.z > 1.0f || pos.z < 0.0f)
 				continue;
 
-			// use white for selected units
-			SColor color = unit->isSelected ? color4::white : SColor{ teamHandler.Team(unit->team)->color };
-			if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
-				if (ghostIconDimming == 0.0f)
-					continue;
-				if (!unit->isSelected) {
-					color.r *= ghostIconDimming;
-					color.g *= ghostIconDimming;
-					color.b *= ghostIconDimming;
+			if (unit->isSelected) {
+				currentColor = color4::white; // selected color
+			} else {
+				currentColor = teamHandler.Team(unit->team)->color;
+				if (!gu->spectatingFullView && !(unit->losStatus[gu->myAllyTeam] & LOS_INRADAR)) {
+					if (ghostIconDimming == 0.0f)
+						continue;
+					currentColor.r *= ghostIconDimming;
+					currentColor.g *= ghostIconDimming;
+					currentColor.b *= ghostIconDimming;
 				}
 			}
 
-			DrawUnitIconScreen(rb, icon, pos, color, unit->radius, unit->GetIsIcon());
+			DrawUnitIconScreen(rb, icon, pos, currentColor, unit->radius, unit->GetIsIcon());
 		}
 
 		if (!gu->spectatingFullView && ghostIconDimming > 0.0f) {
@@ -667,12 +669,12 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 				if (pos.z > 1.0f || pos.z < 0.0f)
 					continue;
 
-				SColor color = SColor{ teamHandler.Team(ghost->team)->color };
-				color.r *= ghostIconDimming;
-				color.g *= ghostIconDimming;
-				color.b *= ghostIconDimming;
+				currentColor = SColor{ teamHandler.Team(ghost->team)->color };
+				currentColor.r *= ghostIconDimming;
+				currentColor.g *= ghostIconDimming;
+				currentColor.b *= ghostIconDimming;
 
-				DrawUnitIconScreen(rb, icon, pos, color, ghost->radius, false);
+				DrawUnitIconScreen(rb, icon, pos, currentColor, ghost->radius, false);
 			}
 		}
 

--- a/rts/Rendering/Units/UnitDrawer.h
+++ b/rts/Rendering/Units/UnitDrawer.h
@@ -188,7 +188,7 @@ protected:
 	void PopIndividualOpaqueState(const S3DModel* model, int teamID, bool deferredPass) const;
 	void PopIndividualAlphaState(const S3DModel* model, int teamID, bool deferredPass) const;
 
-	void DrawUnitMiniMapIcon(TypedRenderBuffer<VA_TYPE_2DTC>& rb, const float iconScale, const float3& pos, const uint8_t* color) const;
+	void DrawUnitMiniMapIcon(TypedRenderBuffer<VA_TYPE_2DTC>& rb, const float iconScale, const float3& pos, const SColor& color) const;
 	float DrawUnitIcon(TypedRenderBuffer<VA_TYPE_TC>& rb, const icon::CIconData* icon, const float iconRadius, float3 pos, const uint8_t* color, const float unitRadius) const;
 	void DrawUnitIconScreen(TypedRenderBuffer<VA_TYPE_2DTC>& rb, const icon::CIconData* icon, const float3 pos, SColor& color, const float unitRadius, bool isIcon) const;
 };

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -122,6 +122,8 @@ CUnitDrawerData::CUnitDrawerData(bool& mtModelDrawer_)
 	iconHideWithUI = configHandler->GetBool("UnitIconsHideWithUI");
 	ghostIconDimming = configHandler->GetFloat("UnitGhostIconsDimming");
 
+	configHandler->NotifyOnChange(this, {"UnitGhostIconsDimming"});
+
 	unitDefImages.clear();
 	unitDefImages.resize(unitDefHandler->NumUnitDefs() + 1);
 
@@ -162,6 +164,13 @@ CUnitDrawerData::~CUnitDrawerData()
 	}
 
 	unitsByIcon.clear();
+
+	configHandler->RemoveObserver(this);
+}
+
+void CUnitDrawerData::ConfigNotify(const std::string& key, const std::string& value)
+{
+	ghostIconDimming = configHandler->GetFloat("UnitGhostIconsDimming");
 }
 
 void CUnitDrawerData::Update()

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -120,6 +120,7 @@ CUnitDrawerData::CUnitDrawerData(bool& mtModelDrawer_)
 	iconFadeVanish = configHandler->GetFloat("UnitIconFadeVanish");
 	useScreenIcons = configHandler->GetBool("UnitIconsAsUI");
 	iconHideWithUI = configHandler->GetBool("UnitIconsHideWithUI");
+	ghostIconDimming = configHandler->GetFloat("UnitGhostIconsDimming");
 
 	unitDefImages.clear();
 	unitDefImages.resize(unitDefHandler->NumUnitDefs() + 1);

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -176,6 +176,8 @@ public:
 	float iconScale = 1.0f;
 	float iconFadeStart = 3000.0f;
 	float iconFadeVanish = 1000.0f;
+
+	void ConfigNotify(const std::string& key, const std::string& value);
 private:
 	SavedData savedData;
 

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -167,6 +167,7 @@ public:
 
 	//icons
 	bool iconHideWithUI = true;
+	float ghostIconDimming = 0.5f;
 
 	// IconsAsUI
 	bool useScreenIcons = false;


### PR DESCRIPTION
### Work done

- Fix dead ghost icons appearing for specs.
  - they don't see the ghosts so shouldn't see the icons either
- Fix "dead" and "alive but not under radar" ghost icons being indistinguishable from  regular radar icons.
  - achieved this by making them show more dimmed
- Make the dimming configurable through UnitGhostIconsDimming config option
  - Also setting to 0 allows disabling icons for ghosts not under radar (first step to fix ([#641](https://github.com/beyond-all-reason/spring/issues/641))
- Apply some cosmetic changes for consistency between DrawUnitMiniMapIcons and DrawUnitIconsScreen code.

### Related issues:

- https://github.com/beyond-all-reason/spring/issues/2031
- https://github.com/beyond-all-reason/spring/issues/2032
- https://github.com/beyond-all-reason/spring/issues/641

### Screenshots

how specs see it (click to see larger):

<img src="https://github.com/user-attachments/assets/f040b429-023a-4061-8eba-5295e526032c" width="400">

how a player sees it:

(note how the two solars at the bottom are dimmed, one is dead and the other one alive, but the player doesn't know since he doesn't have radar coverage).

<img src="https://github.com/user-attachments/assets/f0124cd3-f8ed-4ea8-a030-b71453bceaa7" width="400">

all colors comparison for 16 players (dimming 0.5):

![team-red](https://github.com/user-attachments/assets/cbd05728-aa63-4164-8788-88436db191a0)

![team-blue](https://github.com/user-attachments/assets/b29596bc-3311-4837-9fb9-1358b05772c6)

on minimap:

![under-radar](https://github.com/user-attachments/assets/8b735352-d40c-49e2-84de-cad87afd8be9)
