### PR TITLE
More fixes to Lua docs

### DIFF
--- a/doc/site/README.md
+++ b/doc/site/README.md
@@ -20,8 +20,8 @@ Navigate to http://localhost:4000/spring
 Have [emmylua_doc_cli](https://github.com/CppCXY/emmylua-analyzer-rust/tree/main/crates/emmylua_doc_cli) and [lua-doc-extractor](https://github.com/rhys-vdw/lua-doc-extractor) installed and available in `$PATH`.
 
 ```bash
-rm -rf rts/Lua/library/generated
-lua-doc-extractor rts/Lua/*.cpp --dest rts/Lua/library/generated
+rm -rf rts/Lua/library/generated &&
+lua-doc-extractor rts/Lua/*.cpp --dest rts/Lua/library/generated &&
 emmylua_doc_cli \
   -i rts/Lua/library/ \
   -o doc/site/lua-api \

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -1631,10 +1631,19 @@ int LuaSyncedRead::GetAllyTeamList(lua_State* L)
 
 
 /***
- *
+ * Get all team IDs.
+ * 
  * @function Spring.GetTeamList
- * @param allyTeamID integer? (Default: `-1`) to filter teams belonging to when >= 0
- * @return number[]? list of teamIDs
+ * @param allyTeamID -1|nil (Default: `-1`) 
+ * @return number[] teamIDs List of team IDs.
+ */
+
+/***
+ * Get team IDs in a specific ally team.
+ * 
+ * @function Spring.GetTeamList
+ * @param allyTeamID integer The ally team ID to filter teams by. A value less than 0 will return all teams.
+ * @return number[]? teamIDs List of team IDs or `nil` if `allyTeamID` is invalid.
  */
 int LuaSyncedRead::GetTeamList(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -1461,7 +1461,7 @@ static int TableSelectionCommonFunc(lua_State* L, int unitIndexInTable, bool isS
 /*** Deselects multiple units.
  *
  * @function Spring.DeselectUnitArray
- * @param unitIDs table<any, integer> Table with unit IDs as value.
+ * @param unitIDs integer[] Table with unit IDs as values.
  * @return nil
  */
 int LuaUnsyncedCtrl::DeselectUnitArray(lua_State* L)
@@ -1483,7 +1483,7 @@ int LuaUnsyncedCtrl::DeselectUnitMap(lua_State* L)
 /*** Selects multiple units, or appends to selection. Accepts a table with unitIDs as values
  *
  * @function Spring.SelectUnitArray
- * @param unitMap table<any, integer> Table with unit IDs as values.
+ * @param unitIDs integer[] Table with unit IDs as values.
  * @param append boolean? (Default: `false`) append to current selection
  * @return nil
  */

--- a/rts/Lua/LuaVBO.cpp
+++ b/rts/Lua/LuaVBO.cpp
@@ -120,14 +120,6 @@ LuaVBOs::~LuaVBOs()
 	luaVBOs.clear();
 }
 
-/***
- * @alias GLBufferType
- * | GL.ARRAY_BUFFER
- * | GL.ELEMENT_ARRAY_BUFFER
- * | GL.UNIFORM_BUFFER
- * | GL.SHADER_STORAGE_BUFFER
- */
-
 
 /***
  * Example:
@@ -139,10 +131,13 @@ LuaVBOs::~LuaVBOs()
  *
  * @function gl.GetVBO
  * 
- * @param bufferType GLBufferType? (Default: GL.ARRAY_BUFFER)
+ * @param bufferType GL? (Default: `GL.ARRAY_BUFFER`) The buffer type to use.
  *
- * Use `GL.ARRAY_BUFFER` for vertex data and
- * `GL.ELEMENT_ARRAY_BUFFER` for vertex indices.
+ * Accepts the following:
+ * - `GL.ARRAY_BUFFER` for vertex data.
+ * - `GL.ELEMENT_ARRAY_BUFFER` for vertex indices.
+ * - `GL.UNIFORM_BUFFER`
+ * - `GL.SHADER_STORAGE_BUFFER`
  * 
  * @param freqUpdated boolean? (Default: `true`)
  * 

--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -457,26 +457,16 @@ bool LuaVBOImpl::DefineElementArray(const sol::optional<sol::object> attribDefAr
 }
 
 /***
- * @alias VBODataType
- * | GL.BYTE
- * | GL.UNSIGNED_BYTE
- * | GL.SHORT
- * | GL.UNSIGNED_SHORT
- * | GL.INT
- * | GL.UNSIGNED_INT
- * | GL.FLOAT
- */
-
-/***
  * @class VBOAttributeDef
  * 
- * @field id integer
+ * @field id integer?
+ * 
  * The location in the vertex shader layout e.g.: layout (location = 0) in vec2
  * aPos. optional attrib, specifies location in the vertex shader. If not
  * specified the implementation will increment the counter starting from 0.
  * There can be maximum 16 attributes (so id of 15 is max).
  * 
- * @field name string
+ * @field name string? (Default: `attr#` where `#` is `id`)
  * 
  * The name for this VBO, only used for debugging.
  * 
@@ -486,16 +476,22 @@ bool LuaVBOImpl::DefineElementArray(const sol::optional<sol::object> attribDefAr
  * this buffer. e.g. for the previous layout (location = 0) in vec2 aPos, it
  * would be size = 2.
  * 
- * @field type VBODataType (Default: `GL.FLOAT`)
- * 
- * The datatype of this element.
+ * @field type GL? (Default: `GL.FLOAT`) The datatype of this element.
+ *
+ * Accepts the following:
+ * - `GL.BYTE`
+ * - `GL.UNSIGNED_BYTE`
+ * - `GL.SHORT`
+ * - `GL.UNSIGNED_SHORT`
+ * - `GL.INT`
+ * - `GL.UNSIGNED_INT`
+ * - `GL.FLOAT`
  * 
  * @field normalized boolean? (Defaults: `false`)
  * 
- * It's possible to submit say normal without normalizing them first, normalized
+ * It's possible to submit normals without normalizing them first, normalized
  * will make sure data is normalized.
  */
- 
 
 /***
  * Specify the kind of VBO you will be using.


### PR DESCRIPTION
- Minor cleanup to `SelectUnitArray` and `DeselectUnitArray` docs.
- Add an overload to `Spring.GetTeamList()` that ensures a non-nil return value with no arguments.
- Remove my use of unions of GL values (not supported by LLS).
- Restore `&&` in the example commands to regenerate docs (so you can press up array to do it again after pasting into CLI)