### PR TITLE
Helpers to show 'deprecated' messages.

### DIFF
--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -1017,11 +1017,7 @@ void CGuiHandler::SetShowingMetal(const SCommandDescription* cmdDesc)
 		return;
 	}
 
-	static bool deprecatedMsgDone = false;
-	if (!deprecatedMsgDone) {
-		LOG_L(L_DEPRECATED, "AutoShowMetal is deprecated. Please enable manually from lua instead (see https://github.com/beyond-all-reason/spring/issues/1092).");
-		deprecatedMsgDone = true;
-	}
+	LOG_DEPRECATED("AutoShowMetal is deprecated. Please enable manually from lua instead (see https://github.com/beyond-all-reason/spring/issues/1092).");
 
 	bool show = false;
 	if (cmdDesc == nullptr)

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -6270,11 +6270,7 @@ int LuaSyncedRead::GetUnitCommands(lua_State* L)
 		// *get wants the actual commands
 		PackCommandQueue(L, *queue, numCmds);
 	} else {
-		static bool deprecatedMsgDone = false;
-		if (!deprecatedMsgDone) {
-			LOG_L(L_DEPRECATED, "Getting the command count using GetUnitCommands/GetCommandQueue is deprecated. Please use Spring.GetUnitCommandCount instead.");
-			deprecatedMsgDone = true;
-		}
+		LOG_DEPRECATED("Getting the command count using GetUnitCommands/GetCommandQueue is deprecated. Please use Spring.GetUnitCommandCount instead.");
 		// *get just wants the queue's size
 		lua_pushnumber(L, queue->size());
 	}

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2429,11 +2429,7 @@ int LuaUnsyncedCtrl::FreeUnitIcon(lua_State* L)
  */
 int LuaUnsyncedCtrl::UnitIconSetDraw(lua_State* L)
 {
-	static bool deprecatedMsgDone = false;
-	if (!deprecatedMsgDone) {
-		LOG_L(L_DEPRECATED, "Spring.UnitIconSetDraw is deprecated. Please use Spring.SetUnitIconDraw instead.");
-		deprecatedMsgDone = true;
-	}
+	LOG_DEPRECATED("Spring.UnitIconSetDraw is deprecated. Please use Spring.SetUnitIconDraw instead.");
 	return LuaUnsyncedCtrl::SetUnitIconDraw(L);
 }
 

--- a/rts/System/Log/ILog.h
+++ b/rts/System/Log/ILog.h
@@ -392,6 +392,27 @@ extern void log_frontend_cleanup();
 #define LOG_CLEANUP() \
 	_LOG_CLEANUP()
 
+/**
+ * Helper methods to deprecate functions.
+ */
+#define LOG_DEPRECATED(fmt, ...) \
+	{ \
+		static bool deprecatedMsgDone = false; \
+		if (!deprecatedMsgDone) { \
+			LOG_L(L_DEPRECATED, fmt, ##__VA_ARGS__); \
+			deprecatedMsgDone = true; \
+		} \
+	}
+
+#define LOG_DEPRECATED_S(section, fmt, ...) \
+	{ \
+		static bool deprecatedMsgDone = false; \
+		if (!deprecatedMsgDone) { \
+			LOG_L(section, L_DEPRECATED, fmt, ##__VA_ARGS__); \
+			deprecatedMsgDone = true; \
+		} \
+	}
+
 ///@}
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Work done

- Introduce helper macros to deprecate parts of the code: `LOG_DEPRECATED` and `LOG_DEPRECATED_S`.
- Adapts parts of the code already using this pattern.

### Remarks

- These ensure the deprecated message is shown only the first time the function runs.
- Couldn't see how to make these with modern c++, since we need the static to remember state, and it would be shared among users if not a macro, please let me know if you can think of a better way to do this.
- Allows us to stop replicating the same pattern everywhere and just use the helper.

### Example

```cpp
LOG_DEPRECATED("Getting the command count using GetUnitCommands/GetCommandQueue is deprecated. Please use Spring.GetUnitCommandCount instead.");
```