### PR TITLE
 Fixed resurrectors occasionally skipping repair of freshly resurrected units

### DIFF
--- a/rts/Sim/Units/CommandAI/BuilderCaches.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCaches.cpp
@@ -67,8 +67,8 @@ bool CBuilderCaches::IsUnitBeingReclaimed(const CUnit* unit, const CUnit* friend
 		}
 	}
 
-	for (auto it = removees.begin(); it != removees.end(); ++it)
-		RemoveUnitFromReclaimers(unitHandler.GetUnit(*it));
+	for (const auto removee : removees)
+		RemoveUnitFromReclaimers(unitHandler.GetUnit(removee));
 
 	return retval;
 }
@@ -103,8 +103,8 @@ bool CBuilderCaches::IsFeatureBeingReclaimed(int featureId, const CUnit* friendU
 		}
 	}
 
-	for (auto it = removees.begin(); it != removees.end(); ++it)
-		RemoveUnitFromFeatureReclaimers(unitHandler.GetUnit(*it));
+	for (const auto removee : removees)
+		RemoveUnitFromFeatureReclaimers(unitHandler.GetUnit(removee));
 
 	return retval;
 }
@@ -127,7 +127,7 @@ bool CBuilderCaches::IsFeatureBeingResurrected(int featureId, const CUnit* frien
 			continue;
 		}
 		const Command& c = cq.front();
-		if (c.GetID() != CMD_RESURRECT || c.GetNumParams() != 1) {
+		if (c.GetID() != CMD_RESURRECT || (c.GetNumParams() != 1 && c.GetNumParams() != 5)) {
 			removees.push_back(u->id);
 			continue;
 		}
@@ -138,8 +138,8 @@ bool CBuilderCaches::IsFeatureBeingResurrected(int featureId, const CUnit* frien
 		}
 	}
 
-	for (auto it = removees.begin(); it != removees.end(); ++it)
-		RemoveUnitFromResurrecters(unitHandler.GetUnit(*it));
+	for (const auto removee : removees)
+		RemoveUnitFromResurrecters(unitHandler.GetUnit(removee));
 
 	return retval;
 }

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -464,6 +464,12 @@ bool CBuilder::UpdateResurrect(const Command& fCommand)
 			// prevent FinishCommand from removing this command when the
 			// feature is deleted, since it is needed to start the repair
 			// (WTF!)
+			//
+			// The future lurker:
+			// if you were searching where the hell the huge floating point number
+			// in params[0] was coming from and traced it back to this WTF hack,
+			// increment the number of wasted hours below:
+			//   number_of_hours_wasted = 3;
 			c.SetParam(0, INT_MAX / 2);
 		}
 


### PR DESCRIPTION
* Fixes the handling of resurrectors in CBuilderCaches::IsFeatureBeingResurrected not taking into account CMD_RESURRECT might have 5 parameters
* Count hours spent on some WTF handling of the resurrect command in CBuilder::UpdateResurrect()
* Bring some C++11 into CBuilderCaches

Fixes https://github.com/beyond-all-reason/RecoilEngine/issues/2724