### PR TITLE
Avoid freeze from endless STOP processing at FactoryCAI.

### DIFF
--- a/rts/Sim/Units/CommandAI/FactoryCAI.cpp
+++ b/rts/Sim/Units/CommandAI/FactoryCAI.cpp
@@ -405,7 +405,9 @@ void CFactoryCAI::SlowUpdate()
 					 * Units often get added and removed in large quantities via CTRL/SHIFT,
 					 * such multiple STOPs commands in a row would then produce a freeze
 					 * when the engine tries to process them all in one frame. */
-					if (lastCmdID != CMD_STOP)
+					if (lastCmdID == CMD_STOP)
+						commandQue.pop_front();
+					else
 						ExecuteStop(c);
 				} break;
 				default: {

--- a/rts/Sim/Units/CommandAI/FactoryCAI.cpp
+++ b/rts/Sim/Units/CommandAI/FactoryCAI.cpp
@@ -406,7 +406,7 @@ void CFactoryCAI::SlowUpdate()
 					 * when the engine tries to process them all in one frame.
 					 * Just execute the last in each series to ensure last build is cancelled
 					 * otherwise last unit stays being built. */
-					if (oldQueueSize < 2 || commandQue[1].GetID() != CMD_STOP) {
+					if (oldQueueSize == 1 || commandQue[1].GetID() != CMD_STOP) {
 						ExecuteStop(c);
 					} else {
 						commandQue.pop_front();

--- a/rts/Sim/Units/CommandAI/FactoryCAI.cpp
+++ b/rts/Sim/Units/CommandAI/FactoryCAI.cpp
@@ -398,6 +398,13 @@ void CFactoryCAI::SlowUpdate()
 			// regular order (move/wait/etc)
 			switch (c.GetID()) {
 				case CMD_STOP: {
+					/* Targeted hack to optimize bulk STOP orders.
+					 * Build orders get replaced by STOP instead of being removed,
+					 * this is due to the buildqueue's internal implementation as `std::deque`
+					 * whose interface doesn't support removal from the middle that well.
+					 * Units often get added and removed in large quantities via CTRL/SHIFT,
+					 * such multiple STOPs commands in a row would then produce a freeze
+					 * when the engine tries to process them all in one frame. */
 					if (lastCmdID != CMD_STOP)
 						ExecuteStop(c);
 				} break;

--- a/rts/Sim/Units/CommandAI/FactoryCAI.cpp
+++ b/rts/Sim/Units/CommandAI/FactoryCAI.cpp
@@ -380,6 +380,7 @@ void CFactoryCAI::SlowUpdate()
 
 	CFactory* fac = static_cast<CFactory*>(owner);
 
+	int lastCmdID = 0;
 	while (!commandQue.empty()) {
 		Command& c = commandQue.front();
 
@@ -397,7 +398,8 @@ void CFactoryCAI::SlowUpdate()
 			// regular order (move/wait/etc)
 			switch (c.GetID()) {
 				case CMD_STOP: {
-					ExecuteStop(c);
+					if (lastCmdID != CMD_STOP)
+						ExecuteStop(c);
 				} break;
 				default: {
 					CCommandAI::SlowUpdate();
@@ -408,6 +410,7 @@ void CFactoryCAI::SlowUpdate()
 		// exit if no command was consumed
 		if (oldQueueSize == commandQue.size())
 			break;
+		lastCmdID = c.GetID();
 	}
 }
 


### PR DESCRIPTION
DRAFT for now since just a way to show what the problem is while we discuss and find the best way to fix the problem. (the provided fix can be used to run the replay and prove the issue, and might be the best solution without changing std::deque for something different)

### Work done

- Avoid endless STOP processing in CFactoryCAI::SlowUpdate

### The problem

- [This replay](https://www.beyondallreason.info/replays?gameId=dec4ef6725cef4ecc38ae3a34469e952) shows a situation where the game is effectively frozen for a long time (== minutes) due to a unit processing 33k+ stop commands.
  - This is the light green player queing 33k grunts at factory id 24010, and then trying to clear, that internally does dequeing.
- This happens because GiveCommandReal with RIGHT_MOUSE option does a deque of specific cmdID by replacing them with CMD_STOP commands.
  - Dequeuing went through bar's `luarules/gadgets/cmd_factory_stop_production.lua`, didn't look about the specifics.
  - So, if there were thousands of orders it's going to end with a queue with 1000s of stop orders, and those get processed instantaneously (and quite slow), so the loop keeps going for seconds or minutes (3+ minutes in my computer and its not a potato).
- Not sure why GiveCommandReal is replacing everything by STOP instead of removing them, maybe because the queue can't really remove from the middle, or maybe it wasn't intended to do that in this situation. I understand for the first one it might be a good idea but for next ones not sure.

### Remarks

- Maybe not the best solution, but posting here so this is documented for now and we can discuss
- It's a bit of a hack, but to the real hack was subtituting build orders by stop orders to avoid erasing from the std::deque, this PR somehow "completes the hack".
- Other options would be:
  - actually removing from the queue, leaving just one stop, but don't seem like commandQue allows doing that cleanly.
    - Would like to do this instead, but didn't manage for now, if someone want to implement it, be my guest :), otherwise I may try to do it soon.
  - instead of all STOP, add NOOP commands, that could likely have other complications
- https://github.com/beyond-all-reason/spring/issues/1082 is somehow related, since lua is actually simply trying to clear the queue but there's no native way, so it does it by dequeing by unitdefid. The problem here still needs to be addressed, tho. 