### PR TITLE
Fix /give command position argument.

### DIFF
--- a/rts/Sim/Units/UnitLoader.cpp
+++ b/rts/Sim/Units/UnitLoader.cpp
@@ -121,13 +121,13 @@ void CUnitLoader::ParseAndExecuteGiveUnitsCommand(const std::vector<std::string>
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (args.size() < 2) {
-		LOG_L(L_WARNING, "[%s] not enough arguments (\"/give [amount] <objectName | 'all'> [team] [@x, y, z]\")", __FUNCTION__);
+		LOG_L(L_WARNING, "[%s] not enough arguments (\"/give [amount] <objectName | 'all'> [team] [@x,y,z]\")", __FUNCTION__);
 		return;
 	}
 
 	float3 pos;
-	if (sscanf(args[args.size() - 1].c_str(), "@%f, %f, %f", &pos.x, &pos.y, &pos.z) != 3) {
-		LOG_L(L_WARNING, "[%s] invalid position argument (\"/give [amount] <objectName | 'all'> [team] [@x, y, z]\")", __FUNCTION__);
+	if (sscanf(args[args.size() - 1].c_str(), "@%f,%f,%f", &pos.x, &pos.y, &pos.z) != 3) {
+		LOG_L(L_WARNING, "[%s] invalid position argument (\"/give [amount] <objectName | 'all'> [team] [@x,y,z]\")", __FUNCTION__);
 		return;
 	}
 


### PR DESCRIPTION
### Work done

- Change definition of /give command since the error message now is misleading.

### Remarks

- It did work without spaces, since sscanf ignores whitespace as @sprunk noted.
- Didn't have the spaces originally, but they were added here: 381c1ddabc62b6746c9b83a4da4b1bfd13f1a71e
  - Commit doesn't have a description so can't say exactly what was the intent.
- Warnings need to be fixed, sscanf format string could be kept, but I think better to change it too, to make the code more immediately understandable without being aware of sscanf quirks here.


### How to test

using BAR:

- `/cheat on`
- `/give armpw @3000,100,3000`

It's how it works both before, and after this patch, `/give armpw @3000, 100, 3000` wouldn't work in either situation.
