### PR TITLE
removed expected ./ for TestFileSystem

### DIFF
--- a/test/engine/System/FileSystem/TestFileSystem.cpp
+++ b/test/engine/System/FileSystem/TestFileSystem.cpp
@@ -154,8 +154,8 @@ TEST_CASE("GetNormalizedPath - multiple slashes")
 
 TEST_CASE("GetNormalizedPath - current directory") 
 {
-	CHECK_NORM_PATH("./foo/bar", "./foo/bar");
-	CHECK_NORM_PATH(".\\foo\\bar", "./foo/bar");
+	CHECK_NORM_PATH("./foo/bar", "foo/bar");
+	CHECK_NORM_PATH(".\\foo\\bar", "foo/bar");
 	CHECK_NORM_PATH("foo/./bar", "foo/bar");
 	CHECK_NORM_PATH("foo/.", "foo");
 	CHECK_NORM_PATH(".", ".");
@@ -168,7 +168,7 @@ TEST_CASE("GetNormalizedPath - parent directory")
 	CHECK_NORM_PATH("foo/bar/..", "foo");
 	CHECK_NORM_PATH("foo/bar/../baz", "foo/baz");
 	CHECK_NORM_PATH("foo/../bar", "bar");
-	CHECK_NORM_PATH("./foo/../bar", "./bar");
+	CHECK_NORM_PATH("./foo/../bar", "bar");
 	CHECK_NORM_PATH("foo/bar/../../baz", "baz");
 	CHECK_NORM_PATH("../foo", "../foo");
 	CHECK_NORM_PATH("../../foo", "../../foo");
@@ -177,9 +177,9 @@ TEST_CASE("GetNormalizedPath - parent directory")
 
 TEST_CASE("GetNormalizedPath - mixed cases") 
 {
-	CHECK_NORM_PATH("./foo/./bar/../baz", "./foo/baz");
+	CHECK_NORM_PATH("./foo/./bar/../baz", "foo/baz");
 	CHECK_NORM_PATH("foo//./bar//..//baz", "foo/baz");
-	CHECK_NORM_PATH("./a/b/c/../../d", "./a/d");
+	CHECK_NORM_PATH("./a/b/c/../../d", "a/d");
 	CHECK_NORM_PATH("C:\\foo\\.\\bar\\..\\baz", "C:/foo/baz");
 }
 
@@ -204,40 +204,40 @@ TEST_CASE("GetNormalizedPath - trailing slashes")
 {
 	CHECK_NORM_PATH("foo/bar/", "foo/bar");
 	CHECK_NORM_PATH("foo/bar//", "foo/bar");
-	CHECK_NORM_PATH("./foo/", "./foo");
+	CHECK_NORM_PATH("./foo/", "foo");
 	CHECK_NORM_PATH("foo\\bar\\", "foo/bar");
 	CHECK_NORM_PATH("foo\\bar\\\\", "foo/bar");
-	CHECK_NORM_PATH(".\\foo\\", "./foo");
+	CHECK_NORM_PATH(".\\foo\\", "foo");
 	CHECK_NORM_PATH("C:\\foo\\", "C:/foo");
 }
 
 TEST_CASE("GetNormalizedPath - with file extensions") 
 {
-	CHECK_NORM_PATH("./foo/bar.txt", "./foo/bar.txt");
+	CHECK_NORM_PATH("./foo/bar.txt", "foo/bar.txt");
 	CHECK_NORM_PATH("foo/../bar.log", "bar.log");
-	CHECK_NORM_PATH("./a/b/../c.txt", "./a/c.txt");
+	CHECK_NORM_PATH("./a/b/../c.txt", "a/c.txt");
 }
 
 TEST_CASE("GetNormalizedPath - UTF-8 support") 
 {
-	CHECK_NORM_PATH("./文档/测试.txt", "./文档/测试.txt");
+	CHECK_NORM_PATH("./文档/测试.txt", "文档/测试.txt");
 	CHECK_NORM_PATH("папка/файл.log", "папка/файл.log");
-	CHECK_NORM_PATH("./日本語/../テスト", "./テスト");
+	CHECK_NORM_PATH("./日本語/../テスト", "テスト");
 	CHECK_NORM_PATH("C:\\français\\café\\..\\thé.txt", "C:/français/thé.txt");
-	CHECK_NORM_PATH("./مجلد/ملف.txt", "./مجلد/ملف.txt");
+	CHECK_NORM_PATH("./مجلد/ملف.txt", "مجلد/ملف.txt");
 }
 
 TEST_CASE("GetNormalizedPath - spaces") 
 {
 	CHECK_NORM_PATH("foo bar/baz", "foo bar/baz");
-	CHECK_NORM_PATH("./my folder/test.txt", "./my folder/test.txt");
+	CHECK_NORM_PATH("./my folder/test.txt", "my folder/test.txt");
 	CHECK_NORM_PATH("C:\\Program Files\\app", "C:/Program Files/app");
 }
 
 TEST_CASE("GetNormalizedPath - special characters") 
 {
 	CHECK_NORM_PATH("foo-bar_baz", "foo-bar_baz");
-	CHECK_NORM_PATH("./file (1).txt", "./file (1).txt");
+	CHECK_NORM_PATH("./file (1).txt", "file (1).txt");
 	CHECK_NORM_PATH("foo@bar/baz#123", "foo@bar/baz#123");
 }
 


### PR DESCRIPTION
As discussed in this PR: https://github.com/beyond-all-reason/RecoilEngine/pull/2777. I removed the `./` from the expected result of `FileSystem::GetNormalizedPath`