### PR TITLE
Fixed simple typo

### DIFF
--- a/rts/ExternalAI/Interface/SSkirmishAICallback.h
+++ b/rts/ExternalAI/Interface/SSkirmishAICallback.h
@@ -1765,7 +1765,7 @@ struct SSkirmishAICallback {
 	 */
 	void              (CALLING_CONV *Map_findClosestBuildSite)(int skirmishAIId, int unitDefId, float* pos_posF3, float searchRadius, int minDist, int facing, float* return_posF3_out); //$ REF:unitDefId->UnitDef
 
-// BEGIN OBJECT Map
+// END OBJECT Map
 
 
 


### PR DESCRIPTION
In the current code, we have:
* [first map begin](https://github.com/beyond-all-reason/spring/blob/master/rts/ExternalAI/Interface/SSkirmishAICallback.h#L1502)
* [second(accidental) map begin and subsequent featuredef begin](https://github.com/beyond-all-reason/spring/blob/master/rts/ExternalAI/Interface/SSkirmishAICallback.h#L1768C1-L1772C27)
This is a simple one line PR that fixes this.