### PR TITLE
fixed missing nowide library for FileSink

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ set(test_Log_sources
 set(test_common_libraries
 	Tracy::TracyClient
 	Catch2
+	nowide::nowide
 )
 
 add_custom_target(tests)


### PR DESCRIPTION
test ILog depends on FileSink which in turns depend on <nowide/cstdio.hpp>
