### PR TITLE
Deprecate draw functions

### DIFF
--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -211,6 +211,7 @@ void CUnsyncedLuaHandle::RecvFromSynced(lua_State* srcState, int args)
  * @param unitID integer
  * @param drawMode number
  * @return boolean suppressEngineDraw
+ * @deprecated
  */
 bool CUnsyncedLuaHandle::DrawUnit(const CUnit* unit)
 {
@@ -247,6 +248,7 @@ bool CUnsyncedLuaHandle::DrawUnit(const CUnit* unit)
  * @param featureID integer
  * @param drawMode number
  * @return boolean suppressEngineDraw
+ * @deprecated
  */
 bool CUnsyncedLuaHandle::DrawFeature(const CFeature* feature)
 {
@@ -283,6 +285,7 @@ bool CUnsyncedLuaHandle::DrawFeature(const CFeature* feature)
  * @param weaponID integer
  * @param drawMode number
  * @return boolean suppressEngineDraw
+ * @deprecated
  */
 bool CUnsyncedLuaHandle::DrawShield(const CUnit* unit, const CWeapon* weapon)
 {
@@ -320,6 +323,7 @@ bool CUnsyncedLuaHandle::DrawShield(const CUnit* unit, const CWeapon* weapon)
  * @param projectileID integer
  * @param drawMode number
  * @return boolean suppressEngineDraw
+ * @deprecated
  */
 bool CUnsyncedLuaHandle::DrawProjectile(const CProjectile* projectile)
 {
@@ -357,6 +361,7 @@ bool CUnsyncedLuaHandle::DrawProjectile(const CProjectile* projectile)
  * @param uuid number
  * @param drawMode number
  * @return boolean suppressEngineDraw
+ * @deprecated
  */
 bool CUnsyncedLuaHandle::DrawMaterial(const LuaMaterial* material)
 {


### PR DESCRIPTION
Deprecate `UnsyncedCallins:Draw*` functions.

This will cause warnings in IDE when using Lua types.

Shortcomings:
- This does not add any deprecation reason, nor suggestion for other API because I don't know what they should be.
- Deprecation is not reflected in docs website (upstream: https://github.com/CppCXY/emmylua-analyzer-rust/issues/307)

cc @lhog, @sprunk for suggestions on deprecation messages.

Partially addresses #2114