### PR TITLE
change README to use http instead of SSH for upstream

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,7 +39,7 @@ spring_bar_{BAR105}105.1.1-1050-g5075cc0
 If you aren't seeeing these (often, when you've cloned your fork of the repository and not the upstream version), try the following:
 
 ```bash
-git remote add upstream git@github.com:beyond-all-reason/RecoilEngine.git
+git remote add upstream https://github.com/beyond-all-reason/RecoilEngine
 git fetch --all --tags
 ```
 


### PR DESCRIPTION
SSH can cause permission issues, http doesn't have this issue

https://discord.com/channels/549281623154229250/724924957074915358/1445853207220846633