### PR TITLE
Remove old Draw* callins that no longer exist

### DIFF
--- a/cont/LuaUI/callins.lua
+++ b/cont/LuaUI/callins.lua
@@ -74,11 +74,6 @@ CallInsList = {
 	"FeatureDestroyed",
 
 	"DrawGenesis",
-	"DrawWater",
-	"DrawSky",
-	"DrawSun",
-	"DrawGrass",
-	"DrawTrees",
 	"DrawWorld",
 	"DrawWorldPreUnit",
 	"DrawWorldPreParticles",


### PR DESCRIPTION
Can't find any reference to these callins. As far as I can tell no longer exist.

More discussion here:

https://github.com/beyond-all-reason/spring/pull/2118#issuecomment-2766635058