### PR TITLE
QTPFS: improve path results when destination is trapped

### DIFF
--- a/rts/Sim/Path/QTPFS/NodeLayer.h
+++ b/rts/Sim/Path/QTPFS/NodeLayer.h
@@ -155,6 +155,10 @@ namespace QTPFS {
 			return numRootNodes;
 		}
 
+		int GetNodeCount() const {
+			return POOL_TOTAL_SIZE - nodeIndcs.size();
+		}
+
 		int GetNodelayer() const {
 			return layerNumber;
 		}

--- a/rts/Sim/Path/QTPFS/PathSearch.h
+++ b/rts/Sim/Path/QTPFS/PathSearch.h
@@ -183,7 +183,7 @@ namespace QTPFS {
 		bool ExecutePathSearch();
 		bool ExecuteRawSearch();
 
-		void SetForwardSearchLimit();
+		void SetNodeSearchLimit();
 
 		void GetRectangleCollisionVolume(const SearchNode& snode, CollisionVolume& v, float3& rm) const;
 
@@ -238,7 +238,7 @@ namespace QTPFS {
 		int fwdStepIndex = 0;
 		int bwdStepIndex = 0;
 
-		int fwdNodeSearchLimit = 0;
+		int nodeSearchLimit = 0;
 
 		size_t fwdNodesSearched = 0;
 		size_t bwdNodesSearched = 0;


### PR DESCRIPTION
Reworked QTPFS node search limit calculation to follow more reasonable logic and to search further on the shorter paths.

Helps reduce the situation where engineer-type types, which often provide bad-goals to the pathfinder (reclaim trees, the tree itself is the goal but also a block region), getting a cheap and unhelpful path. If the reverse path is trapped because it unfortunately chose the wrong side of an obstacle to set the path goal.

Example VOD from @6AKU66: https://www.youtube.com/watch?v=i2dDdkYsTv8

An alternative approach to [PR-2145.](https://github.com/beyond-all-reason/RecoilEngine/pull/2145) - the other PR could still be considered if there proves to be any issues with this change.

This approach is preferred due to the reduced complexity and cleans up the original algorithm.