### PR TITLE
Actually erase all .done animation in CUnitScript::TickAllAnims() and not only just one occasion

### DIFF
--- a/rts/Sim/Units/Scripts/UnitScript.cpp
+++ b/rts/Sim/Units/Scripts/UnitScript.cpp
@@ -215,7 +215,7 @@ void CUnitScript::TickAllAnims(int deltaTime)
 				doneAnims.emplace_back(ai);
 		}
 	}
-	spring::VectorEraseIf(anims, [](const auto& ai) { return ai.done; });
+	spring::VectorEraseIfAll(anims, [](const auto& ai) { return ai.done; });
 
 #if 1
 	// BFS pass

--- a/rts/Sim/Units/Scripts/UnitScript.h
+++ b/rts/Sim/Units/Scripts/UnitScript.h
@@ -36,14 +36,14 @@ protected:
 
 	struct AnimInfo {
 		CR_DECLARE_STRUCT(AnimInfo)
-		AnimType animType;
-		int axis;
-		int piece;
-		float speed;
-		float dest;     // means final position when turning or moving, final speed when spinning
-		float accel;    // used for spinning, can be negative
-		bool done;
-		bool hasWaiting;
+		AnimType animType = ANone;
+		int axis  = -1;
+		int piece = -1;
+		float speed = 0.0f;
+		float dest  = 0.0f;    // means final position when turning or moving, final speed when spinning
+		float accel = 0.0f;    // used for spinning, can be negative
+		bool done = false;
+		bool hasWaiting = false;
 	};
 
 	using AnimContainerType = std::vector<AnimInfo>;

--- a/rts/System/ContainerUtil.h
+++ b/rts/System/ContainerUtil.h
@@ -23,9 +23,9 @@ namespace spring {
 	}
 
 	template<typename T, typename UnaryPredicate>
-	static bool VectorEraseIf(std::vector<T>& v, UnaryPredicate p)
+	static bool VectorEraseIf(std::vector<T>& v, UnaryPredicate&& p)
 	{
-		auto it = std::find_if(v.begin(), v.end(), p);
+		auto it = std::find_if(v.begin(), v.end(), std::forward<UnaryPredicate>(p));
 
 		if (it == v.end())
 			return false;
@@ -46,6 +46,50 @@ namespace spring {
 		*it = std::move(v.back());
 		v.pop_back();
 		return true;
+	}
+
+	template<typename T, typename UnaryPredicate>
+	static bool VectorEraseIfAll(std::vector<T>& v, UnaryPredicate&& p)
+	{
+		size_t removed = 0;
+		auto it = v.begin();
+
+		while (it != v.end()) {
+			if (p(*it)) {
+				*it = std::move(v.back());
+				v.pop_back();
+				removed++;
+
+				if (it == v.end())
+					break;
+			} else {
+				++it;
+			}
+		}
+
+		return removed > 0;
+	}
+
+	template<typename T>
+	static bool VectorEraseAll(std::vector<T>& v, const T& e)
+	{
+		size_t removed = 0;
+		auto it = v.begin();
+
+		while (it != v.end()) {
+			if (*it == e) {
+				*it = std::move(v.back());
+				v.pop_back();
+				removed++;
+
+				if (it == v.end())
+					break;
+			} else {
+				++it;
+			}
+		}
+
+		return removed > 0;
 	}
 
 	template<typename T, typename C>


### PR DESCRIPTION
+ some extra rigor in the `AnimInfo` initialization (unneeded really due to the value/zero initialization in anims.emplace_back)

Fixes https://github.com/beyond-all-reason/RecoilEngine/issues/2658