### PR TITLE
Ignore reclaimed when auto-repairing

### DIFF
--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -1643,7 +1643,7 @@ bool CBuilderCAI::FindRepairTargetAndRepair(
 		if (teamHandler.Ally(owner->allyteam, unit->allyteam)) {
 			if (!haveEnemy && (unit->health < unit->maxHealth)) {
 				// Don't auto pick for repair or build if within 900 frames of last reclaim
-				if (unit->AllowUnitAutoRepair())
+				if (!unit->AllowUnitAutoRepair())
 					continue;
 				
 				// don't help allies build unless set on roam

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -1974,8 +1974,10 @@ void CUnit::TurnIntoNanoframe()
 }
 
 bool CUnit::AllowUnitAutoRepair()
-{
-	if ((this->lastOwnerReclaim) >= (gs->frameNum + 900))
+const {
+	if (this->lastOwnerReclaim == 0) return true;
+	
+	if ((gs->frameNum) >= (this->lastOwnerReclaim + 900))
 	{
 		return true;
 	}
@@ -2003,7 +2005,7 @@ bool CUnit::AddBuildPower(CUnit* builder, float amount)
 
 	if (amount >= 0.0f) {
 		// Register attempt to build/repair by owner
-		if (builder->team)==(this->team)
+		if ((builder->team)==(this->team))
 			lastOwnerBuildRepair = gs->frameNum;
 		
 		// build or repair
@@ -2062,8 +2064,8 @@ bool CUnit::AddBuildPower(CUnit* builder, float amount)
 		}
 	} else {
 		// reclaim
-		if (builder->team)==(this->team)
-			lastOwnerBuildReclaim = gs->frameNum;
+		if ((builder->team)==(this->team))
+			lastOwnerReclaim = gs->frameNum;
 		if (!AllowedReclaim(builder)) {
 			builder->DependentDied(this);
 			return false;

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -107,7 +107,7 @@ public:
 	bool AddBuildPower(CUnit* builder, float amount);
 	
 	// FindRepairTarget/FindRepairTargetAndRepair functions will ignore units that return false here
-	bool AllowUnitAutoRepair();
+	bool AllowUnitAutoRepair() const;
 
 	virtual void Activate();
 	virtual void Deactivate();


### PR DESCRIPTION
Adds "AllowUnitAutoRepair()" function in Unit.cpp which returns true when said unit can be a target for autorepair via area commands or fight commands.
Adds LastOwnerReclaim and LastOwnerBuildRepair frames to keep track of the last nano action done by unit's owner
Use unit->AllowUnitAutoRepair() function to decide wether target can be picked from BuilderCAI FindRepairTargetAndRepair()

The result is a 30seconds timer within which the unit having been (partially) reclaimed by its owner cannot be auto repaired or built by any allied builder.
You can cancel that timer by manually repairing the building.

I believe as of now, this is ready for review.

To test this feature you can spawn some nanos and a lab:
1 ) Make sure nanos on their fight command do actually assist the lab when units are being built
2) Try using an area repair command while a unit is being built, make sure it properly assists
3) Now try reclaiming the lab, and use the stop cmd midway, nanos should not instantly start repairing.
4) Wait for 30 seconds, nanos should start repairing again
5) repeat the reclaiming process, stop midway, then give a manual repair command, then stop it midway aswell; nanos should resume repair upon receiving their fight command
6) Eventually make sure they still do assist the lab even though they stopped repairing it

As for the "owner" condition.
Repeat the process but this time use cheats after having set up your nanos on fight and lab; and reclaim with a spawned enemy nano. This should not deny autorepairing.
You can also repeat the same process with allied nanos.