### PR TITLE
Revert #2722 (add builderDefID and builderTeam)

### DIFF
--- a/cont/LuaUI/widgets.lua
+++ b/cont/LuaUI/widgets.lua
@@ -1802,9 +1802,9 @@ end
 --  Unit call-ins
 --
 
-function widgetHandler:UnitCreated(unitID, unitDefID, unitTeam, builderID, builderDefID, builderTeam)
+function widgetHandler:UnitCreated(unitID, unitDefID, unitTeam, builderID)
   for _,w in ipairs(self.UnitCreatedList) do
-    w:UnitCreated(unitID, unitDefID, unitTeam, builderID, builderDefID, builderTeam)
+    w:UnitCreated(unitID, unitDefID, unitTeam, builderID)
   end
   return
 end

--- a/cont/base/springcontent/LuaGadgets/gadgets.lua
+++ b/cont/base/springcontent/LuaGadgets/gadgets.lua
@@ -1379,9 +1379,9 @@ end
 --  Unit call-ins
 --
 
-function gadgetHandler:UnitCreated(unitID, unitDefID, unitTeam, builderID, builderDefID, builderTeam)
+function gadgetHandler:UnitCreated(unitID, unitDefID, unitTeam, builderID)
   for _,g in r_ipairs(self.UnitCreatedList) do
-    g:UnitCreated(unitID, unitDefID, unitTeam, builderID, builderDefID, builderTeam)
+    g:UnitCreated(unitID, unitDefID, unitTeam, builderID)
   end
 end
 

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -1063,14 +1063,12 @@ inline void CLuaHandle::UnitCallIn(const LuaHashString& hs, const CUnit* unit)
  * @param unitDefID integer
  * @param unitTeam integer
  * @param builderID integer?
- * @param builderDefID integer?
- * @param builderTeam integer?
  */
 void CLuaHandle::UnitCreated(const CUnit* unit, const CUnit* builder)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	LUA_CALL_IN_CHECK(L);
-	luaL_checkstack(L, 9, __func__);
+	luaL_checkstack(L, 7, __func__);
 
 	const LuaUtils::ScopedDebugTraceBack traceBack(L);
 
@@ -1081,14 +1079,11 @@ void CLuaHandle::UnitCreated(const CUnit* unit, const CUnit* builder)
 	lua_pushnumber(L, unit->id);
 	lua_pushnumber(L, unit->unitDef->id);
 	lua_pushnumber(L, unit->team);
-	if (builder != nullptr) {
+	if (builder != nullptr)
 		lua_pushnumber(L, builder->id);
-		lua_pushnumber(L, builder->unitDef->id);
-		lua_pushnumber(L, builder->team);
-	}
 
 	// call the routine
-	RunCallInTraceback(L, cmdStr, (builder != nullptr)? 6: 3, 0, traceBack.GetErrFuncIdx(), false);
+	RunCallInTraceback(L, cmdStr, (builder != nullptr)? 4: 3, 0, traceBack.GetErrFuncIdx(), false);
 }
 
 


### PR DESCRIPTION
I've received gamedev feedback that the extra args are just adding bloat in one of the most important callins, since they are just convenience (you can use the builder's unit ID to get both of them) and using them would be relatively rare.

I had failed to put the reasoning behind the request down in #1344 at the time and I don't remember anymore if it was something substantial or just "feels like it belongs" vibes. So I'm leaning towards removing them but I'll let this wait for a bit in case somebody feels strongly about it.