### PR TITLE
added builderDefID and builderTeam to UnitCreated

### DIFF
--- a/cont/LuaUI/widgets.lua
+++ b/cont/LuaUI/widgets.lua
@@ -1802,9 +1802,9 @@ end
 --  Unit call-ins
 --
 
-function widgetHandler:UnitCreated(unitID, unitDefID, unitTeam, builderID)
+function widgetHandler:UnitCreated(unitID, unitDefID, unitTeam, builderID, builderDefID, builderTeam)
   for _,w in ipairs(self.UnitCreatedList) do
-    w:UnitCreated(unitID, unitDefID, unitTeam, builderID)
+    w:UnitCreated(unitID, unitDefID, unitTeam, builderID, builderDefID, builderTeam)
   end
   return
 end

--- a/cont/base/springcontent/LuaGadgets/gadgets.lua
+++ b/cont/base/springcontent/LuaGadgets/gadgets.lua
@@ -1379,9 +1379,9 @@ end
 --  Unit call-ins
 --
 
-function gadgetHandler:UnitCreated(unitID, unitDefID, unitTeam, builderID)
+function gadgetHandler:UnitCreated(unitID, unitDefID, unitTeam, builderID, builderDefID, builderTeam)
   for _,g in r_ipairs(self.UnitCreatedList) do
-    g:UnitCreated(unitID, unitDefID, unitTeam, builderID)
+    g:UnitCreated(unitID, unitDefID, unitTeam, builderID, builderDefID, builderTeam)
   end
 end
 

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -1063,12 +1063,14 @@ inline void CLuaHandle::UnitCallIn(const LuaHashString& hs, const CUnit* unit)
  * @param unitDefID integer
  * @param unitTeam integer
  * @param builderID integer?
+ * @param builderDefID integer?
+ * @param builderTeam integer?
  */
 void CLuaHandle::UnitCreated(const CUnit* unit, const CUnit* builder)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	LUA_CALL_IN_CHECK(L);
-	luaL_checkstack(L, 7, __func__);
+	luaL_checkstack(L, 9, __func__);
 
 	const LuaUtils::ScopedDebugTraceBack traceBack(L);
 
@@ -1079,11 +1081,14 @@ void CLuaHandle::UnitCreated(const CUnit* unit, const CUnit* builder)
 	lua_pushnumber(L, unit->id);
 	lua_pushnumber(L, unit->unitDef->id);
 	lua_pushnumber(L, unit->team);
-	if (builder != nullptr)
+	if (builder != nullptr) {
 		lua_pushnumber(L, builder->id);
+		lua_pushnumber(L, builder->unitDef->id);
+		lua_pushnumber(L, builder->team);
+	}
 
 	// call the routine
-	RunCallInTraceback(L, cmdStr, (builder != nullptr)? 4: 3, 0, traceBack.GetErrFuncIdx(), false);
+	RunCallInTraceback(L, cmdStr, (builder != nullptr)? 6: 3, 0, traceBack.GetErrFuncIdx(), false);
 }
 
 


### PR DESCRIPTION
Closes #1344

Decided to add builder->team as well since we pass for unit.
Let me know if you prefer not to so I can removed it.

Not sure if I should check for builder->unitDef != nullptr,
is there a case where builder is not null but builder->unitDef is?
