### PR TITLE
Remove duplicate GL constants

### DIFF
--- a/rts/Lua/LuaConstGL.cpp
+++ b/rts/Lua/LuaConstGL.cpp
@@ -186,20 +186,6 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	PUSH_GL(FILL);
 
 	/***
-	 * Clear Bits
-	 * @section clearbits
-	 */
-
-	/*** @field GL.DEPTH_BUFFER_BIT integer */
-	PUSH_GL(DEPTH_BUFFER_BIT);
-	/*** @field GL.ACCUM_BUFFER_BIT integer */
-	PUSH_GL(ACCUM_BUFFER_BIT);
-	/*** @field GL.STENCIL_BUFFER_BIT integer */
-	PUSH_GL(STENCIL_BUFFER_BIT);
-	/*** @field GL.COLOR_BUFFER_BIT integer */
-	PUSH_GL(COLOR_BUFFER_BIT);
-
-	/***
 	 * ShadeModel
 	 * @section shademodel
 	 */


### PR DESCRIPTION
These are defined twice:

https://github.com/rhys-vdw/spring/blob/c325950cb6df0b0ae70eaf2606e4f76adf857e4a/rts/Lua/LuaConstGL.cpp#L334-L339

https://github.com/rhys-vdw/spring/blob/c325950cb6df0b0ae70eaf2606e4f76adf857e4a/rts/Lua/LuaConstGL.cpp#L346-L347

This clears the last error from `lua-language-server --check` on the output library.