### PR TITLE
Add ClearFactoryQueue logic, and hook it to INSERT/STOP/REMOVE combos

### DIFF
--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1250,9 +1250,8 @@ void CCommandAI::ExecuteRemove(const Command& c)
 			firstIndex = (int)c.GetParam(0);
 		if (c.GetNumParams() >= 2) {
 			lastIndex = (int)c.GetParam(1);
-			if (lastIndex > queue->size()-1) {
+			if (lastIndex > queue->size()-1)
 				lastIndex = queue->size()-1;
-			}
 		}
 
 		int nElements = lastIndex - firstIndex + 1 ;

--- a/rts/Sim/Units/CommandAI/FactoryCAI.h
+++ b/rts/Sim/Units/CommandAI/FactoryCAI.h
@@ -27,10 +27,12 @@ public:
 	void GiveCommandReal(const Command& c, bool fromSynced = true);
 
 	void ClearBuildQueue();
-	void InsertBuildStop(CCommandQueue::iterator& it, const Command& c);
+	void ClearBuildCommands(CCommandQueue::iterator& it, int nElements);
 
 	void InsertBuildCommand(CCommandQueue::iterator& it, const Command& c);
 	bool RemoveBuildCommand(CCommandQueue::iterator& it);
+
+	void ExecuteFactoryRemove(const Command& newCmd);
 
 	void DecreaseQueueCount(const Command& c, int& buildOption);
 	void FactoryFinishBuild(const Command& command);

--- a/rts/Sim/Units/CommandAI/FactoryCAI.h
+++ b/rts/Sim/Units/CommandAI/FactoryCAI.h
@@ -26,6 +26,9 @@ public:
 
 	void GiveCommandReal(const Command& c, bool fromSynced = true);
 
+	void ClearBuildQueue();
+	void InsertBuildStop(CCommandQueue::iterator& it, const Command& c);
+
 	void InsertBuildCommand(CCommandQueue::iterator& it, const Command& c);
 	bool RemoveBuildCommand(CCommandQueue::iterator& it);
 


### PR DESCRIPTION
### Work done

- Add code to efficiently clear factory queue (unit's commandQueue)
- Hook into INSERT(control, alt)+STOP
- Implement REMOVE(meta)
  - New behaviour accepting params(startIdx, endIdx), if either is unset will default to queue ends.
  - Also accepts ctrl to choose queue.

### Work yet to be done in this PR

- Remove STOP hook if we don't want (just need to remove all changes from CFactoryCAI.*)
- Refine the clear factory behaviour

### Related issues

- https://github.com/beyond-all-reason/spring/issues/1082
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2190

Also see following "precursor" pr: https://github.com/beyond-all-reason/spring/pull/2137

### Remarks

- REMOVE(meta) working great for this use case, use like this:
  - `spGiveOrderToUnit(unitID, CMD.REMOVE, nil, {'meta', 'ctrl'})`
  - `spGiveOrderToUnit(unitID, CMD.REMOVE, 1, {'meta', 'ctrl'})`
  - `spGiveOrderToUnit(unitID, CMD.REMOVE, {1, 20}, {'meta', 'ctrl'})`
- Seems like INSERT(control, alt)+STOP fits quite naturally for this use case, it also supports clearing from a specific element onwards.
  - Probably best not do it though, since breaks the (unwritten and not totally true) "STOP == noop" rule.
  - Use like this: `spGiveOrderToUnit(unitID, CMD.INSERT, {index, CMD.STOP, 0}, {'ctrl', 'alt'})`
    - index is the element to start removing from.
- This can be changed, to use REMOVE instead, if we decide on a way to control that command through modifiers.
  - can also be added and support both STOP and REMOVE through the same core code, just changing it slightly.
  - note most of the remarks here probably apply to REMOVE as well
- It's a bit unclear how callins should react
  - I'm making the STOP command FinishCommand(), that makes it generate UnitCmdDone callin for the command, in this way GUI can react.
  - Don't think STOP currently always sends the UnitCmdDone.
  - Not sure if cancelling the current command should UnitCmdDone, again, don't think it's always the case now (at least dequeue will cancel the first element but not generate a UnitCmdDone), and this code doesn't do it atm. In case its a unit being built don't think it should be called, but for other commands it's probable it should.
- Probably needs a bit of special handling of the WAIT command too, if we want this to work conditionally on the WAIT status of the unit (actually the first command in the queue).
- While we could just not support so many special cases, I think it has some value, so we have more efficient path for the "full queue clear" paths of leaving 0 or 1 commands behind. This way we avoid possibly clearing thousands of commands and then looping through them.