### PR TITLE
Do not select entire group upon "add" command execution.

### DIFF
--- a/doc/site/changelogs/running-changelog.markdown
+++ b/doc/site/changelogs/running-changelog.markdown
@@ -25,3 +25,7 @@ See [the 2025.03 page]({{ site.baseurl }}{% link changelogs/changelog-2025-03.ma
 * the `/debugGL` option now takes an optional numerical argument, 0-15.
 0 and 1 control the whole debug view without touching anything else (i.e. work as before).
 Otherwise values 2-15 are treated as a bitmask: 8 controls stacktraces, 4 report groups, 2 the whole debug enabled/disabled state, 1 ignored.
+
+### Unsynced commands
+
+* `group` command `add` no longer selects entire group after execution.

--- a/rts/Game/UI/Groups/GroupHandler.cpp
+++ b/rts/Game/UI/Groups/GroupHandler.cpp
@@ -109,6 +109,8 @@ bool CGroupHandler::GroupCommand(int num, const std::string& cmd, bool& error)
 				// change group, but do not call SUH::AddUnit while iterating
 				u->SetGroup(group, false, false);
 			}
+
+			return true;
 		} break;
 
 		case hashString("select"): {

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -1213,7 +1213,7 @@ public:
 			{"select <n>", "Select group <n>"},
 			{"focus <n>", "Focus camera on group <n>"},
 			{"set <n>", "Set current selected units as group <n>"},
-			{"add <n>", "Add current selected units to group <n>"},
+			{"add <n>", "Add current selected units to group <n> (does not change selection)"},
 			{"unset", "Deassign control group for currently selected units"},
 			{"selectadd <n>", "Add members from group <n> to currently selected units"},
 			{"selectclear <n>", "Remove members from group <n> from currently selected units"},


### PR DESCRIPTION
## Motivation

Issue:
https://github.com/beyond-all-reason/spring/issues/1243

Summary:
- control group command `add <n>` adds selected units to group `n`, and selects entire group
- the equivalent command in most other RTS games works slightly different
    - it adds selected units to group `n`, but does *not* select entire group after assignment
- @badosu has proposed that the behavior of `add` command be changed instead of introducing new command with this behavior

## Changelog

- add early exit to `GroupCommand` in case of `add` and `set` - `return true;`
    - I was considering `return !group->units.empty()` to preserve return value behavior for `set` when it's called with no selected units
    - in such case, previous implementation would return `false`, but that seemed wrong, because calling `set` with no selection clears the specified group, which is valid and intended behavior
- update command description in `GroupActionExecutor`
- update running changelog

## Notes

- checked games in [Known games](https://github.com/beyond-all-reason/spring/wiki/Known-games), found no evidence of `add` usage
- actual hotkey for this command in BAR is `Ctrl+Shift+<n>`, not `Shift+<n>`
    - https://github.com/beyond-all-reason/Beyond-All-Reason/blob/75d0172738a5b72a9aa2678cf7c89bc55047b3a0/luaui/configs/hotkeys/num_keys.txt#L77