### PR TITLE
Fix doc errors

### DIFF
--- a/doc/emmlua-doc-cli-template/index_template.tl
+++ b/doc/emmlua-doc-cli-template/index_template.tl
@@ -5,7 +5,10 @@ nav_order: 5
 has_children: true
 has_toc: false
 permalink: lua-api
+render_with_liquid: false
 ---
+{# Use `render_with_liquid: false` when we upgrade to Jekyl >=4.0 #}
+{{ "{% raw %}" }}
 
 # index
 
@@ -28,3 +31,5 @@ permalink: lua-api
 - [{{ item.name }}]({{ item.file }})
 {% endfor %}
 {% endif %}
+
+{{ "{% endraw %}" }}

--- a/doc/emmlua-doc-cli-template/lua_alias_template.tl
+++ b/doc/emmlua-doc-cli-template/lua_alias_template.tl
@@ -4,6 +4,8 @@ title: {{ type_name }}
 parent: Lua API
 permalink: lua-api/types/{{ type_name }}
 ---
+{# Use `render_with_liquid: false` when we upgrade to Jekyl >=4.0 #}
+{{ "{% raw %}" }}
 
 # alias {{ type_name }}
 ---
@@ -18,3 +20,5 @@ permalink: lua-api/types/{{ type_name }}
 {% if description %}
 {{ description }}
 {% endif %}
+
+{{ "{% endraw %}" }}

--- a/doc/emmlua-doc-cli-template/lua_enum_template.tl
+++ b/doc/emmlua-doc-cli-template/lua_enum_template.tl
@@ -4,6 +4,8 @@ title: {{ type_name }}
 parent: Lua API
 permalink: lua-api/types/{{ type_name }}
 ---
+{# Use `render_with_liquid: false` when we upgrade to Jekyl >=4.0 #}
+{{ "{% raw %}" }}
 
 # enum {{ type_name }}
 ---
@@ -26,3 +28,5 @@ permalink: lua-api/types/{{ type_name }}
 {{ field.description }}
 
 {% endfor %}
+
+{{ "{% endraw %}" }}

--- a/doc/emmlua-doc-cli-template/lua_global_template.tl
+++ b/doc/emmlua-doc-cli-template/lua_global_template.tl
@@ -4,6 +4,8 @@ title: {{ global_name }}
 parent: Lua API
 permalink: lua-api/globals/{{ global_name }}
 ---
+{# Use `render_with_liquid: false` when we upgrade to Jekyl >=4.0 #}
+{{ "{% raw %}" }}
 
 # global {{ global_name }}
 
@@ -38,3 +40,5 @@ permalink: lua-api/globals/{{ global_name }}
 {% endif %}
 {% endfor %}
 {% endif %}
+
+{{ "{% endraw %}" }}

--- a/doc/emmlua-doc-cli-template/lua_global_template_simple.tl
+++ b/doc/emmlua-doc-cli-template/lua_global_template_simple.tl
@@ -4,6 +4,8 @@ title: {{ global_name }}
 parent: Lua API
 permalink: lua-api/globals/{{ global_name }}
 ---
+{# Use `render_with_liquid: false` when we upgrade to Jekyl >=4.0 #}
+{{ "{% raw %}" }}
 
 # global {{ global_name }}
 
@@ -14,3 +16,5 @@ permalink: lua-api/globals/{{ global_name }}
 {% if description %}
 {{ description }}
 {% endif %}
+
+{{ "{% endraw %}" }}

--- a/doc/emmlua-doc-cli-template/lua_module_template.tl
+++ b/doc/emmlua-doc-cli-template/lua_module_template.tl
@@ -4,6 +4,8 @@ title: {{ module_name }}
 parent: Lua API
 permalink: lua-api/modules/{{ module_name }}
 ---
+{# Use `render_with_liquid: false` when we upgrade to Jekyl >=4.0 #}
+{{ "{% raw %}" }}
 
 # {{ module_name }}
 
@@ -38,3 +40,5 @@ permalink: lua-api/modules/{{ module_name }}
 {% endif %}
 {% endfor %}
 {% endif %}
+
+{{ "{% endraw %}" }}

--- a/doc/emmlua-doc-cli-template/lua_type_template.tl
+++ b/doc/emmlua-doc-cli-template/lua_type_template.tl
@@ -4,6 +4,8 @@ title: {{ type_name }}
 parent: Lua API
 permalink: lua-api/types/{{ type_name }}
 ---
+{# Use `render_with_liquid: false` when we upgrade to Jekyl >=4.0 #}
+{{ "{% raw %}" }}
 
 # class {{ type_name }}
 
@@ -45,3 +47,5 @@ permalink: lua-api/types/{{ type_name }}
 {% endif %}
 {% endfor %}
 {% endif %}
+
+{{ "{% endraw %}" }}

--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -601,33 +601,22 @@ std::tuple<uint32_t, uint32_t, uint32_t> LuaVBOImpl::GetBufferSize()
 
 
 /***
- * Uploads the data (array of floats) into the VBO
+ * Uploads data into the VBO.
  *
- * ```lua
- * vbo:Upload(posArray, 0, 1)
- * -- 0 is offset into vbo (on GPU) in this case no offset
- * -- 1 is lua index index into the Lua table, in this case it's same as default
- * -- Upload will upload from luaOffset to end of lua array
- * ```
- * 
- * ```lua
- * @usage rectInstanceVBO:Upload({1},0)
- * ```
- * 
  * @function VBO:Upload
- * @param vboData number[] a lua array of values to upload into the VBO
+ * @param vboData number[] Array of values to upload into the VBO.
  * @param attributeIndex integer? (Default: `-1`)
  * 
- * If supplied with non-default value then the data from vboData will only be
+ * If supplied with non-default value then the data from `vboData` will only be
  * used to upload the data to this particular attribute.
  * 
- * The whole vboData is expected to contain only attributeIndex data.
+ * The whole `vboData` is expected to contain only attributeIndex data.
  * 
  * Otherwise all attributes get updated sequentially across attributes and elements.
  *
- * @param elemOffset integer? (Default: `0`) Which VBO element to start uploading data from Lua array into.
- * @param luaStartIndex integer? (Default: `1`) Start uploading from that element in supplied Lua array.
- * @param luaFinishIndex integer? Consider this element the last element in Lua array.
+ * @param elemOffset integer? (Default: `0`) The index in destination VBO (on GPU) at which storing begins.
+ * @param luaStartIndex integer? (Default: `1`) The index of `vboData` at which copying begins.
+ * @param luaFinishIndex integer? (Default: `#vboData`) The index of `vboData` at which copying ends.
  * @return number[] indexData
  * @return integer elemOffset
  * @return integer|[integer,integer,integer,integer] attrID


### PR DESCRIPTION
- Fix issue where `{{ }}` in lua doc would cause liquid parser errors.
- Fix Lua doc which caused an error in `emmylua_doc_cli`: https://github.com/CppCXY/emmylua-analyzer-rust/issues/306