### PR TITLE
Remove the max time for out of map guards.

### DIFF
--- a/cont/base/springcontent/LuaGadgets/Gadgets/control_guard.lua
+++ b/cont/base/springcontent/LuaGadgets/Gadgets/control_guard.lua
@@ -32,7 +32,8 @@ local isMobileUnit = {}
 local isBuilder = {}
 
 for unitDefID, udef in pairs(UnitDefs) do
-	if not (udef.isBuilding or udef.speed == 0) then
+	if not udef.isImmobile then
+
 		isMobileUnit[unitDefID] = true
 	end
 	if udef.isBuilder and (udef.buildSpeed and udef.buildSpeed > 0) and (udef.buildDistance and udef.buildDistance > 0) then

--- a/cont/base/springcontent/LuaGadgets/Gadgets/control_guard.lua
+++ b/cont/base/springcontent/LuaGadgets/Gadgets/control_guard.lua
@@ -1,0 +1,128 @@
+
+function gadget:GetInfo()
+	return {
+		name = "Control guard out of map",
+		desc = "Prevent units guarding other units out of map, unless both are builders",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
+local spGetUnitPosition = Spring.GetUnitPosition
+local spGetUnitDefID = Spring.GetUnitDefID
+local spValidUnitID = Spring.ValidUnitID
+local spGiveOrderToUnit = Spring.GiveOrderToUnit
+local spIsPosInMap = Spring.IsPosInMap
+
+local CMD_GUARD = CMD.GUARD
+local CMD_INSERT = CMD.INSERT
+local CMD_INTERNAL = CMD.OPT_INTERNAL
+
+local math_bit_and = math.bit_and
+
+local MAX_TIME_OUT_OF_MAP = Game.gameSpeed*5
+
+local isMobileUnit = {}
+local isBuilder = {}
+
+for unitDefID, udef in pairs(UnitDefs) do
+	if not (udef.isBuilding or udef.speed == 0) then
+		isMobileUnit[unitDefID] = true
+	end
+	if udef.isBuilder and (udef.buildSpeed and udef.buildSpeed > 0) and (udef.buildDistance and udef.buildDistance > 0) then
+		isBuilder[unitDefID] = true
+	end
+end
+
+local allMobileUnits = {}
+local guardingUnits = {}
+
+function gadget:Initialize()
+	gadgetHandler:RegisterAllowCommand(CMD_STOP)
+	gadgetHandler:RegisterAllowCommand(CMD_GUARD)
+	gadgetHandler:RegisterAllowCommand(CMD_INSERT)
+	for _, unitID in pairs(Spring.GetAllUnits()) do
+		gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID))
+	end
+end
+
+function gadget:UnitCreated(unitID, unitDefID, unitTeam)
+	if isMobileUnit[unitDefID] then
+		allMobileUnits[unitID] = true
+	end
+end
+
+function gadget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam, weaponDefID)
+	allMobileUnits[unitID] = nil
+	guardingUnits[unitID] = nil
+end
+
+local function isInsideMap(unitID)
+	local x,_,z = spGetUnitPosition(unitID)
+	return spIsPosInMap(x, z)
+end
+
+local function maybeCancelGuard(unitID, cmdTag, guardeeID, frame)
+	if guardeeID and spValidUnitID(guardeeID) then
+		if isInsideMap(guardeeID) then
+			guardingUnits[unitID] = frame
+		else
+			if frame - guardingUnits[unitID] > MAX_TIME_OUT_OF_MAP then
+				spGiveOrderToUnit(unitID, CMD.REMOVE, cmdTag)
+			end
+		end
+	else
+		guardingUnits[unitID] = nil
+	end
+end
+
+function gadget:GameFrame(f)
+	if f % 69 == 0 then
+		for unitID, _ in pairs(guardingUnits) do
+			local cmdID, cmdOptions, cmdTag, cmdParam1  = spGetUnitCurrentCommand(unitID)
+			if cmdID and math_bit_and(cmdOptions, CMD_INTERNAL) == CMD_INTERNAL then
+				cmdID, cmdOptions, cmdTag, cmdParam1  = spGetUnitCurrentCommand(unitID, 2)
+			end
+			if cmdID == CMD_GUARD then
+				maybeCancelGuard(unitID, cmdTag, cmdParam1, f)
+			elseif not cmdID then
+				guardingUnits[unitID] = nil
+			end
+		end
+	end
+end
+
+function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOptions, cmdTag, fromSynced, fromLua)
+	if not isMobileUnit[unitDefID] then
+		return true
+	end
+	if cmdID == CMD_GUARD or cmdID == CMD_INSERT then
+		local guardeeID = cmdParams[1]
+		if cmdID == CMD_INSERT then
+			cmdID = cmdParams[2]
+			if not cmdID == CMD_GUARD then return true end
+			guardeeID = cmdParams[4]
+		else
+			guardeeID = cmdParams[1]
+		end
+		-- To guard out of map both units must be builders
+		if guardeeID and spValidUnitID(guardeeID) then
+			local guardeeUnitDefID = spGetUnitDefID(guardeeID)
+			if not (isBuilder[unitDefID] and isBuilder[guardeeUnitDefID]) then
+				if isInsideMap(guardeeID) then
+					-- storing frame number, but will be updated later
+					guardingUnits[unitID] = 0
+				else
+					return false
+				end
+			end
+		end
+	end
+	return true
+end

--- a/cont/base/springcontent/LuaGadgets/Gadgets/control_guard.lua
+++ b/cont/base/springcontent/LuaGadgets/Gadgets/control_guard.lua
@@ -103,7 +103,7 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 		return true
 	end
 	if cmdID == CMD_GUARD or cmdID == CMD_INSERT then
-		local guardeeID = cmdParams[1]
+		local guardeeID
 		if cmdID == CMD_INSERT then
 			cmdID = cmdParams[2]
 			if not cmdID == CMD_GUARD then return true end

--- a/cont/base/springcontent/LuaGadgets/Gadgets/control_guard.lua
+++ b/cont/base/springcontent/LuaGadgets/Gadgets/control_guard.lua
@@ -36,7 +36,7 @@ for unitDefID, udef in pairs(UnitDefs) do
 
 		isMobileUnit[unitDefID] = true
 	end
-	if udef.isBuilder and (udef.buildSpeed and udef.buildSpeed > 0) and (udef.buildDistance and udef.buildDistance > 0) then
+	if udef.isBuilder then
 		isBuilder[unitDefID] = true
 	end
 end

--- a/cont/base/springcontent/LuaGadgets/Gadgets/control_guard.lua
+++ b/cont/base/springcontent/LuaGadgets/Gadgets/control_guard.lua
@@ -45,9 +45,6 @@ local allMobileUnits = {}
 local guardingUnits = {}
 
 function gadget:Initialize()
-	gadgetHandler:RegisterAllowCommand(CMD_STOP)
-	gadgetHandler:RegisterAllowCommand(CMD_GUARD)
-	gadgetHandler:RegisterAllowCommand(CMD_INSERT)
 	for _, unitID in pairs(Spring.GetAllUnits()) do
 		gadget:UnitCreated(unitID, Spring.GetUnitDefID(unitID))
 	end

--- a/rts/Sim/Units/CommandAI/AirCAI.cpp
+++ b/rts/Sim/Units/CommandAI/AirCAI.cpp
@@ -495,10 +495,6 @@ void CAirCAI::ExecuteGuard(Command& c)
 		StopMoveAndFinishCommand();
 		return;
 	}
-	if (guardee->outOfMapTime > (GAME_SPEED * 5)) {
-		StopMoveAndFinishCommand();
-		return;
-	}
 
 	const bool pushAttackCommand =
 		(owner->maxRange > 0.0f) &&

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -874,10 +874,6 @@ void CBuilderCAI::ExecuteGuard(Command& c)
 		StopMoveAndFinishCommand();
 		return;
 	}
-	if (guardee->outOfMapTime > (GAME_SPEED * 5)) {
-		StopMoveAndFinishCommand();
-		return;
-	}
 
 
 	if (CBuilder* b = dynamic_cast<CBuilder*>(guardee)) {

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -622,10 +622,6 @@ void CMobileCAI::ExecuteGuard(Command& c)
 		StopMoveAndFinishCommand();
 		return;
 	}
-	if (guardee->outOfMapTime > (GAME_SPEED * 5)) {
-		StopMoveAndFinishCommand();
-		return;
-	}
 
 	constexpr int retaliationTimeout = 40;
 	const bool pushAttackCommand =

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -675,8 +675,6 @@ void CUnit::Update()
 	}
 
 	restTime += 1;
-	outOfMapTime += 1;
-	outOfMapTime *= (!pos.IsInBounds());
 }
 
 void CUnit::UpdateWeaponVectors()
@@ -2933,7 +2931,6 @@ CR_REG_METADATA(CUnit, (
 	CR_MEMBER(delayedWreckLevel),
 
 	CR_MEMBER(restTime),
-	CR_MEMBER(outOfMapTime),
 
 	CR_MEMBER(reloadSpeed),
 	CR_MEMBER(maxRange),

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -391,7 +391,6 @@ public:
 
 	// how long the unit has been inactive
 	unsigned int restTime = 0;
-	unsigned int outOfMapTime = 0;
 
 	float reloadSpeed = 1.0f;
 	float maxRange = 0.0f;


### PR DESCRIPTION
### Work done

- Remove the max time for out of map guards.
- Add sample gadget `control_guard.lua`, games can use to keep old behaviour through lua, but letting builders guard.

### Remarks

- Actually a bug, since https://github.com/beyond-all-reason/spring/pull/1769 was supposed to remove such restrictions.
  - completely overlooked this, sorry about that.
- Still, to keep current engine behaviour through lua, it becomes a bit more complicated for games to manage the timer:
  - See [here](https://github.com/saurtron/Beyond-All-Reason/commit/8adb876482914b1aef4d4db307acb6f280569f5f) for how I adapted bar code to check that. Not too bad, but a bit overcomplicated given the difficulty in tracking units current command.
  - Given there are other safeguards not sure if just removing this and ignoring in-game for now may be ok too, even without this, didn't see any extreme out of map behaviour in my tests.
- `unit->outOfMapTime` isn't used for anything else actually, so could remove it altogether, otherwise an alternative would be to allow lua to fetch the value, but not sure that'll be too useful in the end.
  - pls comment if you prefer removing or adding lua bind.
  - I think probably removing is the way to go.
  - **note:** for now I removed it