### PR TITLE
Revert broken rename of MakeWords

### DIFF
--- a/cont/LuaUI/actions.lua
+++ b/cont/LuaUI/actions.lua
@@ -185,7 +185,7 @@ end
 --  Calls
 --
 
-local function splitBySpace(line)
+local function MakeWords(line)
   local words = {}
   for w in string.gmatch(line, "[^%s]+") do
     table.insert(words, w)
@@ -223,7 +223,7 @@ function actionHandler:KeyAction(press, _, _, isRepeat, _, actions)
   for _, action in ipairs(actions) do
     local cmd = action["command"]
     local extra = action["extra"]
-    local args = splitBySpace(extra)
+    local args = MakeWords(extra)
     if (TryAction(actionSet, cmd, extra, args, isRepeat, not press, actions)) then
       return true
     end
@@ -234,7 +234,7 @@ end
 
 
 function actionHandler:TextAction(line)
-  local words = splitBySpace(line)
+  local words = MakeWords(line)
   local cmd = words[1]
   if (cmd == nil) then
     return false

--- a/cont/base/springcontent/LuaHandler/Utilities/actions.lua
+++ b/cont/base/springcontent/LuaHandler/Utilities/actions.lua
@@ -31,7 +31,7 @@ local keyReleaseActions = {}
 --------------------------------------------------------------------------------
 -- Helpers
 
-local function splitBySpace(line)
+local function MakeWords(line)
 	local words = {}
 	for w in line:gmatch("[^%s]+") do
 		table.insert(words, w)
@@ -212,7 +212,7 @@ local function KeyAction(press, _, _, isRepeat, _, actions)
 	for _, action in ipairs(actions) do
 		local cmd = action["command"]
 		local extra = action["extra"]
-		local args = splitBySpace(extra)
+		local args = MakeWords(extra)
 		if (TryAction(actionSet, cmd, extra, args, isRepeat, not press, actions)) then
 			return true
 		end


### PR DESCRIPTION
Something had to be done because it broke LuaHandler/Utilities/actions.TextAction, which contained a reference to MakeWords after the function was renamed. The rename broke naming consistency of functions in Lua (CamelCase), so I reverted the rename rather than fix the overlooked rename.

Fixes https://github.com/beyond-all-reason/RecoilEngine/issues/2392

Bug introduced in https://github.com/beyond-all-reason/RecoilEngine/commit/999bc9f9d6bc516fd19eadbe0b2b6b0f8c42639b