### PR TITLE
doc(LuaHandle): Improve GameSetup doc

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -3810,7 +3810,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
  * @param ready boolean whether the player is currently ready or not
  * @param playerStates table<number,READY_STATE> indexed by playerID
  * @return boolean? gameHandled disables the engine ui when true
- * @return boolean? newReady whether the player is ready (ignored unless gameHandled is provided)
+ * @return boolean? newReady whether the player is ready (ignored unless `gameHandled = true`)
  */
 bool CLuaHandle::GameSetup(const string& state, bool& ready,
                            const std::vector< std::pair<int, std::string> >& playerStates)


### PR DESCRIPTION
Note the return api could be improved there, this is current:

```
_gameHandled = true, _ready = true   -> lua takes over, sets user to ready
_gameHandled = true, _ready = false  -> lua takes over, sets user to not ready
_gameHandled = false, _ready = true  -> lua does not take over, ignores _ready
_gameHandled = false, _ready = false -> lua does not take over, ignores _ready
```

This would be simpler (except for some possible confusion with nil being falsy):

```
_ready = true | false -> lua takes over, sets user to _ready
_ready = any() | nil -> engine takes over
```

The problem with the API above is that there could be unintended consequences of distinguishing between nil and false. Code in lua often does not care about returning actual booleans, with nil being a completely acceptable falsy return. Example:

```lua
local ready = isUserReady() -- In theory should return a boolean, but nil is used as falsy
return ready -- returning nil makes the engine takeover, while game wanted to set ready to false
```