### PR TITLE
Alternative fix to allow legacy aircraft crashing behaviour.

### DIFF
--- a/rts/Sim/MoveTypes/HoverAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.cpp
@@ -964,7 +964,8 @@ bool CHoverAirMoveType::Update()
 			UpdateHovering();
 			break;
 		case AIRCRAFT_CRASHING: {
-			if (UpdateAirPhysics()) {
+			if (UpdateAirPhysics()
+					|| (CGround::GetHeightAboveWater(owner->pos.x, owner->pos.z) + 5.0f + owner->radius) > owner->pos.y){
 				owner->ForcedKillUnit(nullptr, true, false, -CSolidObject::DAMAGE_AIRCRAFT_CRASHED);
 			} else {
 				#define SPIN_DIR(o) ((o->id & 1) * 2 - 1)

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -520,8 +520,10 @@ bool CStrafeAirMoveType::Update()
 			break;
 		case AIRCRAFT_CRASHING: {
 			// NOTE: the crashing-state can only be set (and unset) by scripts
-			if (UpdateAirPhysics({crashRudder, crashElevator, crashAileron, 0.0f}, owner->frontdir))
+			if (UpdateAirPhysics({crashRudder, crashElevator, crashAileron, 0.0f}, owner->frontdir)
+					|| (CGround::GetHeightAboveWater(owner->pos.x, owner->pos.z) + 5.0f + owner->radius) > owner->pos.y){
 				owner->ForcedKillUnit(nullptr, true, false, -CSolidObject::DAMAGE_AIRCRAFT_CRASHED);
+			}
 
 			amtEmitCrashTrailFuncs[crashExpGenID != -1u](owner, crashExpGenID);
 		} break;


### PR DESCRIPTION
Fixes aircraft getting stuck during non-crashing movement caused by: https://github.com/beyond-all-reason/RecoilEngine/commit/f8a921af59666413a849ff0e894e506d4c4eddbf

This fix reinstates so older code that will only execute with the first crash impact check fails to detect a crash. This means the intended fix to prevent aircraft bounce is is kept, but also remains compatible with units that were designed to work with the original checks (and as such don't crash when they should on the new check.) This way both checks are in place. It also only affects crashing aircraft, unlike the above mentioned commit which incorrectly impacts the behaviour of aircraft in other movement modes.
