### PR TITLE
Make RmlSolLua build in C++23 mode

### DIFF
--- a/rts/Rml/SolLua/plugin/SolLuaDataModel.cpp
+++ b/rts/Rml/SolLua/plugin/SolLuaDataModel.cpp
@@ -36,6 +36,7 @@
 
 namespace Rml::SolLua
 {
+	SolLuaDataModel::SolLuaDataModel(sol::state_view s) : Lua{ s } {}
 
 	SolLuaObjectDef::SolLuaObjectDef(SolLuaDataModel* model)
 		: VariableDefinition(DataVariableType::Scalar), m_model(model)
@@ -77,7 +78,7 @@ namespace Rml::SolLua
 	int SolLuaObjectDef::Size(void* ptr)
 	{
 		auto object = static_cast<sol::object*>(ptr);
-		
+
 		// Non-table types have no children to iterate over.
 		if (object->get_type() != sol::type::table)
 			return 0;

--- a/rts/Rml/SolLua/plugin/SolLuaDataModel.h
+++ b/rts/Rml/SolLua/plugin/SolLuaDataModel.h
@@ -48,7 +48,7 @@ namespace Rml::SolLua
 
 	struct SolLuaDataModel
 	{
-		SolLuaDataModel(sol::state_view s) : Lua{ s } {}
+		SolLuaDataModel(sol::state_view s);
 
 		Rml::DataModelConstructor Constructor;
 		Rml::DataModelHandle Handle;


### PR DESCRIPTION
This is a backport of https://github.com/LoneBoco/RmlSolLua/commit/47a55d1244d54322e92c9dd3fcd89cc44a796b45 to our in-tree version, and the last step to enable C++23 build.

Initially I intended to fix things upstream and then update our in-tree version from there, but when I got to that second step, I was faced with over 60 compiler errors, and after fixing couple of them I realized that we have a non-trivial amount of changes in our in-tree version. So I'm backing off, instead backporting just the changes needed to enable C++23 build. 