### PR TITLE
QTPFS path fixes

### DIFF
--- a/rts/Sim/Path/QTPFS/PathSearch.cpp
+++ b/rts/Sim/Path/QTPFS/PathSearch.cpp
@@ -930,15 +930,22 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 					// If we trace back to the bwd source node, then we have a full path already.
 					// No need to worry about goal distance.
 					if (lastNode != bwd.srcSearchNode) {
+						// helper function
+						static const auto SqDistance2D = [](const float3& p0, const float2& p1) -> float {
+							const float dx = p0.x - p1.x;
+							const float dz = p0.z - p1.y;
+							return (dx * dx + dz * dz);
+						};
+
 						// Find the nearest point on that node to the goal.
 						const auto* curNode = nodeLayer->GetPoolNode(lastNode->GetIndex());
 						const INode::NeighbourPoints& nearestPoint =
 							*std::ranges::min_element(curNode->GetNeighbours(), {}, [&](const INode::NeighbourPoints& np){
-									return fwd.tgtPoint.SqDistance2D(np.netpoints[0]);
+									return SqDistance2D(fwd.tgtPoint, np.netpoints[0]);
 								});
 
 						// Configure the search result params if the path ends within the goal distance.
-						const float distToGoalSq = fwd.tgtPoint.SqDistance2D(nearestPoint.netpoints[0]);
+						const float distToGoalSq = SqDistance2D(fwd.tgtPoint, nearestPoint.netpoints[0]);
 						if ( distToGoalSq <= goalDistance*goalDistance ){
 							useFwdPathOnly = true;
 							expectIncompletePartialSearch = true;

--- a/rts/System/float3.h
+++ b/rts/System/float3.h
@@ -518,7 +518,7 @@ public:
 	/**
 	 * @brief distance2D between float3 and float2 (only x and z)
 	 * @param f float2 to compare against
-	 * @return 2D distance between a float3 and a float2
+	 * @return 2D distance between float3s
 	 *
 	 * Calculates the distance between this float3
 	 * and another float2 2-dimensionally (that is,
@@ -560,23 +560,6 @@ public:
 		return (dx*dx + dz*dz);
 	}
 
-
-	/**
-	 * @brief distance2D between float3 and float2 (only x and z)
-	 * @param f float2 to compare against
-	 * @return 2D squared distance between a float3 and a float2
-	 *
-	 * Calculates the distance between this float3
-	 * and another float2 2-dimensionally (that is,
-	 * only using the x and z components).  Sums the
-	 * differences in the x and z components, square
-	 * root for pythagorean theorem
-	 */
-	float SqDistance2D(const float2& f) const {
-		const float dx = x - f.x;
-		const float dz = z - f.y;
-		return (dx*dx + dz*dz);
-	}
 
 	/**
 	 * @brief Length of this vector


### PR DESCRIPTION
Fixes https://github.com/beyond-all-reason/RecoilEngine/issues/2660

1.Fixed an issue where the reverse search was incorrectly dropping nodes within goal proximity of the start point.
2. Partial path searches will now check whether a joined forward path will finish within the goal radius, which means it can then discard any further reverse searching.