### PR TITLE
Use ninja for Docker builds

### DIFF
--- a/docker-build/scripts/03_compile.sh
+++ b/docker-build/scripts/03_compile.sh
@@ -2,4 +2,4 @@ cd "${BUILD_DIR}"
 
 echo "CCACHE_DEBUG=${CCACHE_DEBUG}"
 
-make -j$(nproc) all
+ninja all


### PR DESCRIPTION
Going through the trouble of installing `ninja-build` package only to use `make` in the end is just sad.

I'm not using Docker locally, so I rely on CI to test this. I would be surprised if anything goes wrong with this one-line change.