### PR TITLE
Run workflows that commit and publish things only in upstream

### DIFF
--- a/.github/workflows/generate-lua-library.yml
+++ b/.github/workflows/generate-lua-library.yml
@@ -8,6 +8,7 @@ on:
       - 'rts/Lua/**'
 jobs:
   generate-library:
+    if: github.repository == 'beyond-all-reason/spring' || github.event_name == 'workflow_dispatch'
     name: Regenerate library
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   publish:
+    if: github.repository == 'beyond-all-reason/spring' || github.event_name == 'workflow_dispatch'
     name: Publish Site
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The workflows can still be executed manually on forks, but they should not be automatically executed.

cc @rhys-vdw 