### PR TITLE
Minor `SResourcePack` cleanup

### DIFF
--- a/rts/Sim/Misc/Resource.h
+++ b/rts/Sim/Misc/Resource.h
@@ -14,11 +14,10 @@ struct SResourcePack {
 	union {
 		float res[MAX_RESOURCES];
 		struct { float metal, energy; };
-		struct { float res1, res2; };
 	};
 
 public:
-	SResourcePack() : res1(0.0f), res2(0.0f) {}
+	SResourcePack() : metal(0.0f), energy(0.0f) {}
 	SResourcePack(const float value) : metal(value), energy(value) {}
 	SResourcePack(const float m, const float e) : metal(m), energy(e) {}
 	CR_DECLARE_STRUCT(SResourcePack)

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -2295,7 +2295,7 @@ static bool LimitToFullStorage(const CUnit* u, const CTeam* team, SResourceOrder
 		GetScale(order->use[i], team->res[i], &scale);
 
 		if (u->harvestStorage.empty()) {
-			GetScale(order->add[i], team->resStorage.res[i] - team->res[i], &scale);
+			GetScale(order->add[i], team->resStorage[i] - team->res[i], &scale);
 		} else {
 			GetScale(order->add[i], u->harvestStorage[i] - u->harvested[i], &scale);
 		}


### PR DESCRIPTION
 * remove `.res1` and `.res2`. Operator[] exists for future arbitrary resources, and legacy code uses `.metal` and `.energy`.
 * make sure operator[] is actually used for indexed access. Ideally the underlying array would be made private, but this can't be done while keeping `metal` and `energy` public since they're an union.