### PR TITLE
Added missing TaskType at parallel_reduce call in TestFileSystem

### DIFF
--- a/test/engine/System/testThreadPool.cpp
+++ b/test/engine/System/testThreadPool.cpp
@@ -127,7 +127,7 @@ TEST_CASE("test_parallel_reduce")
 		return threadnum;
 	};
 
-	const int result = parallel_reduce(TestFunc, ReduceFunc);
+	const int result = parallel_reduce<SyncTask<decltype(TestFunc)>>(TestFunc, ReduceFunc);
 	CHECK(result == ((NUM_THREADS - 1) * ((NUM_THREADS - 1) + 1)) / 2);
 }
 


### PR DESCRIPTION
Before the TestThreadPool would fail to compile with:
```
/build/src/rts/System/Threading/ThreadPool.h:806:20: note:   template argument deduction/substitution failed:
/build/src/test/engine/System/testThreadPool.cpp:130:43: note:   couldn't deduce template parameter 'TaskType'
  130 |         const int result = parallel_reduce(TestFunc, ReduceFunc);
      |                            ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
```
