### PR TITLE
Link SetProjectileTimeToLive and GetUnitSeismicSignature lua methods.

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -270,6 +270,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetProjectileVelocity);
 	REGISTER_LUA_CFUNC(SetProjectileCollision);
 	REGISTER_LUA_CFUNC(SetProjectileTarget);
+	REGISTER_LUA_CFUNC(SetProjectileTimeToLive);
 	REGISTER_LUA_CFUNC(SetProjectileIsIntercepted);
 	REGISTER_LUA_CFUNC(SetProjectileDamages);
 	REGISTER_LUA_CFUNC(SetProjectileIgnoreTrackingError);

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -217,6 +217,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetUnitArmored);
 	REGISTER_LUA_CFUNC(GetUnitIsActive);
 	REGISTER_LUA_CFUNC(GetUnitIsCloaked);
+	REGISTER_LUA_CFUNC(GetUnitSeismicSignature);
 	REGISTER_LUA_CFUNC(GetUnitSelfDTime);
 	REGISTER_LUA_CFUNC(GetUnitStockpile);
 	REGISTER_LUA_CFUNC(GetUnitSensorRadius);


### PR DESCRIPTION
### Work done

- Link some methods currently unlinked in lua.
  - LuaSyncedCtrl::SetProjectileTimeToLive
  - LuaSyncedRead::GetUnitSeismicSignature

### Remarks

- Checked all methods at Synced/Unsynced/Read/Ctrl, and these are the only ones I found.
- One I added myself, not sure how that could have happened, sorry about that :P.
- Tested the methods since being unlinked wasn't sure if they were tested originally