### PR TITLE
Run engine CI after building new docker images

### DIFF
--- a/.github/workflows/docker-images-build.yml
+++ b/.github/workflows/docker-images-build.yml
@@ -58,27 +58,49 @@ jobs:
         with:
           name: image-digest-${{ matrix.system }}
           path: ${{ matrix.system }}.txt
-  publish:
-    name: Update digest branch
-    needs: build-images
-    if: github.event_name == 'workflow_dispatch' && inputs.update-digests == true || github.event_name == 'push'
+  gather-digests:
+    name: Gather digests
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    needs: build-images
+    outputs:
+      images_versions: ${{ steps.merge.outputs.images_versions }}
     steps:
-      - uses: actions/checkout@v6
       - name: Fetch digests
         uses: actions/download-artifact@v7
         with:
           path: .digests
           pattern: image-digest-*
           merge-multiple: true
-      - name: Update digests
+      - name: Merge digests
+        id: merge
         run: |
-          for digest in $(ls .digests); do
-            sed -i -r "s/(image_version\[${digest%.*}\]=)(.*)/\1$(cat .digests/$digest)/" docker-build-v2/images_versions.sh
+          echo "images_versions=$(
+            for digest in $(ls .digests); do
+              echo "${digest%.*}=$(cat .digests/$digest)"
+            done | jq -Rnc '[inputs] | map(. | split("=") | {key: .[0], value: .[1]}) | from_entries'
+          )" >> "$GITHUB_OUTPUT"
+  test-build:
+    needs: gather-digests
+    uses: ./.github/workflows/engine-build.yml
+    with:
+      image-versions: ${{ needs.gather-digests.outputs.images_versions }}
+    secrets: inherit
+  publish:
+    name: Update digest branch
+    needs: [test-build, gather-digests]
+    if: github.event_name == 'workflow_dispatch' && inputs.update-digests == true || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Update digests
+        env:
+          images_versions: ${{ needs.gather-digests.outputs.images_versions }}
+        run: |
+          echo "$images_versions" | jq -r 'to_entries[] | "\(.key) \(.value)"' | while read -r platform digest; do
+            sed -i -r "s/(image_version\[$platform\]=)(.*)/\1$digest/" docker-build-v2/images_versions.sh
           done
-          rm -r .digests
       - name: Commit and push
         uses: stefanzweifel/git-auto-commit-action@v7
         with:

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -42,6 +42,10 @@ on:
       package-suffix:
         description: 'Custom suffix for the package name'
         type: string
+      image-versions:
+        description: 'Allows override image-versions for this run'
+        type: string
+        default: '{}'
   pull_request:
     paths-ignore:
       - 'doc/**'
@@ -143,12 +147,13 @@ jobs:
             http-get://127.0.0.1:8085/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
           wait-for: 3m
       - name: Pull builder image
+        id: resolve-image
         # Fetching image from GitHub can be *incredibly* slow, so cache layers also in the
         # namespace.so container registry.
         run: |
           source src/docker-build-v2/images_versions.sh
 
-          digest=${image_version[${{ matrix.system }}]}
+          digest=${{ fromJson(inputs.image-versions || '{}')[matrix.system] || format('${{image_version[{0}]}}', matrix.system) }}
           ghcr_image=ghcr.io/${{ github.repository_owner }}/recoil-build-${{ matrix.system }}
           nsc_image=${{ env.NSC_CONTAINER_REGISTRY }}/recoil-build-${{ matrix.system }}
 
@@ -157,6 +162,8 @@ jobs:
           docker pull $ghcr_image@$digest
           docker image tag $ghcr_image@$digest $nsc_image
           docker push $nsc_image
+
+          echo "image=$ghcr_image@$digest" >> "$GITHUB_OUTPUT"
       - name: Build
         # Instead of manually running docker, it would be cool to just run whole GitHub actions
         # in container, but unfortunately ubuntu 18.04 is just too old to be able to do it ;(.
@@ -172,7 +179,7 @@ jobs:
             -v $(pwd)/artifacts:/build/artifacts:rw \
             -e CCACHE_${{ inputs.recache && 'RECACHE' || 'NORECACHE' }}=1 \
             --network host \
-            ghcr.io/${{ github.repository_owner }}/recoil-build-${{ matrix.system }}@${image_version[${{ matrix.system }}]} \
+            ${{ steps.resolve-image.outputs.image }} \
             bash <<EOF
           set -e
           cd /build/src/docker-build-v2/scripts


### PR DESCRIPTION
Ensures that the newly build docker images can correctly compile the engine before we commit the new image digests to master.

Tested: https://github.com/beyond-all-reason/RecoilEngine/actions/runs/20527885564