### PR TITLE
check-lua workflow: Always upload library artifact.

### DIFF
--- a/.github/workflows/check-lua.yml
+++ b/.github/workflows/check-lua.yml
@@ -50,6 +50,7 @@ jobs:
       
       - name: Upload Lua Library artifact
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: ${{github.run_id}}-library
           path: rts/Lua/library/


### PR DESCRIPTION
### Work done

- check-lua workflow: Always upload library artifact.


### Remarks

- Proposed by @rhys-vdw 
- This way when it fails now we can see what it was working with.
  - just for debugging