### PR TITLE
Default missile smokePeriod 8 -> 1

### DIFF
--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -243,7 +243,7 @@ WEAPONTAG(float3, animParams4, visuals.animParams[3]).fallbackName("animParams")
 // Missile
 WEAPONTAG(bool, smokeTrail, visuals.smokeTrail).defaultValue(false).description("MissileLauncher only. Does it leave a smoke trail ribbon?");
 WEAPONTAG(bool, smokeTrailCastShadow, visuals.smokeTrailCastShadow).defaultValue(true).description("Does the smoke trail cast shadow?");
-WEAPONTAG(int, smokePeriod, visuals.smokePeriod).defaultValue(8).description("Smoke trail update rate - the trail ribbon will make a new vertex this many sim frames. Use for high turn-rate homing missiles to prevent jagged edges. Smaller is smoother but more performance-heavy.");
+WEAPONTAG(int, smokePeriod, visuals.smokePeriod).defaultValue(1).description("Smoke trail update rate - the trail ribbon will make a new vertex this many sim frames. Use for high turn-rate homing missiles to prevent jagged edges. Smaller is smoother but more performance-heavy.");
 WEAPONTAG(int, smokeTime, visuals.smokeTime).defaultValue(2 * GAME_SPEED).description("Smoke trail linger duration, in sim frames");
 WEAPONTAG(float, smokeSize, visuals.smokeSize).defaultValue(7.0f).description("Smoke trail size multiplier");
 WEAPONTAG(float, smokeColor, visuals.smokeColor).defaultValue(0.65f).description("Smoke trail brightness multiplier");


### PR DESCRIPTION
Much less ugly default.

Existing games can apply this one-liner if needed: `for _, wd in pairs(WeaponDefs) do wd.smokeperiod = wd.smokeperiod or 8; end`, but I think they'll be happy with the improved look anyway.