### PR TITLE
Apply a missed `unit->leavesGhost`

### DIFF
--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -272,7 +272,7 @@ void CUnitDrawerData::UpdateCurrentUnitIcon(const CUnit* unit)
 	bool unitVisible =
 		(losStatus & inLosOrRad) != 0 &&
 		(losStatus & prevMask) == prevMask ||
-		gameSetup->ghostedBuildings && unit->unitDef->IsBuildingUnit() && (losStatus & LOS_PREVLOS) != 0;
+		gameSetup->ghostedBuildings && unit->leavesGhost && (losStatus & LOS_PREVLOS) != 0;
 
 	const bool customIcon = (unitVisible || gu->spectatingFullView);
 


### PR DESCRIPTION
a11dbbaa27bd542b5b7912955ca056dd2ad8b238 changed many checks for `unit->unitDef->IsBuildingUnit` into `unit->leavesGhost` but seems to have missed this one.