### PR TITLE
fixed 'CREG: Test3 (Missing Class Members)'

### DIFF
--- a/rts/Rendering/Env/Decals/GroundDecalHandler.cpp
+++ b/rts/Rendering/Env/Decals/GroundDecalHandler.cpp
@@ -91,6 +91,7 @@ CR_REG_METADATA(CGroundDecalHandlerData, (
 	CR_MEMBER_UN(smfDrawer),
 
 	CR_MEMBER_UN(highQuality),
+	CR_MEMBER_UN(ghostDimming),
 	CR_MEMBER_UN(sdbc),
 
 	CR_POSTLOAD(PostLoad)


### PR DESCRIPTION
Closes #2667 by adding missing `CR_MEMBER_UN(ghostDimming),` at `rts/Rendering/Env/Decals/GroundDecalHandler.cpp`.

Failing unit tests log:
```
[t=00:00:00.001208] CREG: Test3 (Missing Class Members)
[t=00:00:00.001233] Warning:   Missing member(s) in class CGroundDecalHandlerData, between highQuality & sdbc, ~7 byte(s)
[t=00:00:00.008241] Warning: CREG Results: 1 of 215 classes are broken
```