### PR TITLE
Fix crash on Save — fix serialization crash by commenting out animParams

### DIFF
--- a/rts/Sim/Projectiles/ExpGenSpawnable.cpp
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.cpp
@@ -35,7 +35,8 @@ CR_REG_METADATA(CExpGenSpawnable, (
 	CR_MEMBER(animProgress4),
 	CR_MEMBER_BEGINFLAG(CM_Config),
 		CR_MEMBER(rotParams),
-		CR_FAKE(animParams, float3),
+		// CR_FAKE(animParams, float3), // Caused a serialization crash (creg::FakeType::GetName) // this is 90% vibe coded
+		// I had an annoying crash on save — and went hey AI tech me how to use gdb ... and in the end it sugested this chage.
 		CR_MEMBER(animParams1),
 		CR_MEMBER(animParams2),
 		CR_MEMBER(animParams3),


### PR DESCRIPTION
Comment out CR_FAKE for animParams to prevent serialization crash.

I did a quick test and saving works again, no idea if it broke something else!

<br>

This is the first time I traced a crash with `gdb` and lots of AI, back to some actual code.

Somebody pretty please check that this is sane and won't break something else!
(I've got no idea what I'm doing and am honestly amazed this worked)

fixes #2654 