### PR TITLE
NEAREST filter on GenerateTexture for crisp text when ssaa is enabled.

### DIFF
--- a/rts/Rml/Backends/RmlUi_Renderer_GL3_Recoil.cpp
+++ b/rts/Rml/Backends/RmlUi_Renderer_GL3_Recoil.cpp
@@ -1067,8 +1067,8 @@ RenderInterface_GL3_Recoil::GenerateTexture(Rml::Span<const Rml::byte> source_da
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, source_dimensions.x, source_dimensions.y, 0, GL_RGBA, GL_UNSIGNED_BYTE,
 				 source_data.data());
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);


### PR DESCRIPTION
### Work done

- Set NEAREST filter on CreateTexture

### Remarks

- Not sure if it's the proper fix, but even after https://github.com/beyond-all-reason/spring/pull/1901 I still see text becoming a bit blurry when `MinSampleShadingRate = 1.0` is set.

### Screenshots

You can see the text with this PR looks just as good with or without `MinSampleShadingRate = 1.0`. The bot image does show aa effect, even with this pr.

aa on master:

![rml1](https://github.com/user-attachments/assets/5b79c99b-15f4-489b-9e17-d1703e3146e9)

aa with pr:

![rml2](https://github.com/user-attachments/assets/8a8998d7-a0f8-4780-864f-475c06b7eb57)

no aa:

![rml3](https://github.com/user-attachments/assets/1b47463a-7550-4e2a-a84b-7b5b6f44190a)
