### PR TITLE
change demofile name generation to not strip part of map version

### DIFF
--- a/doc/StartScriptFormat.txt
+++ b/doc/StartScriptFormat.txt
@@ -25,7 +25,7 @@
 // note that the same values for clients also need to be set here
 [GAME]
 {
-	MapName=;           // with .smf extension
+	MapName=;           // without any extension
 	GameType=Balanced Annihilation V6.81; // either primary mod NAME, rapid tag name or archive name
 	GameStartDelay=4;   // optional, in seconds (unsigned int), default: 4
 	                    // The number of seconds till the game starts,

--- a/rts/System/LoadSave/DemoRecorder.cpp
+++ b/rts/System/LoadSave/DemoRecorder.cpp
@@ -153,8 +153,6 @@ void CDemoRecorder::SetName(const std::string& mapName, const std::string& modNa
 	std::ostringstream buf;
 
 	oss << demoDir << curTime << "_";
-	// mapName has not been passed with an extension since commit 28c3b5e, 
-	// which changes map loading to use an archive scanner
 	oss << mapName;
 	oss << "_";
 	// FIXME: why is this not included?


### PR DESCRIPTION
this PR changes the demofile name generation to only strip file extensions if the file extension is `.sd7`

when setting the name of a demofile, `FileSystem::GetBasename` is called to strip the file extension from `mapName`. when a `mapName` is passed without a file extension, this will strip the text after the last period

for example `All That Glitters v2.2` gets truncated to `All That Glitters v2`

this doesn't do anything bad, as the name of a demofile is already arbitrary, but i assume the intention is to keep the full map name