### PR TITLE
Block `/aicontrol` by default

### DIFF
--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -192,7 +192,7 @@ void CGameServer::Initialize()
 		netPingTimings.fill(spring_notime);
 		mapDrawTimings.fill({spring_notime, 0});
 		chatMutedFlags.fill({false, false});
-		aiControlFlags.fill(false);
+		aiControlFlags.fill(true);
 
 		const std::vector<PlayerBase>& playerStartData = myGameSetup->GetPlayerStartingDataCont();
 		const std::vector<TeamBase>&     teamStartData = myGameSetup->GetTeamStartingDataCont();


### PR DESCRIPTION
This flag controls whether given player can call `/aicontrol` to spawn a skirmish AI at runtime (false = allowed, true = blocked). The current default is that everybody can do this and the host has to block; after this PR they will have to receive permission from the host first.

Caveats:
* the interface for giving or removing permission is to call `/aiCtrl Sprung` or `/aiCtrlByNum 123` and it can only flip the bool (no way to "set 1" or "set 0"). This means that any existing users of those flags would be broken. Fortunately there don't seem to be any (no github hits for [aictrl](https://github.com/search?q=aictrl+-is%3Afork&type=code) or [aictrlbynum](https://github.com/search?q=aictrlbynum+-is%3Afork&type=code) outside engine itself). In theory it would be good to add the option but I want to keep this PR's scope small and I don't anticipate anybody being very eager to actually use those to enable.
* it's a bit harsh, what about singleplayer or `/cheat`? The implementation actually foresaw those: https://github.com/beyond-all-reason/RecoilEngine/blob/75bca20cf4ff962407a88e62bdcc36deba103f8d/rts/Net/GameServer.cpp#L1667
but still decided that the flag should take priority. I think the proper long-term way would be to let a game (synced LuaRules) decide to add AI slots, a'la #363, but at the moment I'm not unhappy about those rules. Devs and singleplayers who knew about the `/aicontrol` command (seems to be barely anybody) can still just call `/aictrl` in front of `/aicontrol`.