### PR TITLE
added missing lzma library for unitsync unit tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,7 @@ set(test_common_libraries
 	Tracy::TracyClient
 	Catch2
 	nowide::nowide
+	${LZMA_LIBRARY}
 )
 
 add_custom_target(tests)


### PR DESCRIPTION
TestUnitSync are failing with the following output:

```
libunitsync.so: error: undefined reference to 'lzma_code'
libunitsync.so: error: undefined reference to 'lzma_stream_decoder'
libunitsync.so: error: undefined reference to 'lzma_lzma_preset'
libunitsync.so: error: undefined reference to 'lzma_properties_size'
libunitsync.so: error: undefined reference to 'lzma_stream_encoder'
libunitsync.so: error: undefined reference to 'lzma_alone_decoder'
libunitsync.so: error: undefined reference to 'lzma_alone_encoder'
libunitsync.so: error: undefined reference to 'lzma_end'
```
