### PR TITLE
Change default big font outline width to 2.

### DIFF
--- a/rts/Rendering/Fonts/glFont.cpp
+++ b/rts/Rendering/Fonts/glFont.cpp
@@ -26,7 +26,7 @@ CONFIG(std::string, SmallFontFile).defaultValue("fonts/FreeSansBold.otf").descri
 
 CONFIG(int,      FontSize).defaultValue(23).description("Sets the font size (in pixels) of the MainMenu and more.");
 CONFIG(int, SmallFontSize).defaultValue(14).description("Sets the font size (in pixels) of the engine GUIs and more.");
-CONFIG(int,      FontOutlineWidth).defaultValue(3).description("Sets the width of the black outline around Spring engine text, such as the title screen version number, clock, and basic UI. Does not affect LuaUI elements.");
+CONFIG(int,      FontOutlineWidth).defaultValue(2).description("Sets the width of the black outline around Spring engine text, such as the title screen version number, clock, and basic UI. Does not affect LuaUI elements.");
 CONFIG(int, SmallFontOutlineWidth).defaultValue(2).description("see FontOutlineWidth");
 CONFIG(float,      FontOutlineWeight).defaultValue(25.0f).description("Sets the opacity of Spring engine text, such as the title screen version number, clock, and basic UI. Does not affect LuaUI elements.");
 CONFIG(float, SmallFontOutlineWeight).defaultValue(10.0f).description("see FontOutlineWeight");


### PR DESCRIPTION
### Work done

- Change default big font outline width to 2
  - Makes it render like pre 2025.03 releases.

### Related issues

- Fixes https://github.com/beyond-all-reason/spring/issues/2175

### Remarks

- Previous blur algo bug was making 3 here render like 2.
- Now it renders correctly, but 3 looks too thick, thus to make engine maintain (default) behaviour we should change this to 2.
- If possible this should go into 2025.03 release, since changing the width is affecting games, and a change in behaviour that's usually best to avoid.