### PR TITLE
Handle nonpositive `weaponDef.stockpileTime` better

### DIFF
--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -511,7 +511,7 @@ bool CWeapon::UpdateStockpile()
 	if (!weaponDef->stockpile)
 		return true;
 
-	if (numStockpileQued > 0) {
+	if (weaponDef->stockpileTime > 0.0f && numStockpileQued > 0) {
 		const float p = 1.0f / weaponDef->stockpileTime;
 
 		if (owner->UseResources(weaponDef->cost * p))

--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -160,7 +160,7 @@ WEAPONTAG(float, fireStarter).defaultValue(0.0f).minimumValue(0.0f).scaleValue(0
 WEAPONTAG(bool, paralyzer).defaultValue(false).description("Is the weapon a paralyzer? If true the weapon only stuns enemy units and does not cause damage in the form of lost hit-points.");
 WEAPONTAG(int, paralyzeTime,  damages.paralyzeDamageTime).defaultValue(10).minimumValue(0).description("Determines the maximum length of time in seconds that the target will be paralyzed. The timer is restarted every time the target is hit by the weapon. Cannot be less than 0.");
 WEAPONTAG(bool, stockpile).defaultValue(false).description("Does each round of the weapon have to be built and stockpiled by the player? Will only correctly function for the first of each stockpiled weapons a unit has.");
-WEAPONTAG(float, stockpileTime).fallbackName("reload").defaultValue(1.0f).scaleValue(GAME_SPEED).description("The time in seconds taken to stockpile one round of the weapon.");
+WEAPONTAG(float, stockpileTime).fallbackName("reload").defaultValue(1.0f).minimumValue(0.0f).scaleValue(GAME_SPEED).description("The time in seconds taken to stockpile one round of the weapon. Set to 0 for it not to progress (useful for a Lua reimplementation).");
 
 // Interceptor
 WEAPONTAG(int, targetable).defaultValue(0).description("Bitmask representing the types of weapon that can intercept this weapon. Each digit of binary that is set to one means that a weapon with the corresponding digit in its interceptor tag will intercept this weapon. Instant-hitting weapons such as [#BeamLaser], [#LightningCannon] and [#Rifle] cannot be targeted.");


### PR DESCRIPTION
 * negative values no longer allowed.
 * zero no longer poisons everything (incl. resources due to stockpile cost) with NaN. Now means engine won't progress stockpile on its own. Useful for a Lua reimplementation.