### PR TITLE
Add check lua workflow

### DIFF
--- a/.github/workflows/check-lua.yml
+++ b/.github/workflows/check-lua.yml
@@ -10,8 +10,8 @@ on:
     paths:
       - 'rts/Lua/**'
 jobs:
-  generate-library:
-    name: Regenerate library
+  cehck-library:
+    name: Check library
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Lua CPP files
@@ -27,14 +27,19 @@ jobs:
             --repo https://github.com/${{ github.repository }}/blob/${{ github.sha }} \
             --error
 
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+      - name: Install dra
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/devmatteini/dra/refs/heads/main/install.sh | bash -s -- --to ./dra
 
       - name: Install Lua Language Server
         run: |
-          brew install lua-language-server
+          ./dra download \
+            --select "lua-language-server-{tag}-linux-x64.tar.gz" \
+            LuaLS/lua-language-server \
+            --output lls.tar.gz
+          mkdir lls
+          tar -xvzf lls.tar.gz -C lls
 
       - name: Check 
         run: |
-          lua-language-server --check rts/Lua/library
+          ./lls/bin/lua-language-server --check rts/Lua/library

--- a/.github/workflows/check-lua.yml
+++ b/.github/workflows/check-lua.yml
@@ -1,0 +1,40 @@
+name: Check Lua library
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'rts/Lua/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'rts/Lua/**'
+jobs:
+  generate-library:
+    name: Regenerate library
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Lua CPP files
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: rts/Lua
+
+      - name: Generate Lua library
+        run: |
+          npm install -g lua-doc-extractor@3.1
+          lua-doc-extractor rts/Lua/*.cpp \
+            --dest rts/Lua/library/generated \
+            --repo https://github.com/${{ github.repository }}/blob/${{ github.sha }} \
+            --error
+
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Install Lua Language Server
+        run: |
+          brew install lua-language-server
+
+      - name: Check 
+        run: |
+          lua-language-server --check rts/Lua/library


### PR DESCRIPTION
Add workflow to check that Lua library is valid.

- Checks that lua-doc-extractor succeeds.
- Does type check and static analysis via lua-doc-extractor (will report references to non-existent types and other misconfigurations).
- **Does not** check that emmylua-doc-cli succeeds (should be fine so long as the above works, I've yet to see it error ever). If it's a problem we can add it later.

Example of failure: https://github.com/rhys-vdw/spring/pull/1

Note #2124 must be merged first this since it fixes the last Lua errors.

Closes #1760