### PR TITLE
IUnsyncedActionExecutor processing of ActionRelease events.

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -2234,13 +2234,8 @@ void CGame::ActionReceived(const Action& action, int playerID)
 bool CGame::ActionPressed(const Action& action, bool isRepeat)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	const IUnsyncedActionExecutor* executor = unsyncedGameCommands->GetActionExecutor(action.command);
-
-	if (executor != nullptr) {
-		// an executor for that action was found
-		if (executor->ExecuteAction(UnsyncedAction(action, isRepeat)))
-			return true;
-	}
+	if (unsyncedGameCommands->ActionPressed(action, isRepeat))
+		return true;
 
 	if (CGameServer::IsServerCommand(action.command)) {
 		CommandMessage pckt(action, gu->myPlayerNum);
@@ -2249,4 +2244,9 @@ bool CGame::ActionPressed(const Action& action, bool isRepeat)
 	}
 
 	return (gameCommandConsole.ExecuteAction(action));
+}
+
+bool CGame::ActionReleased(const Action& action)
+{
+	return unsyncedGameCommands->ActionReleased(action);
 }

--- a/rts/Game/UnsyncedActionExecutor.h
+++ b/rts/Game/UnsyncedActionExecutor.h
@@ -38,7 +38,21 @@ protected:
 	}
 
 public:
+	bool ExecuteActionRelease(const UnsyncedAction& action) const {
+		if (IsCheatRequired() && !gs->cheatEnabled) {
+			LOG_L(L_WARNING, "Chat command /%s (%s) cannot be executed (release) (cheats required)!",
+					GetCommand().c_str(),
+					(IsSynced() ? "synced" : "unsynced"));
+			return false;
+		} else {
+			return ExecuteRelease(action);
+		}
+	}
+
 	virtual ~IUnsyncedActionExecutor() {}
+
+private:
+	virtual bool ExecuteRelease(const UnsyncedAction& action) const { return false; }
 };
 
 #endif // UNSYNCED_ACTION_EXECUTOR_H

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -665,6 +665,11 @@ public:
 	}
 
 	bool ExecuteRelease(const UnsyncedAction& action) const final {
+		if (button == 4 || button == 5) {
+			// HACK   somehow weird things happen when MouseRelease is called for button 4 and 5.
+			// Note that SYS_WMEVENT on windows also only sends MousePress events for these buttons.
+			return false;
+		}
 		mouse->MouseRelease(mouse->lastx, mouse->lasty, button);
 		// TODO: false for backwards compatibility
 		return false;

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -614,7 +614,8 @@ public:
 
 	bool ExecuteRelease(const UnsyncedAction& action) const final {
 		inMapDrawer->SetDrawMode(false);
-		return true;
+		// TODO: false for backwards compatibility
+		return false;
 	}
 };
 
@@ -665,8 +666,8 @@ public:
 
 	bool ExecuteRelease(const UnsyncedAction& action) const final {
 		mouse->MouseRelease(mouse->lastx, mouse->lasty, button);
-
-		return true;
+		// TODO: false for backwards compatibility
+		return false;
 	}
 
 private:
@@ -678,10 +679,14 @@ class MouseStateActionExecutor : public IUnsyncedActionExecutor {
 public:
 	MouseStateActionExecutor() : IUnsyncedActionExecutor("mousestate", "Toggles mousestate") {}
 
-	bool Execute(const UnsyncedAction& action) const final { return true; }
+	bool Execute(const UnsyncedAction& action) const final {
+		// TODO: false for backwards compatibility
+		return false;
+	}
 	bool ExecuteRelease(const UnsyncedAction& action) const final {
 		mouse->ToggleMiddleClickScroll();
-		return true;
+		// TODO: false for backwards compatibility
+		return false;
 	}
 };
 
@@ -748,6 +753,7 @@ public:
 
 	bool ExecuteRelease(const UnsyncedAction& action) const final {
 		camera->SetMovState(moveStateIdx, false);
+		// TODO: maybe should return false for backwards compatibility
 		return halt;
 	}
 
@@ -1819,12 +1825,16 @@ class GameInfoCloseActionExecutor : public IUnsyncedActionExecutor {
 public:
 	GameInfoCloseActionExecutor() : IUnsyncedActionExecutor("gameinfoclose", "Closes game info") {}
 
-	bool Execute(const UnsyncedAction& action) const final { return true; }
+	bool Execute(const UnsyncedAction& action) const final {
+		// TODO: false for backwards compatibility
+		return false;
+	}
 
 	bool ExecuteRelease(const UnsyncedAction& action) const final {
 		if (CGameInfo::IsActive()) {
+			// TODO: handled in release, and return false for backwards compatibility
 			CGameInfo::Disable();
-			return true;
+			return false;
 		}
 		return false;
 	}

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -3833,11 +3833,21 @@ private:
 } // namespace (unnamed)
 
 
+bool UnsyncedGameCommands::ActionPressed(const Action& action, bool isRepeat)
+{
+	const IUnsyncedActionExecutor* executor = GetActionExecutor(action.command);
+
+	if (executor != nullptr) {
+		// an executor for that action was found
+		if (executor->ExecuteAction(UnsyncedAction(action, isRepeat)))
+			return true;
+	}
+
+	return false;
+}
 
 
-
-// TODO CGame stuff in UnsyncedGameCommands: refactor (or move)
-bool CGame::ActionReleased(const Action& action)
+bool UnsyncedGameCommands::ActionReleased(const Action& action)
 {
 	switch (hashString(action.command.c_str())) {
 		case hashString("drawinmap"): {

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -682,7 +682,7 @@ private:
 
 class MouseStateActionExecutor : public IUnsyncedActionExecutor {
 public:
-	MouseStateActionExecutor() : IUnsyncedActionExecutor("mousestate", "Toggles mousestate") {}
+	MouseStateActionExecutor() : IUnsyncedActionExecutor("MouseState", "Toggles mousestate") {}
 
 	bool Execute(const UnsyncedAction& action) const final {
 		// TODO: false for backwards compatibility
@@ -1828,7 +1828,7 @@ public:
 
 class GameInfoCloseActionExecutor : public IUnsyncedActionExecutor {
 public:
-	GameInfoCloseActionExecutor() : IUnsyncedActionExecutor("gameinfoclose", "Closes game info") {}
+	GameInfoCloseActionExecutor() : IUnsyncedActionExecutor("GameInfoClose", "Closes game info") {}
 
 	bool Execute(const UnsyncedAction& action) const final {
 		// TODO: false for backwards compatibility

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -3894,7 +3894,8 @@ bool UnsyncedGameCommands::ActionReleased(const Action& action)
 
 	if (executor != nullptr) {
 		// an executor for that action was found
-		executor->ExecuteActionRelease(UnsyncedAction(action, false));
+		if (executor->ExecuteActionRelease(UnsyncedAction(action, false)))
+			return true;
 	}
 
 	return false; // prior implementation always returned false - I don't know why, but we'll maintain behaviour until we have reason to change it.

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -1822,8 +1822,11 @@ public:
 	bool Execute(const UnsyncedAction& action) const final { return true; }
 
 	bool ExecuteRelease(const UnsyncedAction& action) const final {
-		CGameInfo::Disable();
-		return true;
+		if (CGameInfo::IsActive()) {
+			CGameInfo::Disable();
+			return true;
+		}
+		return false;
 	}
 };
 

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -611,6 +611,11 @@ public:
 		inMapDrawer->SetDrawMode(true);
 		return true;
 	}
+
+	bool ExecuteRelease(const UnsyncedAction& action) const final {
+		inMapDrawer->SetDrawMode(false);
+		return true;
+	}
 };
 
 
@@ -658,9 +663,28 @@ public:
 		return true;
 	}
 
+	bool ExecuteRelease(const UnsyncedAction& action) const final {
+		mouse->MouseRelease(mouse->lastx, mouse->lasty, button);
+
+		return true;
+	}
+
 private:
 	int button;
 };
+
+
+class MouseStateActionExecutor : public IUnsyncedActionExecutor {
+public:
+	MouseStateActionExecutor() : IUnsyncedActionExecutor("mousestate", "Toggles mousestate") {}
+
+	bool Execute(const UnsyncedAction& action) const final { return true; }
+	bool ExecuteRelease(const UnsyncedAction& action) const final {
+		mouse->ToggleMiddleClickScroll();
+		return true;
+	}
+};
+
 
 class MouseCancelSelectionRectangleActionExecutor : public IUnsyncedActionExecutor {
 public:
@@ -719,6 +743,11 @@ public:
 	bool Execute(const UnsyncedAction& action) const final {
 		camera->SetMovState(moveStateIdx, true);
 
+		return halt;
+	}
+
+	bool ExecuteRelease(const UnsyncedAction& action) const final {
+		camera->SetMovState(moveStateIdx, false);
 		return halt;
 	}
 
@@ -1781,6 +1810,19 @@ public:
 			}
 		}
 
+		return true;
+	}
+};
+
+
+class GameInfoCloseActionExecutor : public IUnsyncedActionExecutor {
+public:
+	GameInfoCloseActionExecutor() : IUnsyncedActionExecutor("gameinfoclose", "Closes game info") {}
+
+	bool Execute(const UnsyncedAction& action) const final { return true; }
+
+	bool ExecuteRelease(const UnsyncedAction& action) const final {
+		CGameInfo::Disable();
 		return true;
 	}
 };
@@ -3846,82 +3888,16 @@ bool UnsyncedGameCommands::ActionPressed(const Action& action, bool isRepeat)
 	return false;
 }
 
-
 bool UnsyncedGameCommands::ActionReleased(const Action& action)
 {
-	switch (hashString(action.command.c_str())) {
-		case hashString("drawinmap"): {
-			inMapDrawer->SetDrawMode(false);
-		} break;
+	const IUnsyncedActionExecutor* executor = GetActionExecutor(action.command);
 
-		case hashString("moveforward"): {
-			camera->SetMovState(CCamera::MOVE_STATE_FWD, false);
-		} break;
-		case hashString("moveback"): {
-			camera->SetMovState(CCamera::MOVE_STATE_BCK, false);
-		} break;
-		case hashString("moveleft"): {
-			camera->SetMovState(CCamera::MOVE_STATE_LFT, false);
-		} break;
-		case hashString("moveright"): {
-			camera->SetMovState(CCamera::MOVE_STATE_RGT, false);
-		} break;
-		case hashString("moveup"): {
-			camera->SetMovState(CCamera::MOVE_STATE_UP, false);
-		} break;
-		case hashString("movedown"): {
-			camera->SetMovState(CCamera::MOVE_STATE_DWN, false);
-		} break;
-
-		case hashString("movefast"): {
-			camera->SetMovState(CCamera::MOVE_STATE_FST, false);
-		} break;
-		case hashString("moveslow"): {
-			camera->SetMovState(CCamera::MOVE_STATE_SLW, false);
-		} break;
-		case hashString("movetilt"): {
-			camera->SetMovState(CCamera::MOVE_STATE_TLT, false);
-		} break;
-		case hashString("movereset"): {
-			camera->SetMovState(CCamera::MOVE_STATE_RST, false);
-		} break;
-		case hashString("moverotate"): {
-			camera->SetMovState(CCamera::MOVE_STATE_RTT, false);
-		} break;
-
-		case hashString("mouse1"): {
-			mouse->MouseRelease(mouse->lastx, mouse->lasty, 1);
-		} break;
-		case hashString("mouse2"): {
-			mouse->MouseRelease(mouse->lastx, mouse->lasty, 2);
-		} break;
-		case hashString("mouse3"): {
-			mouse->MouseRelease(mouse->lastx, mouse->lasty, 3);
-		} break;
-
-		#if 0
-		// HACK   somehow weird things happen when MouseRelease is called for button 4 and 5.
-		// Note that SYS_WMEVENT on windows also only sends MousePress events for these buttons.
-		case hashString("mouse4"): {
-			mouse->MouseRelease(mouse->lastx, mouse->lasty, 4);
-		} break;
-		case hashString("mouse5"): {
-			mouse->MouseRelease(mouse->lastx, mouse->lasty, 5);
-		} break;
-		#endif
-
-		case hashString("mousestate"): {
-			mouse->ToggleMiddleClickScroll();
-		} break;
-		case hashString("gameinfoclose"): {
-			CGameInfo::Disable();
-		} break;
-
-		default: {
-		} break;
+	if (executor != nullptr) {
+		// an executor for that action was found
+		executor->ExecuteActionRelease(UnsyncedAction(action, false));
 	}
 
-	return false;
+	return false; // prior implementation always returned false - I don't know why, but we'll maintain behaviour until we have reason to change it.
 }
 
 
@@ -3971,6 +3947,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_TLT, "Tilt"  , false));
 	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_RST, "Reset" , false));
 	AddActionExecutor(AllocActionExecutor<CameraMoveActionExecutor>(CCamera::MOVE_STATE_RTT, "Rotate", false));
+	AddActionExecutor(AllocActionExecutor<MouseStateActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<AIKillReloadActionExecutor>(true));
 	AddActionExecutor(AllocActionExecutor<AIKillReloadActionExecutor>(false));
 	AddActionExecutor(AllocActionExecutor<AIControlActionExecutor>());
@@ -4021,6 +3998,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<NetMsgSmoothingActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SpeedControlActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<GameInfoActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<GameInfoCloseActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<HideInterfaceActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<HardwareCursorActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<FullscreenActionExecutor>());

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -3911,7 +3911,7 @@ bool UnsyncedGameCommands::ActionReleased(const Action& action)
 			return true;
 	}
 
-	return false; // prior implementation always returned false - I don't know why, but we'll maintain behaviour until we have reason to change it.
+	return false;
 }
 
 

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -614,7 +614,7 @@ public:
 
 	bool ExecuteRelease(const UnsyncedAction& action) const final {
 		inMapDrawer->SetDrawMode(false);
-		// TODO: false for backwards compatibility
+		// TODO: false for backwards compatibility (needs in depth review before changing)
 		return false;
 	}
 };
@@ -671,7 +671,7 @@ public:
 			return false;
 		}
 		mouse->MouseRelease(mouse->lastx, mouse->lasty, button);
-		// TODO: false for backwards compatibility
+		// TODO: false for backwards compatibility (needs in depth review)
 		return false;
 	}
 
@@ -685,12 +685,12 @@ public:
 	MouseStateActionExecutor() : IUnsyncedActionExecutor("MouseState", "Toggles mousestate") {}
 
 	bool Execute(const UnsyncedAction& action) const final {
-		// TODO: false for backwards compatibility
+		// TODO: false for backwards compatibility (needs in depth review)
 		return false;
 	}
 	bool ExecuteRelease(const UnsyncedAction& action) const final {
 		mouse->ToggleMiddleClickScroll();
-		// TODO: false for backwards compatibility
+		// TODO: false for backwards compatibility (needs in depth review)
 		return false;
 	}
 };
@@ -758,8 +758,8 @@ public:
 
 	bool ExecuteRelease(const UnsyncedAction& action) const final {
 		camera->SetMovState(moveStateIdx, false);
-		// TODO: maybe should return false for backwards compatibility
-		return halt;
+		// TODO: false for backwards compatibility (needs in depth review)
+		return false;
 	}
 
 private:
@@ -1831,13 +1831,14 @@ public:
 	GameInfoCloseActionExecutor() : IUnsyncedActionExecutor("GameInfoClose", "Closes game info") {}
 
 	bool Execute(const UnsyncedAction& action) const final {
-		// TODO: false for backwards compatibility
+		// TODO: false for backwards compatibility (may or may not make sense to keep it, probably not)
 		return false;
 	}
 
 	bool ExecuteRelease(const UnsyncedAction& action) const final {
 		if (CGameInfo::IsActive()) {
 			// TODO: handled in release, and return false for backwards compatibility
+			// (needs in depth review)
 			CGameInfo::Disable();
 			return false;
 		}

--- a/rts/Game/UnsyncedGameCommands.h
+++ b/rts/Game/UnsyncedGameCommands.h
@@ -20,6 +20,9 @@ public:
 	static void DestroyInstance(bool reload);
 
 	void AddDefaultActionExecutors() override;
+
+	bool ActionPressed(const Action& action, bool isRepeat);
+	bool ActionReleased(const Action& action);
 };
 
 #define unsyncedGameCommands UnsyncedGameCommands::GetInstance()


### PR DESCRIPTION
### Work done

- Cherry pick more @MasterBel2's commits (with small tweaks, see below).
- Gives Actions the capability to process ActionRelease.
- Refactors UnsyncedGameActions::ActionRelease and put it's code into the appropriate actions.

### Remarks

Note, while this adds some engine capabilities, it can be considered pure refactor and not affect engine behaviour at all. It just adds the way to forward ActionReleased to UnsyncedGameActions so they can be more self contained (before this pr, ActionReleased was just a big method doing ad-hoc out-of-action code).

#### First commit

Adapted from @MasterBel2's: [Move ActionPressed and ActionReleased from CGame to `UnsyncedGa…](https://github.com/beyond-all-reason/spring/pull/893/commits/17f84a5cdb406aa04bc13814f49d8e5a1fc71e7d)

Here, differing a bit from MasterBel's, instead of completely moving ActionPressed and ActionReleased from Game.cpp to UnsyncedGameActions, I'm keeping both methods at Game.cpp, and moving small parts to UnsyncedGameActions, that way we remove some code from Game.cpp, while giving UnsyncedGameActions both methods to then apply the next patch. This removes the weird CGame::ActionReleased in UnsyncedGameActions.cpp.

I didn't move everything, since, I'm not convinced about moving everything to UnsyncedGameActions, since ActionPressed is calling some other components, like clientNet and gameCommandConsole. Those are more visible in Game.cpp, where ActionReceived still lives, doing other Action work. Moving full ActionPress/Release would mean dividing Action handling between Game.cpp and UnsyncedGameCommands.cpp.

The remains are small, and can still be moved later on, if we see the need. So, this later may be refactored, once my other Mouse Input work progresses (where Game.cpp also being refactored into a separate InputReceiver).

#### Second commit

Verbatim cherry-pick from @MasterBel2's: [Move ActionReleased handling to individual actions](https://github.com/beyond-all-reason/spring/pull/893/commits/0ace3599b7131fe559f7362b859f128e0b73ac47)

This patch is fully applied, and is the one doing the real work here. It's refactoring a lot of custom code at ActionReleased into specific actions. It also gives actions the capability to process ActionRelease events, and that's already used to get much cleaner code.

This patch is the real win here.

Will also likely help alot later on, when refactoring other engine behaviours into actions.