### PR TITLE
Fix fontconfig use after free on game start

### DIFF
--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -523,6 +523,10 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 
 				FcPatternGetString( origPattern, FC_FAMILY , 0, &family );
 			}
+
+			if (family != nullptr)
+				FcPatternAddString(pattern, FC_FAMILY, family);
+
 		}
 
 		FcPatternAddInteger(pattern, FC_WEIGHT, weight);
@@ -531,9 +535,6 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 
 		if (pixelSize > 0.0)
 			FcPatternAddDouble(pattern, FC_PIXEL_SIZE, pixelSize);
-
-		if (family)
-			FcPatternAddString(pattern, FC_FAMILY, family);
 	}
 
 	FcDefaultSubstitute(pattern);


### PR DESCRIPTION
### Work done

- Fix by using the fontconfig font family before origPattern expires and wipes data.

### Related issues

- Fixes: https://github.com/beyond-all-reason/spring/issues/2203