### PR TITLE
Add Spring.GetMouseButtonsPressed

### DIFF
--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -239,6 +239,7 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetGatherMode);
 	REGISTER_LUA_CFUNC(GetActivePage);
 
+	REGISTER_LUA_CFUNC(GetMouseButtonsPressed);
 	REGISTER_LUA_CFUNC(GetMouseState);
 	REGISTER_LUA_CFUNC(GetMouseCursor);
 	REGISTER_LUA_CFUNC(GetMouseStartPosition);
@@ -3594,21 +3595,32 @@ int LuaUnsyncedRead::GetMouseStartPosition(lua_State* L)
 
 /***
  *
- * @function Spring.GetMouseButtonState
- * @param button integer
- * @return boolean pressed
+ * @function Spring.GetMouseButtonsPressed
+ * @param button1 integer? Index of the first button.
+ * @param ... integer Indices for more buttons.
+ * @return boolean ... Pressed status for the buttons.
  */
-int LuaUnsyncedRead::GetMouseButtonState(lua_State* L)
+int LuaUnsyncedRead::GetMouseButtonsPressed(lua_State* L)
 {
-	assert(mouse != nullptr);
+	int numArgs = lua_gettop(L);
 
-	const int button = luaL_checkint(L, 1);
+	if (numArgs == 0) {
+		for (int i = 0; i < NUM_BUTTONS ; ++i)
+			lua_pushboolean(L, mouse->buttons[i].pressed);
 
-	if ((button <= 0) || (button > NUM_BUTTONS))
-		return 0;
+		return NUM_BUTTONS;
+	}
 
-	lua_pushboolean(L, mouse->buttons[button].pressed);
-	return 1;
+	for (int i = 1; i <= numArgs ; ++i) {
+		int button = luaL_checkint(L, i);
+
+		if ((button <= 0) || (button > NUM_BUTTONS))
+			luaL_error(L, "%d: bad button index", button);
+
+		lua_pushboolean(L, mouse->buttons[button].pressed);
+	}
+
+	return numArgs;
 }
 
 

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3592,6 +3592,25 @@ int LuaUnsyncedRead::GetMouseStartPosition(lua_State* L)
 }
 
 
+/***
+ *
+ * @function Spring.GetMouseButtonState
+ * @return boolean pressed
+ */
+int LuaUnsyncedRead::GetMouseButtonState(lua_State* L)
+{
+	assert(mouse != nullptr);
+
+	const int button = luaL_checkint(L, 1);
+
+	if ((button <= 0) || (button > NUM_BUTTONS))
+		return 0;
+
+	lua_pushboolean(L, mouse->buttons[button].pressed);
+	return 1;
+}
+
+
 /******************************************************************************
  * Text
  * @section text

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3605,14 +3605,14 @@ int LuaUnsyncedRead::GetMouseStartPosition(lua_State* L)
  */
 int LuaUnsyncedRead::GetMouseButtonsPressed(lua_State* L)
 {
-	int numArgs = lua_gettop(L);
+	const int numArgs = lua_gettop(L);
 
 	if (numArgs == 0) {
 		luaL_error(L, "Need to pass some button indexes.");
 	}
 
 	for (int i = 1; i <= numArgs ; ++i) {
-		int button = luaL_checkint(L, i);
+		const int button = luaL_checkint(L, i);
 
 		if (button <= 0)
 			luaL_error(L, "%d: bad button index", button);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3596,6 +3596,10 @@ int LuaUnsyncedRead::GetMouseStartPosition(lua_State* L)
 /***
  *
  * @function Spring.GetMouseButtonsPressed
+ *
+ * Get pressed status for all buttons, or optionally pass a list of
+ * button indices to get the pressed status for.
+ *
  * @param button1 integer? Index of the first button.
  * @param ... integer Indices for more buttons.
  * @return boolean ... Pressed status for the buttons.

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3595,6 +3595,7 @@ int LuaUnsyncedRead::GetMouseStartPosition(lua_State* L)
 /***
  *
  * @function Spring.GetMouseButtonState
+ * @param button integer
  * @return boolean pressed
  */
 int LuaUnsyncedRead::GetMouseButtonState(lua_State* L)

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3599,7 +3599,7 @@ int LuaUnsyncedRead::GetMouseStartPosition(lua_State* L)
  *
  * Get pressed status for specific buttons.
  *
- * @param button1 integer? Index of the first button.
+ * @param button1 integer Index of the first button.
  * @param ... integer Indices for more buttons.
  * @return boolean ... Pressed status for the buttons.
  */

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3597,8 +3597,7 @@ int LuaUnsyncedRead::GetMouseStartPosition(lua_State* L)
  *
  * @function Spring.GetMouseButtonsPressed
  *
- * Get pressed status for all buttons, or optionally pass a list of
- * button indices to get the pressed status for.
+ * Get pressed status for specific buttons.
  *
  * @param button1 integer? Index of the first button.
  * @param ... integer Indices for more buttons.
@@ -3609,10 +3608,7 @@ int LuaUnsyncedRead::GetMouseButtonsPressed(lua_State* L)
 	int numArgs = lua_gettop(L);
 
 	if (numArgs == 0) {
-		for (int i = 0; i < NUM_BUTTONS ; ++i)
-			lua_pushboolean(L, mouse->buttons[i].pressed);
-
-		return NUM_BUTTONS;
+		luaL_error(L, "Need to pass some button indexes.");
 	}
 
 	for (int i = 1; i <= numArgs ; ++i) {

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3618,10 +3618,12 @@ int LuaUnsyncedRead::GetMouseButtonsPressed(lua_State* L)
 	for (int i = 1; i <= numArgs ; ++i) {
 		int button = luaL_checkint(L, i);
 
-		if ((button <= 0) || (button > NUM_BUTTONS))
+		if (button <= 0)
 			luaL_error(L, "%d: bad button index", button);
-
-		lua_pushboolean(L, mouse->buttons[button].pressed);
+		if (button > NUM_BUTTONS)
+			lua_pushboolean(L, false);
+		else
+			lua_pushboolean(L, mouse->buttons[button].pressed);
 	}
 
 	return numArgs;

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -143,6 +143,7 @@ class LuaUnsyncedRead {
 		static int GetGameSpeed(lua_State* L);
 		static int GetGameState(lua_State* L);
 
+		static int GetMouseButtonState(lua_State* L);
 		static int GetMouseState(lua_State* L);
 		static int GetMouseCursor(lua_State* L);
 		static int GetMouseStartPosition(lua_State* L);

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -143,7 +143,7 @@ class LuaUnsyncedRead {
 		static int GetGameSpeed(lua_State* L);
 		static int GetGameState(lua_State* L);
 
-		static int GetMouseButtonState(lua_State* L);
+		static int GetMouseButtonsPressed(lua_State* L);
 		static int GetMouseState(lua_State* L);
 		static int GetMouseCursor(lua_State* L);
 		static int GetMouseStartPosition(lua_State* L);


### PR DESCRIPTION
### Work Done

- Add Spring.GetMouseButtonsPressed

### Remarks

- No other way to get state of buttons 4+ atm from lua, afaics.
- Could instead add to Spring.GetMouseState, but that one already has too many return values.
  - Still if you prefer could do this, maybe controlled through an input parameter to control how many extra buttons to return at the end.
  - Could make expanding Spring.GetMouseState trickier later, like maybe we want to query for a different mouse, or some other return parameter need to be added.
- see the [comment below](https://github.com/beyond-all-reason/spring/pull/2167#issuecomment-2797060315) by @sprunk for more ideas we considered about possible API for this.