### PR TITLE
Enable proper cylinder or ellipsoid based targetting volumes for LightningCannon as well

### DIFF
--- a/rts/Sim/Weapons/LightningCannon.h
+++ b/rts/Sim/Weapons/LightningCannon.h
@@ -12,6 +12,7 @@ public:
 	CLightningCannon(CUnit* owner = nullptr, const WeaponDef* def = nullptr);
 
 private:
+	bool TestRange(const float3& tgtPos, const SWeaponTarget& trg) const override final;
 	void FireImpl(const bool scriptCall) override final;
 	float GetPredictedImpactTime(float3 p) const override final { return 0.0f; }
 

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -111,6 +111,7 @@ protected:
 	void UpdateWeaponPieces(const bool updateAimFrom = true);
 	float3 GetLeadVec(const CUnit* unit) const;
 
+	float GetShapedWeaponRange(const float3& dir, float maxLength) const;
 private:
 	void UpdateAim();
 	void UpdateFire();
@@ -126,7 +127,6 @@ private:
 	void HoldIfTargetInvalid();
 
 	bool TryTarget(const float3 tgtPos, const SWeaponTarget& trg, bool preFire = false) const;
-
 public:
 	CUnit* owner;
 	CWeapon* slavedTo;                      // use this weapon to choose target


### PR DESCRIPTION
* A change similar to https://github.com/beyond-all-reason/RecoilEngine/commit/012ce5333cd70a7fb135b01f2ba3108617000b05 for "LightningCannon", addresses https://github.com/beyond-all-reason/RecoilEngine/issues/777#issuecomment-3184249277
* Some code DRYing