### PR TITLE
Return handled status from GotChatMsg at CGame::ProcessAction.

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -2203,14 +2203,15 @@ bool CGame::ProcessAction(const Action& action, int keyCode, int scanCode, bool 
 	if (ActionPressed(keyCode, scanCode, action, isRepeat))
 		return true;
 
+	bool handled = false;
 	// maybe a widget is interested?
 	if (luaUI != nullptr && luaUI->GotChatMsg(action.rawline, false))
-		return true;
+		handled = true;
 
 	if (luaMenu != nullptr && luaMenu->GotChatMsg(action.rawline, false))
-		return true;
+		handled |= true;
 
-	return false;
+	return handled;
 }
 
 void CGame::ActionReceived(const Action& action, int playerID)

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -2204,11 +2204,11 @@ bool CGame::ProcessAction(const Action& action, int keyCode, int scanCode, bool 
 		return true;
 
 	// maybe a widget is interested?
-	if (luaUI != nullptr)
-		luaUI->GotChatMsg(action.rawline, false); //FIXME add return argument!
+	if (luaUI != nullptr && luaUI->GotChatMsg(action.rawline, false))
+		return true;
 
-	if (luaMenu != nullptr)
-		luaMenu->GotChatMsg(action.rawline, false); //FIXME add return argument!
+	if (luaMenu != nullptr && luaMenu->GotChatMsg(action.rawline, false))
+		return true;
 
 	return false;
 }

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -2209,7 +2209,7 @@ bool CGame::ProcessAction(const Action& action, int keyCode, int scanCode, bool 
 		handled = true;
 
 	if (luaMenu != nullptr && luaMenu->GotChatMsg(action.rawline, false))
-		handled |= true;
+		handled = true;
 
 	return handled;
 }


### PR DESCRIPTION
### Work done

- Return handled status from GotChatMsg at CGame::ProcessAction.

### Remarks

- Removes FIXME, but useless otherwise since nobody using the result from ProcessAction atm.
  - Could be used at `CGame::ProcessCommandText`, but the return value seems to be more just to see if it was a command, not if the command was processed.
- I think luaUI and luaMenu can't both exist at the same time, otherwise would need to `|=` the result from both instead of `return true` on first match. 