### PR TITLE
Use L3 cache to choose a performance core for the main thread to pin to.

### DIFF
--- a/rts/System/Platform/CpuID.cpp
+++ b/rts/System/Platform/CpuID.cpp
@@ -96,6 +96,7 @@ namespace springproc {
 
 	void CPUID::EnumerateCores() {
 		processorMasks = cpu_topology::GetProcessorMasks();
+		processorCaches = cpu_topology::GetProcessorCache();
 
 		const uint32_t logicalCountMask  = (processorMasks.efficiencyCoreMask | processorMasks.performanceCoreMask);
 		const uint32_t perfCoreCountMask = processorMasks.performanceCoreMask & ~processorMasks.hyperThreadHighMask;

--- a/rts/System/Platform/CpuID.h
+++ b/rts/System/Platform/CpuID.h
@@ -51,6 +51,7 @@ namespace springproc {
 		bool HasHyperThreading() const { return smtDetected; };
 
 		cpu_topology::ProcessorMasks GetAvailableProcessorAffinityMask() const { return processorMasks; };
+		cpu_topology::ProcessorCaches GetProcessorCaches() const { return processorCaches; }
 
 	private:
 		CPUID();
@@ -62,6 +63,7 @@ namespace springproc {
 		int numPerformanceCores;
 
 		cpu_topology::ProcessorMasks processorMasks;
+		cpu_topology::ProcessorCaches processorCaches;
 
 		bool smtDetected;
 	};

--- a/rts/System/Platform/CpuTopology.h
+++ b/rts/System/Platform/CpuTopology.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
 
 namespace cpu_topology {
+
+static constexpr uint32_t MAX_CACHE_LEVELS = 3;
 
 struct ProcessorMasks {
 	uint32_t performanceCoreMask = 0;
@@ -11,7 +14,17 @@ struct ProcessorMasks {
 	uint32_t hyperThreadHighMask = 0;
 };
 
+struct ProcessorGroupCaches {
+	uint32_t groupMask = 0;
+	uint32_t cacheSizes[MAX_CACHE_LEVELS] = {0, 0, 0};
+};
+
+struct ProcessorCaches {
+	std::vector<ProcessorGroupCaches> groupCaches;
+};
+
 // OS-specific implementation to get the processor masks.
 ProcessorMasks GetProcessorMasks();
+ProcessorCaches GetProcessorCache();
 
 }

--- a/rts/System/Platform/Linux/CpuTopology.cpp
+++ b/rts/System/Platform/Linux/CpuTopology.cpp
@@ -161,4 +161,67 @@ ProcessorMasks GetProcessorMasks() {
 	return processorMasks;
 }
 
+uint32_t get_thread_cache(int cpu) {
+	std::ifstream file("/sys/devices/system/cpu/cpu" + std::to_string(cpu) + "/cache/index3/size");
+	uint32_t sizeInBytes = 0;
+	if (file) {
+		std::string line;
+		std::getline(file, line);
+		std::istringstream ss(line);
+		ss >> sizeInBytes;
+	}
+	return sizeInBytes;
+}
+
+ProcessorGroupCaches& get_group_cache(ProcessorCaches& processorCaches, uint32_t cacheSize) {
+	auto foundCache = std::find_if
+		( processorCaches.groupCaches.begin()
+		, processorCaches.groupCaches.end()
+		, [cacheSize](const auto& gc) -> bool { return (gc.cacheSizes[2] == cacheSize); });
+
+	if (foundCache == processorCaches.groupCaches.end()) {
+		processorCaches.groupCaches.push_back({});
+		auto& newCacheGroup = processorCaches.groupCaches[processorCaches.groupCaches.size()-1];
+		newCacheGroup.cacheSizes[2] = cacheSize;
+		return newCacheGroup;
+	}
+
+	return (*foundCache);
+}
+
+// Notes.
+// Here we are grouping by the cache size, which isn't the same a groups and their cache sizes.
+// This is fine what our needs at the moment. We're currently only looking a performance core
+// with the most cache for the main thread.
+// We are also only looking at L3 caches at the moment.
+ProcessorCaches GetProcessorCache() {
+	ProcessorCaches processorCaches;
+	int num_cpus = get_cpu_count();
+
+	for (int cpu = 0; cpu < num_cpus; ++cpu) {
+		if (cpu >= MAX_CPUS) {
+			LOG_L(L_WARNING, "CPU index %d exceeds bitset limit.", cpu);
+			continue;
+		}
+		uint32_t cacheSize = get_thread_cache(cpu);
+		ProcessorGroupCaches& groupCache = get_group_cache(processorCaches, cacheSize);
+
+		groupCache.groupMask |= (0x1 << cpu);
+	}
+
+	std::stable_sort
+		( processorCaches.groupCaches.begin()
+		, processorCaches.groupCaches.end()
+		// sort larger to the bottom.
+		, [](const auto &lh, const auto &rh) -> bool { return lh.cacheSizes[2] > rh.cacheSizes[2]; });
+
+	std::for_each
+		( processorCaches.groupCaches.begin()
+		, processorCaches.groupCaches.end()
+		, [](const auto& cache) -> void { LOG("Found logical processors (mask 0x%08x) using L3 cache (sized %dKB) ", cache.groupMask, cache.cacheSizes[2] / 1024); });
+
+
+	return processorCaches;
+}
+
 } //namespace cpu_topology

--- a/rts/System/Platform/Threading.h
+++ b/rts/System/Platform/Threading.h
@@ -126,6 +126,7 @@ namespace Threading {
 	bool HasHyperThreading();
 
 	uint32_t GetSystemAffinityMask();
+	uint32_t GetPreferredMainThreadMask();
 
 	/**
 	 * Inform the OS kernel that we are a cpu-intensive task

--- a/rts/System/Platform/Win/CpuTopology.cpp
+++ b/rts/System/Platform/Win/CpuTopology.cpp
@@ -2,6 +2,7 @@
 
 #include "System/Log/ILog.h"
 
+#include <algorithm>
 #include <bit>
 #include <set>
 #include <windows.h>
@@ -35,13 +36,27 @@ namespace spring_overrides {
 		RelationAll = 0xffff
 		} LOGICAL_PROCESSOR_RELATIONSHIP;
 
-	typedef struct _PROCESSOR_RELATIONSHIP {
+	typedef struct {
 		BYTE Flags;
 		BYTE EfficiencyClass;
 		BYTE Reserved[20];
 		WORD GroupCount;
 		GROUP_AFFINITY GroupMask[ANYSIZE_ARRAY];
-		} PROCESSOR_RELATIONSHIP,*PPROCESSOR_RELATIONSHIP;
+	} PROCESSOR_RELATIONSHIP,*PPROCESSOR_RELATIONSHIP;
+
+	typedef struct {
+		BYTE                 Level;
+		BYTE                 Associativity;
+		WORD                 LineSize;
+		DWORD                CacheSize;
+		PROCESSOR_CACHE_TYPE Type;
+		BYTE                 Reserved[18];
+		WORD                 GroupCount;
+		union {
+		  GROUP_AFFINITY GroupMask;
+		  GROUP_AFFINITY GroupMasks[ANYSIZE_ARRAY];
+		} DUMMYUNIONNAME;
+	} CACHE_RELATIONSHIP, *PCACHE_RELATIONSHIP;
 
 	typedef struct _SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
 		LOGICAL_PROCESSOR_RELATIONSHIP Relationship;
@@ -64,15 +79,14 @@ namespace spring_overrides {
 }
 
 
-ProcessorMasks GetProcessorMasks() {
+BOOL GetProcessorInformation
+	( spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX& buffer
+	, DWORD& returnLength
+	, cpu_topology::spring_overrides::LOGICAL_PROCESSOR_RELATIONSHIP queryRelationshipType
+	)
+{
 	spring_overrides::GetLogicalProcessorInformationExFunc Local_GetLogicalProcessorInformationEx;
-	spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX buffer = NULL;
-	spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX ptr = NULL;
-	DWORD returnLength = 0;
-	DWORD byteOffset = 0;
 	BOOL done = FALSE;
-	BYTE performanceClass = 0;
-	ProcessorMasks processorMasks;
 
 	Local_GetLogicalProcessorInformationEx = (spring_overrides::GetLogicalProcessorInformationExFunc) GetProcAddress(
 		GetModuleHandle(TEXT("kernel32")),
@@ -80,12 +94,12 @@ ProcessorMasks GetProcessorMasks() {
 	if (NULL == Local_GetLogicalProcessorInformationEx)
 	{
 		LOG("GetLogicalProcessorInformation is not supported.\n");
-		return processorMasks;
+		return FALSE;
 	}
 
 	while (!done)
 	{
-		DWORD rc = Local_GetLogicalProcessorInformationEx(spring_overrides::RelationProcessorCore, buffer, &returnLength);
+		DWORD rc = Local_GetLogicalProcessorInformationEx(queryRelationshipType, buffer, &returnLength);
 
 		if (FALSE == rc)
 		{
@@ -97,13 +111,27 @@ ProcessorMasks GetProcessorMasks() {
 				buffer = (spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)malloc(returnLength);
 
 				if (NULL == buffer)
-					return processorMasks;
+					return FALSE;
 			}
 			else
-				return processorMasks;
+				return FALSE;
 		}
 		else
 			done = TRUE;
+	}
+	return TRUE;
+}
+
+ProcessorMasks GetProcessorMasks() {
+	spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX buffer = NULL;
+	spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX ptr = NULL;
+	DWORD returnLength = 0;
+	DWORD byteOffset = 0;
+	BYTE performanceClass = 0;
+	ProcessorMasks processorMasks;
+
+	if (GetProcessorInformation(buffer, returnLength, spring_overrides::RelationProcessorCore) == FALSE){
+		return processorMasks;
 	}
 
 	// The number of EfficiencyClass values depends on the processor.The highest numbered class is always the
@@ -121,6 +149,7 @@ ProcessorMasks GetProcessorMasks() {
 		ptr = (spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)(((char*)buffer) + byteOffset);
 	}
 
+	// Now collect the logical processor masks.
 	ptr = buffer;
 	byteOffset = 0;
 	while (byteOffset < returnLength)
@@ -154,6 +183,58 @@ ProcessorMasks GetProcessorMasks() {
 		free(buffer);
 
 	return processorMasks;
+}
+
+ProcessorCaches GetProcessorCache() {
+	spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX buffer = NULL;
+	spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX ptr = NULL;
+	DWORD returnLength = 0;
+	DWORD byteOffset = 0;
+	ProcessorCaches processorCaches;
+
+	if (GetProcessorInformation(buffer, returnLength, spring_overrides::RelationCache) == FALSE) {
+		return processorCaches;
+	}
+
+	ptr = buffer;
+	byteOffset = 0;
+	while (byteOffset < returnLength)
+	{
+		if (ptr->Relationship == spring_overrides::RelationCache && ptr->Cache.Level == 3)
+		{
+			const uint32_t supportedMask = static_cast<uint32_t>(ptr->Cache.GroupMasks[0].Mask);
+			if (supportedMask == 0) {
+				LOG("Info: Processor group %d has a thread mask outside of the supported range."
+					, int(ptr->Processor.GroupCount));
+				break;
+			}
+
+			ProcessorGroupCaches groupCache;
+			groupCache.groupMask = supportedMask;
+			groupCache.cacheSizes[ptr->Cache.Level - 1] = ptr->Cache.CacheSize;
+
+			processorCaches.groupCaches.push_back(groupCache);
+		}
+
+		byteOffset += ptr->Size;
+		ptr = (spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)(((char*)buffer) + byteOffset);
+	}
+
+	if (buffer)
+		free(buffer);
+
+	std::stable_sort
+		( processorCaches.groupCaches.begin()
+		, processorCaches.groupCaches.end()
+		// sort larger to the bottom.
+		, [](const auto &lh, const auto &rh) -> bool { return lh.cacheSizes[2] > rh.cacheSizes[2]; });
+
+	std::for_each
+		( processorCaches.groupCaches.begin()
+		, processorCaches.groupCaches.end()
+		, [](const auto& cache) -> void { LOG("Found logical processors (mask 0x%08x) using L3 cache (sized %dKB) ", cache.groupMask, cache.cacheSizes[2] / 1024); });
+
+	return processorCaches;
 }
 
 } //namespace cpu_topology

--- a/rts/System/Platform/Win/CpuTopology.cpp
+++ b/rts/System/Platform/Win/CpuTopology.cpp
@@ -185,6 +185,8 @@ ProcessorMasks GetProcessorMasks() {
 	return processorMasks;
 }
 
+// Notes. We're only interested in L3 cache sizes at the moment becasue we're only using this
+// information to find a performance core with the most cache to pin the main thread to.
 ProcessorCaches GetProcessorCache() {
 	spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX buffer = NULL;
 	spring_overrides::PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX ptr = NULL;

--- a/rts/System/Threading/ThreadPool.cpp
+++ b/rts/System/Threading/ThreadPool.cpp
@@ -592,7 +592,9 @@ void SetDefaultThreadCount()
 	std::uint32_t mainAffinity = systemCores;
 
 	#ifndef UNIT_TEST
-	mainAffinity &= configHandler->GetUnsigned("SetCoreAffinity");
+	std::uint32_t configAffinity = configHandler->GetUnsigned("SetCoreAffinity");
+	mainAffinity &= (configAffinity != 0) ? configAffinity : Threading::GetPreferredMainThreadMask();
+	LOG("[ThreadPool] Main thread affinity requested as 0x%08x", mainAffinity);
 	#endif
 
 	std::uint32_t workerAvailCores = systemCores & ~mainAffinity;


### PR DESCRIPTION
This will ensure AMD X3D CPUs will have the main thread on the CCU with the most cache. It will also help keep the main thread on an AMD performance core if running on an AMD CPU with mixed cores (lie 4 and 4c for example.)