### PR TITLE
Remove unused action related arguments

### DIFF
--- a/rts/ExternalAI/AICallback.cpp
+++ b/rts/ExternalAI/AICallback.cpp
@@ -136,7 +136,7 @@ void CAICallback::SendTextMsg(const char* text, int zone)
 	const std::vector<uint8_t>& teamAIs = skirmishAIHandler.GetSkirmishAIsInTeam(this->team);
 	const SkirmishAIData* aiData = skirmishAIHandler.GetSkirmishAI(teamAIs[0]); // FIXME is there a better way?
 
-	if (!game->ProcessCommandText(-1, -1, text))
+	if (!game->ProcessCommandText(text))
 		return;
 
 	LOG("<SkirmishAI: %s %s (team %d)>: %s", aiData->shortName.c_str(), aiData->version.c_str(), team, text);

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -2237,7 +2237,7 @@ bool CGame::ActionPressed(int keyCode, int scanCode, const Action& action, bool 
 
 	if (executor != nullptr) {
 		// an executor for that action was found
-		if (executor->ExecuteAction(UnsyncedAction(action, keyCode, isRepeat)))
+		if (executor->ExecuteAction(UnsyncedAction(action, isRepeat)))
 			return true;
 	}
 

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -2199,8 +2199,8 @@ bool CGame::ProcessCommandText(const std::string& command) {
 
 bool CGame::ProcessAction(const Action& action, bool isRepeat)
 {
-	if (ActionPressed(action, isRepeat))
 	RECOIL_DETAILED_TRACY_ZONE;
+	if (ActionPressed(action, isRepeat))
 		return true;
 
 	// maybe a widget is interested?

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1136,7 +1136,7 @@ int CGame::KeyPressed(int keyCode, int scanCode, bool isRepeat)
 
 	// try our list of actions
 	for (const Action& action: lastActionList) {
-		if (ActionPressed(keyCode, scanCode, action, isRepeat)) {
+		if (ActionPressed(action, isRepeat)) {
 			return 0;
 		}
 	}
@@ -2183,24 +2183,24 @@ void CGame::Save(std::string&& fileName, std::string&& saveArgs)
 
 
 
-bool CGame::ProcessCommandText(int keyCode, int scanCode, const std::string& command) {
+bool CGame::ProcessCommandText(const std::string& command) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (command.size() <= 2)
 		return false;
 
 	if ((command[0] == '/') && (command[1] != '/')) {
 		// strip the '/'
-		ProcessAction(Action(command.substr(1)), keyCode, scanCode, false);
+		ProcessAction(Action(command.substr(1)), false);
 		return true;
 	}
 
 	return false;
 }
 
-bool CGame::ProcessAction(const Action& action, int keyCode, int scanCode, bool isRepeat)
+bool CGame::ProcessAction(const Action& action, bool isRepeat)
 {
+	if (ActionPressed(action, isRepeat))
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (ActionPressed(keyCode, scanCode, action, isRepeat))
 		return true;
 
 	// maybe a widget is interested?
@@ -2230,7 +2230,7 @@ void CGame::ActionReceived(const Action& action, int playerID)
 	}
 }
 
-bool CGame::ActionPressed(int keyCode, int scanCode, const Action& action, bool isRepeat)
+bool CGame::ActionPressed(const Action& action, bool isRepeat)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const IUnsyncedActionExecutor* executor = unsyncedGameCommands->GetActionExecutor(action.command);

--- a/rts/Game/Game.h
+++ b/rts/Game/Game.h
@@ -88,8 +88,8 @@ public:
 	/// Send a message to other players (allows prefixed messages with e.g. "a:...")
 	void SendNetChat(std::string message, int destination = -1);
 
-	bool ProcessCommandText(int keyCode, int scanCode, const std::string& command);
-	bool ProcessAction(const Action& action, int keyCode = -1, int scanCode = -1, bool isRepeat = false);
+	bool ProcessCommandText(const std::string& command);
+	bool ProcessAction(const Action& action, bool isRepeat = false);
 
 	void ReloadCOB(const std::string& msg, int player);
 	void ReloadCEGs(const std::string& tag);
@@ -129,7 +129,7 @@ private:
 	int TextInput(const std::string& utf8Text) override;
 	int TextEditing(const std::string& utf8Text, unsigned int start, unsigned int length) override;
 
-	bool ActionPressed(int keyCode, int scanCode, const Action& action, bool isRepeat);
+	bool ActionPressed(const Action& action, bool isRepeat);
 	bool ActionReleased(const Action& action);
 	/// synced actions (received from server) go in here
 	void ActionReceived(const Action& action, int playerID);

--- a/rts/Game/GameControllerTextInput.cpp
+++ b/rts/Game/GameControllerTextInput.cpp
@@ -162,7 +162,7 @@ void GameControllerTextInput::PasteClipboard() {
 }
 
 
-bool GameControllerTextInput::HandleChatCommand(int key, const std::string& command) {
+bool GameControllerTextInput::HandleChatCommand(const std::string& command) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	switch (hashString(command.c_str())) {
 		case hashString("chatswitchall"): {
@@ -222,7 +222,7 @@ bool GameControllerTextInput::HandleChatCommand(int key, const std::string& comm
 
 
 // can only be called by CGame (via ConsumePressedKey)
-bool GameControllerTextInput::HandleEditCommand(int keyCode, int scanCode, const std::string& command) {
+bool GameControllerTextInput::HandleEditCommand(const std::string& command) {
 	switch (hashString(command.c_str())) {
 		case hashString("edit_return"): {
 			userWriting = false;
@@ -237,7 +237,7 @@ bool GameControllerTextInput::HandleEditCommand(int keyCode, int scanCode, const
 					cmd = userInput;
 				}
 
-				if (game->ProcessCommandText(keyCode, scanCode, cmd)) {
+				if (game->ProcessCommandText(cmd)) {
 					// execute an action
 					gameConsoleHistory.AddLine(cmd);
 					ClearInput();
@@ -371,7 +371,7 @@ bool GameControllerTextInput::HandleEditCommand(int keyCode, int scanCode, const
 }
 
 
-bool GameControllerTextInput::HandlePasteCommand(int key, const std::string& rawLine) {
+bool GameControllerTextInput::HandlePasteCommand(const std::string& rawLine) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	// we cannot use extra commands because tokenization strips multiple
 	// spaces or even trailing spaces, the text should be copied verbatim
@@ -392,22 +392,22 @@ bool GameControllerTextInput::CheckHandlePasteCommand(const std::string& rawLine
 	if (!userWriting)
 		return false;
 
-	return (HandlePasteCommand(0, rawLine));
+	return (HandlePasteCommand(rawLine));
 }
 
 
-bool GameControllerTextInput::ProcessKeyPressAction(int keyCode, int scanCode, const Action& action) {
+bool GameControllerTextInput::ProcessKeyPressAction(const Action& action) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	assert(userWriting);
 
 	if (action.command == "pastetext")
-		return (HandlePasteCommand(keyCode, action.rawline));
+		return (HandlePasteCommand(action.rawline));
 
 	if (action.command.find("edit_") == 0)
-		return (HandleEditCommand(keyCode, scanCode, action.command));
+		return (HandleEditCommand(action.command));
 
 	if (action.command.find("chatswitch") == 0)
-		return (HandleChatCommand(keyCode, action.command));
+		return (HandleChatCommand(action.command));
 
 	return false;
 }
@@ -419,7 +419,7 @@ bool GameControllerTextInput::ConsumePressedKey(int keyCode, int scanCode, const
 		return false;
 
 	for (const Action& action: actions) {
-		if (!ProcessKeyPressAction(keyCode, scanCode, action))
+		if (!ProcessKeyPressAction(action))
 			continue;
 
 		// the key was used, ignore it (ex: alt+a)

--- a/rts/Game/GameControllerTextInput.h
+++ b/rts/Game/GameControllerTextInput.h
@@ -73,10 +73,10 @@ public:
 private:
 	void PasteClipboard();
 
-	bool HandleChatCommand(int key, const std::string& command);
-	bool HandleEditCommand(int keyCode, int scanCode, const std::string& command);
-	bool HandlePasteCommand(int key, const std::string& rawLine);
-	bool ProcessKeyPressAction(int keyCode, int scanCode, const Action& action);
+	bool HandleChatCommand(const std::string& command);
+	bool HandleEditCommand(const std::string& command);
+	bool HandlePasteCommand(const std::string& rawLine);
+	bool ProcessKeyPressAction(const Action& action);
 
 public:
 	/// current writing/editing positions

--- a/rts/Game/UnsyncedActionExecutor.h
+++ b/rts/Game/UnsyncedActionExecutor.h
@@ -13,16 +13,10 @@ class Action;
 class UnsyncedAction : public IAction
 {
 public:
-	UnsyncedAction(const Action& action, int key, bool repeat)
+	UnsyncedAction(const Action& action, bool repeat)
 		: IAction(action)
-		, key(key)
 		, repeat(repeat)
 	{}
-
-	/**
-	 * Returns the normalized key symbol.
-	 */
-	unsigned int GetKey() const { return key; }
 
 	/**
 	 * Returns whether the action is to be executed repeatedly.
@@ -30,7 +24,6 @@ public:
 	bool IsRepeat() const { return repeat; }
 
 private:
-	int key;
 	bool repeat;
 };
 


### PR DESCRIPTION
### Work done

- Remove unused `keyCode` and `scanCode` arguments from Action processing
- Removed `key` property of `UnsyncedAction` (unused)

### Remarks

- Cherry-picks from @MasterBel2 https://github.com/beyond-all-reason/spring/pull/893
- I think this is a harmless change, and good to have since those parameters are unused so just a cleanup.
- Also included at https://github.com/beyond-all-reason/spring/pull/2166
  - the idea is divide the 4 commits there in 1-3 PRs and get them in independently, since those don't depend on my other input work.