### PR TITLE
Many more Lua fixes

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -3569,18 +3569,34 @@ string CLuaHandle::WorldTooltip(const CUnit* unit,
 	return retval;
 }
 
-
 /***
- *
  * @function Callins:MapDrawCmd
- * @param playerID number
- * @param type string "point" | "line" | "erase"
+ * @param playerID integer
+ * @param type "point"
  * @param posX number
  * @param posY number
  * @param posZ number
- * @param data4 string|number point: label, erase: radius, line: pos2X
- * @param pos2Y number? when type is line
- * @param pos2Z number? when type is line
+ * @param label string
+ */
+/***
+ * @function Callins:MapDrawCmd
+ * @param playerID integer
+ * @param type "line"
+ * @param pos1X number
+ * @param pos1Y number
+ * @param pos1Z number
+ * @param pos2X number
+ * @param pos2Y number
+ * @param pos2Z number
+ */
+/***
+ * @function Callins:MapDrawCmd
+ * @param playerID integer
+ * @param type "erase"
+ * @param posX number
+ * @param posY number
+ * @param posZ number
+ * @param radius number
  */
 bool CLuaHandle::MapDrawCmd(int playerID, int type,
                             const float3* pos0,

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -3501,15 +3501,30 @@ bool CLuaHandle::GroupChanged(int groupID)
 	return RunCallIn(L, cmdStr, 1, 0);
 }
 
-
-
 /***
  * @function Callins:WorldTooltip
- * @param ttType string "unit" | "feature" | "ground" | "selection"
- * @param data1 number unitID | featureID | posX
- * @param data2 number? posY
- * @param data3 number? posZ
- * @return string newTooltip
+ * @param type "unit"
+ * @param unitId integer
+ * @return string tooltip
+ */
+/***
+ * @function Callins:WorldTooltip
+ * @param type "feature"
+ * @param featureId integer
+ * @return string tooltip
+ */
+/***
+ * @function Callins:WorldTooltip
+ * @param type "ground"
+ * @param posX number
+ * @param posY number
+ * @param posZ number
+ * @return string tooltip
+ */
+/***
+ * @function Callins:WorldTooltip
+ * @param type "selection"
+ * @return string tooltip
  */
 string CLuaHandle::WorldTooltip(const CUnit* unit,
                                 const CFeature* feature,

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -562,7 +562,7 @@ void CLuaHandle::Shutdown()
  *
  * @function Callins:GotChatMsg
  * @param msg string
- * @param playerID number
+ * @param playerID integer
  */
 bool CLuaHandle::GotChatMsg(const string& msg, int playerID)
 {
@@ -733,7 +733,7 @@ void CLuaHandle::GameOver(const std::vector<unsigned char>& winningAllyTeams)
 /*** Called when the game is paused.
  *
  * @function Callins:GamePaused
- * @param playerID number
+ * @param playerID integer
  * @param paused boolean
  */
 void CLuaHandle::GamePaused(int playerID, bool paused)
@@ -872,7 +872,7 @@ void CLuaHandle::GameID(const unsigned char* gameID, unsigned int numBytes)
 /*** Called when a team dies (see `Spring.KillTeam`).
  *
  * @function Callins:TeamDied
- * @param teamID number
+ * @param teamID integer
  */
 void CLuaHandle::TeamDied(int teamID)
 {
@@ -895,7 +895,7 @@ void CLuaHandle::TeamDied(int teamID)
 
 /*** @function Callins:TeamChanged
  *
- * @param teamID number
+ * @param teamID integer
  */
 void CLuaHandle::TeamChanged(int teamID)
 {
@@ -919,7 +919,7 @@ void CLuaHandle::TeamChanged(int teamID)
 /*** Called whenever a player's status changes e.g. becoming a spectator.
  *
  * @function Callins:PlayerChanged
- * @param playerID number
+ * @param playerID integer
  */
 void CLuaHandle::PlayerChanged(int playerID)
 {
@@ -943,7 +943,7 @@ void CLuaHandle::PlayerChanged(int playerID)
 /*** Called whenever a new player joins the game.
  *
  * @function Callins:PlayerAdded
- * @param playerID number
+ * @param playerID integer
  */
 void CLuaHandle::PlayerAdded(int playerID)
 {
@@ -967,7 +967,7 @@ void CLuaHandle::PlayerAdded(int playerID)
 /*** Called whenever a player is removed from the game.
  *
  * @function Callins:PlayerRemoved
- * @param playerID number
+ * @param playerID integer
  * @param reason string
  */
 void CLuaHandle::PlayerRemoved(int playerID, int reason)
@@ -1020,7 +1020,7 @@ inline void CLuaHandle::UnitCallIn(const LuaHashString& hs, const CUnit* unit)
  * @param unitID integer
  * @param unitDefID integer
  * @param unitTeam integer
- * @param builderID number?
+ * @param builderID integer?
  */
 void CLuaHandle::UnitCreated(const CUnit* unit, const CUnit* builder)
 {
@@ -1065,8 +1065,8 @@ void CLuaHandle::UnitFinished(const CUnit* unit)
  * @param unitID integer
  * @param unitDefID integer
  * @param unitTeam integer
- * @param factID number
- * @param factDefID number
+ * @param factID integer
+ * @param factDefID integer
  * @param userOrders boolean
  */
 void CLuaHandle::UnitFromFactory(const CUnit* unit,
@@ -1147,10 +1147,10 @@ void CLuaHandle::UnitConstructionDecayed(const CUnit* unit, float timeSinceLastB
  * @param unitID integer
  * @param unitDefID integer
  * @param unitTeam integer
- * @param attackerID number
- * @param attackerDefID number
+ * @param attackerID integer
+ * @param attackerDefID integer
  * @param attackerTeam number
- * @param weaponDefID number
+ * @param weaponDefID integer
  */
 void CLuaHandle::UnitDestroyed(const CUnit* unit, const CUnit* attacker, int weaponDefID)
 {
@@ -1257,7 +1257,7 @@ void CLuaHandle::UnitIdle(const CUnit* unit)
  * @param unitID integer
  * @param unitDefID integer
  * @param unitTeam integer
- * @param cmdID number
+ * @param cmdID integer
  * @param cmdParams table
  * @param options CommandOptions
  * @param cmdTag number
@@ -1291,7 +1291,7 @@ void CLuaHandle::UnitCommand(const CUnit* unit, const Command& command, int play
  * @param unitID integer
  * @param unitDefID integer
  * @param unitTeam integer
- * @param cmdID number
+ * @param cmdID integer
  * @param cmdParams table
  * @param options CommandOptions
  * @param cmdTag number
@@ -1323,10 +1323,10 @@ void CLuaHandle::UnitCmdDone(const CUnit* unit, const Command& command)
  * @param unitTeam integer
  * @param damage number
  * @param paralyzer number
- * @param weaponDefID number
- * @param projectileID number
- * @param attackerID number
- * @param attackerDefID number
+ * @param weaponDefID integer
+ * @param projectileID integer
+ * @param attackerID integer
+ * @param attackerDefID integer
  * @param attackerTeam number
  */
 void CLuaHandle::UnitDamaged(
@@ -1787,8 +1787,8 @@ void CLuaHandle::UnitDecloaked(const CUnit* unit)
  * Both units must be registered with `Script.SetWatchUnit`.
  *
  * @function Callins:UnitUnitCollision
- * @param colliderID number
- * @param collideeID number
+ * @param colliderID integer
+ * @param collideeID integer
  */
 bool CLuaHandle::UnitUnitCollision(const CUnit* collider, const CUnit* collidee)
 {
@@ -1839,8 +1839,8 @@ bool CLuaHandle::UnitUnitCollision(const CUnit* collider, const CUnit* collidee)
  *
  * The unit must be registered with `Script.SetWatchUnit` and the feature registered with `Script.SetWatchFeature`.
  *
- * @param colliderID number
- * @param collideeID number
+ * @param colliderID integer
+ * @param collideeID integer
  */
 bool CLuaHandle::UnitFeatureCollision(const CUnit* collider, const CFeature* collidee)
 {
@@ -1967,8 +1967,8 @@ void CLuaHandle::RenderUnitDestroyed(const CUnit* unit)
  *
  * @function Callins:FeatureCreated
  *
- * @param featureID number
- * @param allyTeamID number
+ * @param featureID integer
+ * @param allyTeamID integer
  */
 void CLuaHandle::FeatureCreated(const CFeature* feature)
 {
@@ -1994,8 +1994,8 @@ void CLuaHandle::FeatureCreated(const CFeature* feature)
  *
  * @function Callins:FeatureDestroyed
  *
- * @param featureID number
- * @param allyTeamID number
+ * @param featureID integer
+ * @param allyTeamID integer
  */
 void CLuaHandle::FeatureDestroyed(const CFeature* feature)
 {
@@ -2021,14 +2021,14 @@ void CLuaHandle::FeatureDestroyed(const CFeature* feature)
  *
  * @function Callins:FeatureDamaged
  *
- * @param featureID number
- * @param featureDefID number
+ * @param featureID integer
+ * @param featureDefID integer
  * @param featureTeam number
  * @param damage number
- * @param weaponDefID number
- * @param projectileID number
- * @param attackerID number
- * @param attackerDefID number
+ * @param weaponDefID integer
+ * @param projectileID integer
+ * @param attackerID integer
+ * @param attackerDefID integer
  * @param attackerTeam number
  */
 void CLuaHandle::FeatureDamaged(
@@ -2077,9 +2077,9 @@ void CLuaHandle::FeatureDamaged(
  *
  * Note that weaponDefID is missing if the projectile is spawned as part of a burst, but `Spring.GetProjectileDefID` and `Spring.GetProjectileName` still work in callin scope using proID.
  *
- * @param proID number
- * @param proOwnerID number
- * @param weaponDefID number
+ * @param proID integer
+ * @param proOwnerID integer
+ * @param weaponDefID integer
  *
  */
 void CLuaHandle::ProjectileCreated(const CProjectile* p)
@@ -2124,9 +2124,9 @@ void CLuaHandle::ProjectileCreated(const CProjectile* p)
 /*** Called when the projectile is destroyed.
  *
  * @function Callins:ProjectileDestroyed
- * @param proID number
- * @param ownerID number
- * @param proWeaponDefID number
+ * @param proID integer
+ * @param ownerID integer
+ * @param proWeaponDefID integer
  */
 void CLuaHandle::ProjectileDestroyed(const CProjectile* p)
 {
@@ -2178,12 +2178,12 @@ void CLuaHandle::ProjectileDestroyed(const CProjectile* p)
  *
  * @function Callins:Explosion
  *
- * @param weaponDefID number
+ * @param weaponDefID integer
  * @param px number
  * @param py number
  * @param pz number
- * @param attackerID number
- * @param projectileID number
+ * @param attackerID integer
+ * @param projectileID integer
  * @return boolean noGfx if then no graphical effects are drawn by the engine for this explosion.
  */
 bool CLuaHandle::Explosion(int weaponDefID, int projectileID, const float3& pos, const CUnit* owner)
@@ -2268,7 +2268,7 @@ void CLuaHandle::StockpileChanged(const CUnit* unit,
  *
  * @function Callins:RecvLuaMsg
  * @param msg string
- * @param playerID number
+ * @param playerID integer
  */
 bool CLuaHandle::RecvLuaMsg(const string& msg, int playerID)
 {
@@ -3484,7 +3484,7 @@ bool CLuaHandle::AddConsoleLine(const string& msg, const string& section, int le
 /*** Called when a unit is added to or removed from a control group.
  *
  * @function Callins:GroupChanged
- * @param groupID number
+ * @param groupID integer
  */
 bool CLuaHandle::GroupChanged(int groupID)
 {
@@ -3756,7 +3756,7 @@ const char* CLuaHandle::RecvSkirmishAIMessage(int aiTeam, const char* inData, in
 /*** Called when a Pr-downloader download is queued
  *
  * @function Callins:DownloadQueued
- * @param id number
+ * @param id integer
  * @param name string
  * @param type string
  */
@@ -3784,7 +3784,7 @@ void CLuaHandle::DownloadQueued(int ID, const string& archiveName, const string&
 /*** Called when a Pr-downloader download is started via VFS.DownloadArchive.
  *
  * @function Callins:DownloadStarted
- * @param id number
+ * @param id integer
  */
 void CLuaHandle::DownloadStarted(int ID)
 {
@@ -3807,7 +3807,7 @@ void CLuaHandle::DownloadStarted(int ID)
 /*** Called when a Pr-downloader download finishes successfully.
  *
  * @function Callins:DownloadFinished
- * @param id number
+ * @param id integer
  */
 void CLuaHandle::DownloadFinished(int ID)
 {
@@ -3830,8 +3830,8 @@ void CLuaHandle::DownloadFinished(int ID)
 /*** Called when a Pr-downloader download fails to complete.
  *
  * @function Callins:DownloadFailed
- * @param id number
- * @param errorID number
+ * @param id integer
+ * @param errorID integer
  */
 void CLuaHandle::DownloadFailed(int ID, int errorID)
 {
@@ -3855,9 +3855,9 @@ void CLuaHandle::DownloadFailed(int ID, int errorID)
 /*** Called incrementally during a Pr-downloader download.
  *
  * @function Callins:DownloadProgress
- * @param id number
- * @param downloaded number
- * @param total number
+ * @param id integer
+ * @param downloaded integer
+ * @param total integer
  */
 void CLuaHandle::DownloadProgress(int ID, long downloaded, long total)
 {

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -358,7 +358,7 @@ bool CUnsyncedLuaHandle::DrawProjectile(const CProjectile* projectile)
 /***
  *
  * @function UnsyncedCallins:DrawMaterial
- * @param uuid number
+ * @param uuid integer
  * @param drawMode number
  * @return boolean suppressEngineDraw
  * @deprecated

--- a/rts/Lua/LuaShaders.cpp
+++ b/rts/Lua/LuaShaders.cpp
@@ -1224,7 +1224,7 @@ int LuaShaders::UniformArray(lua_State* L)
  * numbers for the matrix.
  *
  * @function gl.UniformMatrix
- * @param locationID number|string uniformName
+ * @param locationID integer|string uniformName
  * @param matrix number[] A 2x2, 3x3 or 4x4 matrix.
  */
 int LuaShaders::UniformMatrix(lua_State* L)

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -994,8 +994,10 @@ int LuaSyncedCtrl::KillTeam(lua_State* L)
  * Declare game over.
  * 
  * @function Spring.GameOver
- * @param ... integer A list of winning ally team IDs. Pass no
- * arguments if undecided. Multiple winners will declare a draw.
+ * @param winningAllyTeamIDs integer[] A list of winning ally team IDs. Pass
+ * multiple winners to declare a draw. Pass no arguments if undecided (e.g.
+ * when dropped from the host).
+ * @returns integer Number of accepted (valid) ally teams.
  */
 int LuaSyncedCtrl::GameOver(lua_State* L)
 {

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2045,14 +2045,14 @@ int LuaSyncedCtrl::SetUnitResourcing(lua_State* L)
 
 /***
  * @function Spring.SetUnitStorage
- * @param unitID number
+ * @param unitID integer
  * @param res string
  * @param amount number
  */
 
 /***
  * @function Spring.SetUnitStorage
- * @param unitID number
+ * @param unitID integer
  * @param res ResourceUsage keys are: "[m|e]" metal | energy. Values are amounts
  */
 int LuaSyncedCtrl::SetUnitStorage(lua_State* L)

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -990,16 +990,12 @@ int LuaSyncedCtrl::KillTeam(lua_State* L)
 }
 
 
-/*** Will declare game over.
- *
+/*** 
+ * Declare game over.
+ * 
  * @function Spring.GameOver
- *
- * A list of winning allyteams can be passed, if undecided (like when dropped from the host) it should be empty (no winner), in the case of a draw with multiple winners, all should be listed.
- *
- * @param allyTeamID1 number?
- * @param allyTeamID2 number?
- * @param allyTeamIDn number?
- * @return nil
+ * @param ... integer A list of winning ally team IDs. Pass no
+ * arguments if undecided. Multiple winners will declare a draw.
  */
 int LuaSyncedCtrl::GameOver(lua_State* L)
 {

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -1692,7 +1692,7 @@ int LuaSyncedCtrl::GetCOBScriptID(lua_State* L)
  * @param flattenGround boolean? (Default: `true`) the unit flattens ground, if it normally does so
  * @param unitID integer? requests specific unitID
  * @param builderID integer?
- * @return number|nil unitID meaning unit was created
+ * @return integer|nil unitID meaning unit was created
  */
 int LuaSyncedCtrl::CreateUnit(lua_State* L)
 {
@@ -7124,7 +7124,7 @@ int LuaSyncedCtrl::SpawnExplosion(lua_State* L)
  * @param radius number? (Default: `0`)
  * @param damage number? (Default: `0`)
  * @return boolean? success
- * @return number cegID
+ * @return integer cegID
  */
 int LuaSyncedCtrl::SpawnCEG(lua_State* L)
 {

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -1684,17 +1684,17 @@ int LuaSyncedCtrl::GetCOBScriptID(lua_State* L)
  *
  * Offmap positions are clamped! Use MoveCtrl to move to such positions.
  *
- * @param unitDefName string|number or unitDefID
- * @param x number
- * @param y number
- * @param z number
+ * @param unitDef string|integer UnitDef name or ID.
+ * @param posX number
+ * @param posY number
+ * @param posZ number
  * @param facing Facing
  * @param teamID integer
- * @param build boolean? (Default: `false`) the unit is created in "being built" state with buildProgress = 0
- * @param flattenGround boolean? (Default: `true`) the unit flattens ground, if it normally does so
- * @param unitID integer? requests specific unitID
+ * @param build boolean? (Default: `false`) The unit is created in "being built" state with zero `buildProgress`.
+ * @param flattenGround boolean? (Default: `true`) The unit flattens ground, if it normally does so.
+ * @param unitID integer? Request a specific unitID.
  * @param builderID integer?
- * @return integer|nil unitID meaning unit was created
+ * @return integer? unitID The ID of the created unit, or `nil` if the unit could not be created.
  */
 int LuaSyncedCtrl::CreateUnit(lua_State* L)
 {

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -4652,33 +4652,50 @@ int LuaSyncedCtrl::SetFeatureResurrect(lua_State* L)
 	return 0;
 }
 
+/***
+ * Enable feature movement control.
+ * 
+ * @function Spring.SetFeatureMoveCtrl
+ * @param featureID integer
+ * @param enabled true Enable feature movement.
+ * @param initialVelocityX number? Initial velocity on X axis, or `nil` for no change.
+ * @param initialVelocityY number? Initial velocity on Y axis, or `nil` for no change.
+ * @param initialVelocityZ number? Initial velocity on Z axis, or `nil` for no change.
+ * @param accelerationX number? Acceleration per frame on X axis, or `nil` for no change.
+ * @param accelerationY number? Acceleration per frame on Y axis, or `nil` for no change.
+ * @param accelerationZ number? Acceleration per frame on Z axis, or `nil` for no change.
+ */
 
 /***
+ * Disable feature movement control.
+ * 
+ * Optional parameter allow physics vectors to build when not using `MoveCtrl`.
+ * 
+ * It is necessary to unlock feature movement on x, z axis before changing
+ * feature physics.
+ *
+ * For example:
+ * 
+ * ```lua
+ * -- Unlock all movement before setting velocity.
+ * Spring.SetFeatureMoveCtrl(featureID,false,1,1,1,1,1,1,1,1,1)
+ * 
+ * -- Set velocity.
+ * Spring.SetFeatureVelocity(featureID,10,0,10)
+ * ```
+ * 
  * @function Spring.SetFeatureMoveCtrl
- *
- * Use this callout to control feature movement. The arg* arguments are parsed as follows and all optional:
- *
- * If enable is true:
- * [, velVector(x,y,z)  * initial velocity for feature
- * [, accVector(x,y,z)  * acceleration added every frame]]
- *
- * If enable is false:
- * [, velocityMask(x,y,z)  * dimensions in which velocity is allowed to build when not using MoveCtrl
- * [, impulseMask(x,y,z)  * dimensions in which impulse is allowed to apply when not using MoveCtrl
- * [, movementMask(x,y,z)  * dimensions in which feature is allowed to move when not using MoveCtrl]]]
- *
- * It is necessary to unlock feature movement on x,z axis before changing feature physics.
- *
- * For example use `Spring.SetFeatureMoveCtrl(featureID,false,1,1,1,1,1,1,1,1,1)` to unlock all movement prior to making `Spring.SetFeatureVelocity` calls.
- *
  * @param featureID integer
- * @param enable boolean?
- * @param arg1 number?
- * @param arg2 number?
- * @param argn number?
- *
- * @return nil
- *
+ * @param enabled false Disable feature movement.
+ * @param velocityMaskX number? Lock velocity change in X dimension when not using `MoveCtrl`. `0` to lock, non-zero to allow, or `nil` to for no change.
+ * @param velocityMaskY number? Lock velocity change in Y dimension when not using `MoveCtrl`. `0` to lock, non-zero to allow, or `nil` to for no change.
+ * @param velocityMaskZ number? Lock velocity change in Z dimension when not using `MoveCtrl`. `0` to lock, non-zero to allow, or `nil` to for no change.
+ * @param impulseMaskX number? Lock impulse in X dimension when not using `MoveCtrl`. `0` to lock, non-zero to allow, or `nil` to for no change.
+ * @param impulseMaskY number? Lock impulse in Y dimension when not using `MoveCtrl`. `0` to lock, non-zero to allow, or `nil` to for no change.
+ * @param impulseMaskZ number? Lock impulse in Z dimension when not using `MoveCtrl`. `0` to lock, non-zero to allow, or `nil` to for no change.
+ * @param movementMaskX number? Lock move in X dimension when not using `MoveCtrl`. `0` to lock the axis, non-zero to allow, or `nil` for no change.
+ * @param movementMaskY number? Lock move in Y dimension when not using `MoveCtrl`. `0` to lock the axis, non-zero to allow, or `nil` for no change.
+ * @param movementMaskZ number? Lock move in Z dimension when not using `MoveCtrl`. `0` to lock the axis, non-zero to allow, or `nil` for no change.
  */
 int LuaSyncedCtrl::SetFeatureMoveCtrl(lua_State* L)
 {

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -1512,7 +1512,7 @@ int LuaSyncedRead::GetSideData(lua_State* L)
  *
  * @function Spring.GetGaiaTeamID
  *
- * @return number teamID
+ * @return integer teamID
  */
 int LuaSyncedRead::GetGaiaTeamID(lua_State* L)
 {
@@ -1739,7 +1739,7 @@ int LuaSyncedRead::GetPlayerList(lua_State* L)
  * @function Spring.GetTeamInfo
  * @param teamID integer
  * @param getTeamKeys boolean? (Default: `true`) whether to return the customTeamKeys table
- * @return number? teamID
+ * @return integer? teamID
  * @return number leader
  * @return number isDead
  * @return number hasAI
@@ -2169,8 +2169,8 @@ int LuaSyncedRead::GetTeamMaxUnits(lua_State* L)
  * @return string name
  * @return boolean active
  * @return boolean spectator
- * @return number teamID
- * @return number allyTeamID
+ * @return integer teamID
+ * @return integer allyTeamID
  * @return number pingTime
  * @return number cpuUsage
  * @return string country
@@ -3429,7 +3429,7 @@ int LuaSyncedRead::GetUnitMapCentroid(lua_State* L)
  * @function Spring.GetUnitNearestAlly
  * @param unitID integer
  * @param range number? (Default: `1.0e9`)
- * @return number? unitID
+ * @return integer? unitID
  */
 int LuaSyncedRead::GetUnitNearestAlly(lua_State* L)
 {
@@ -3455,7 +3455,7 @@ int LuaSyncedRead::GetUnitNearestAlly(lua_State* L)
  * @param unitID integer
  * @param range number? (Default: `1.0e9`)
  * @param useLOS boolean? (Default: `true`)
- * @return number? unitID
+ * @return integer? unitID
  */
 int LuaSyncedRead::GetUnitNearestEnemy(lua_State* L)
 {
@@ -4592,7 +4592,7 @@ int LuaSyncedRead::GetUnitBuildFacing(lua_State* L)
  * Works for both mobile builders and factories.
  *
  * @param unitID integer
- * @return number buildeeUnitID or nil
+ * @return integer buildeeUnitID or nil
  */
 int LuaSyncedRead::GetUnitIsBuilding(lua_State* L)
 {
@@ -4689,8 +4689,8 @@ static int GetFactoryWorkerTask(lua_State* L, const CFactory *factory)
  * and build commands (negative buildee unitDefID).
  *
  * @param unitID integer
- * @return number cmdID of the relevant command
- * @return number targetID if applicable (all except RESTORE)
+ * @return integer cmdID of the relevant command
+ * @return integer targetID if applicable (all except RESTORE)
  */
 int LuaSyncedRead::GetUnitWorkerTask(lua_State* L)
 {
@@ -4943,7 +4943,7 @@ int LuaSyncedRead::GetUnitNanoPieces(lua_State* L)
  * Returns nil if the unit is not being transported.
  *
  * @param unitID integer
- * @return number|nil transportUnitID
+ * @return integer|nil transportUnitID
  */
 int LuaSyncedRead::GetUnitTransporter(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -3189,7 +3189,7 @@ int LuaUnsyncedCtrl::Quit(lua_State* L)
  *
  * @function Spring.SetUnitGroup
  * @param unitID integer
- * @param groupID number the group number to be assigned, or -1 for deassignment
+ * @param groupID integer the group number to be assigned, or -1 for deassignment
  * @return nil
  */
 int LuaUnsyncedCtrl::SetUnitGroup(lua_State* L)

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -4767,10 +4767,10 @@ int LuaUnsyncedRead::GetGroundDecalCreationFrame(lua_State* L)
 
 
 /***
- *
  * @function Spring.GetGroundDecalOwner
  * @param decalID integer
- * @return integer? unitID|number featureID(+MAX_UNITS)
+ * @return integer? value If owner is a unit, then this is `unitID`, if owner is
+ * a feature it is `featureID + MAX_UNITS`. If there is no owner, then `nil`.
  */
 int LuaUnsyncedRead::GetGroundDecalOwner(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -2323,7 +2323,7 @@ int LuaUnsyncedRead::GetFeaturesInScreenRectangle(lua_State* L)
 /***
  *
  * @function Spring.GetLocalPlayerID
- * @return number playerID
+ * @return integer playerID
  */
 int LuaUnsyncedRead::GetLocalPlayerID(lua_State* L)
 {
@@ -2335,7 +2335,7 @@ int LuaUnsyncedRead::GetLocalPlayerID(lua_State* L)
 /***
  *
  * @function Spring.GetLocalTeamID
- * @return number teamID
+ * @return integer teamID
  */
 int LuaUnsyncedRead::GetLocalTeamID(lua_State* L)
 {
@@ -2347,7 +2347,7 @@ int LuaUnsyncedRead::GetLocalTeamID(lua_State* L)
 /***
  *
  * @function Spring.GetLocalAllyTeamID
- * @return number allyTeamID
+ * @return integer allyTeamID
  */
 int LuaUnsyncedRead::GetLocalAllyTeamID(lua_State* L)
 {
@@ -2488,7 +2488,7 @@ int LuaUnsyncedRead::HaveAdvShading(lua_State* L)
 /***
  *
  * @function Spring.GetWaterMode
- * @return number waterRendererID
+ * @return integer waterRendererID
  * @return string waterRendererName
  * @see rts/Rendering/Env/IWater.h
  */
@@ -3297,7 +3297,7 @@ int LuaUnsyncedRead::GetGameState(lua_State* L)
  *
  * @function Spring.GetActiveCommand
  * @return number? cmdIndex
- * @return number? cmdID
+ * @return integer? cmdID
  * @return number? cmdType
  * @return nil|string cmdName
  */
@@ -4019,7 +4019,7 @@ int LuaUnsyncedRead::GetGroupList(lua_State* L)
 /***
  *
  * @function Spring.GetSelectedGroup
- * @return number groupID -1 when no group selected
+ * @return integer groupID -1 when no group selected
  */
 int LuaUnsyncedRead::GetSelectedGroup(lua_State* L)
 {
@@ -4032,7 +4032,7 @@ int LuaUnsyncedRead::GetSelectedGroup(lua_State* L)
  *
  * @function Spring.GetUnitGroup
  * @param unitID integer
- * @return number? groupID
+ * @return integer? groupID
  */
 int LuaUnsyncedRead::GetUnitGroup(lua_State* L)
 {
@@ -4770,7 +4770,7 @@ int LuaUnsyncedRead::GetGroundDecalCreationFrame(lua_State* L)
  *
  * @function Spring.GetGroundDecalOwner
  * @param decalID integer
- * @return number? unitID|number featureID(+MAX_UNITS)
+ * @return integer? unitID|number featureID(+MAX_UNITS)
  */
 int LuaUnsyncedRead::GetGroundDecalOwner(lua_State* L)
 {

--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -1474,7 +1474,7 @@ void LuaVBOImpl::DumpDefinition()
 /*** Gets the OpenGL Buffer ID
  *
  * @function VBO:GetID
- * @return number bufferID
+ * @return integer bufferID
  */
 uint32_t LuaVBOImpl::GetID() const
 {


### PR DESCRIPTION
- Fix some incorrectly annotated varargs e.g. `arg1, arg2, argn`.
- Add overloads to clarify arguments on a couple of callbacks.
- Mass replace `number` -> `integer` for all parameters with name ending in "ID".