### PR TITLE
Avoid ProjectileDrawer initialization error log on headless.

### DIFF
--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -195,8 +195,11 @@ void CProjectileDrawer::Init() {
 		ParseAtlasTextures(false, mapResGroundFXTexturesTable, blockedTexNames, groundFXAtlas);
 	}
 
-	if (!textureAtlas->Finalize())
+	if (!textureAtlas->Finalize()) {
+#ifndef HEADLESS
 		LOG_L(L_ERROR, "Could not finalize projectile-texture atlas. Use fewer/smaller textures.");
+#endif
+	}
 
 
 	flaretex        = &textureAtlas->GetTexture("flare");


### PR DESCRIPTION
### Work done

- Skip error ProjectileDrawer error log on headless

### Remarks

- Could instead introduce a new log level L_HEADED_ERROR or similar, mapped to L_ERROR when not headless, and to L_INFO on headless.
  - Unless this pops up in many places, don't think that would be wanted, but let me know if you prefer it.
- The situation is harmless in headless.