### PR TITLE
Consolidate string+int sized font keys into SizedFontKey pair.

### DIFF
--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -74,16 +74,18 @@
 typedef unsigned char FT_Byte;
 #endif
 
-static spring::unordered_map<std::string, std::weak_ptr<FontFace>> fontFaceCache;
+typedef std::pair<std::string, int> SizedFontKey;
+
+static spring::unordered_map<SizedFontKey, std::weak_ptr<FontFace>> fontFaceCache;
 static spring::unordered_map<std::string, std::weak_ptr<FontFileBytes>> fontMemCache;
-static spring::unordered_set<std::pair<std::string, int>, spring::synced_hash<std::pair<std::string, int>>> invalidFonts;
+static spring::unordered_set<SizedFontKey> invalidFonts;
 static auto cacheMutexes = spring::WrappedSyncRecursiveMutex{};
 
 struct TimestampedFont { std::shared_ptr<FontFace> fontFace; float timestamp; };
 
 /* pinnedRecentFonts maintains shared_ptrs to the weak_ptrs from fontFaceCache. This prevents the weak_ptr from expiring
  * when no other part of the code holds a shared_ptr, as is the case when searching game and system fallback fonts. */
-static spring::unordered_map<std::pair<std::string, int>, TimestampedFont> pinnedRecentFonts;
+static spring::unordered_map<SizedFontKey, TimestampedFont> pinnedRecentFonts;
 
 #include "NonPrintableSymbols.inl"
 
@@ -420,7 +422,7 @@ static std::shared_ptr<FontFace> GetRenderFontFace(const std::string& fontfile, 
 
 	FT_Error error;
 
-	const auto fontKey = fontfile + IntToString(size);
+	const auto fontKey = make_pair(fontfile, size);
 	const auto fontIt = fontFaceCache.find(fontKey);
 
 	if (fontIt != fontFaceCache.end() && !fontIt->second.expired())
@@ -891,7 +893,7 @@ void CFontTexture::PinFont(std::shared_ptr<FontFace>& face, const std::string& f
 		cached->second.timestamp = time;
 	} else {
 		if (pinnedRecentFonts.size() >= maxPinnedFonts) {
-			std::pair<string, int>* oldest;
+			SizedFontKey* oldest;
 			float oldestTime = time;
 			for(auto &[key, timestampedFont]: pinnedRecentFonts) {
 				if (timestampedFont.timestamp <= oldestTime) {


### PR DESCRIPTION
### Work done

- Consolidate string+int sized font keys into `SizedFontKey` pair.
- Also redundant template parameter to invalidFonts set.

### Related issues

- https://github.com/beyond-all-reason/spring/issues/2066

### Remarks

- Small refactor
- The same "struct" was being used in different places, sometimes as `string+int`, sometimes as `string+string(int)`.
