### PR TITLE
Add 'system.nativeExcessSharing' modrule

### DIFF
--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -126,6 +126,7 @@ void CModInfo::ResetState()
 
 		SLuaAllocLimit::MAX_ALLOC_BYTES = SLuaAllocLimit::MAX_ALLOC_BYTES_DEFAULT;
 
+		nativeExcessSharing = true;
 		allowTake = true;
 
 		allowEnginePlayerlist = true;
@@ -186,6 +187,7 @@ void CModInfo::Init(const std::string& modFileName)
 		// Specify in megabytes: 1 << 20 = (1024 * 1024)
 		SLuaAllocLimit::MAX_ALLOC_BYTES = static_cast<decltype(SLuaAllocLimit::MAX_ALLOC_BYTES)>(system.GetInt("LuaAllocLimit", SLuaAllocLimit::MAX_ALLOC_BYTES >> 20u)) << 20u;
 
+		nativeExcessSharing = system.GetBool("nativeExcessSharing", nativeExcessSharing);
 		allowTake = system.GetBool("allowTake", allowTake);
 		allowEnginePlayerlist = system.GetBool("allowEnginePlayerlist", allowEnginePlayerlist);
 	}

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -230,6 +230,7 @@ public:
 
 	int quadFieldQuadSizeInElmos;
 
+	bool nativeExcessSharing;
 	bool allowTake;
 	bool allowEnginePlayerlist;
 


### PR DESCRIPTION
Controls whether "red slider" applies (I considered making it so that you can set the red slider to `nil` but that would be a much larger change that makes the interface confusing).

Note that red slider is actually how excess works (i.e. resources above 100% storage do not have any separate handling, they are entirely shared by virtue of being above the red slider too).

Anyway, this allows a Lua reimplementation.