### PR TITLE
Validate demo file header fields in LoadStats to prevent OOB access

### DIFF
--- a/rts/System/LoadSave/DemoReader.cpp
+++ b/rts/System/LoadSave/DemoReader.cpp
@@ -166,6 +166,13 @@ void CDemoReader::LoadStats()
 	playerStats.clear();
 	teamStats.clear();
 
+	if (fileHeader.winningAllyTeamsSize < 0 || fileHeader.winningAllyTeamsSize > MAX_TEAMS)
+		return;
+	if (fileHeader.numPlayers < 0 || fileHeader.numPlayers > MAX_PLAYERS)
+		return;
+	if (fileHeader.numTeams < 0 || fileHeader.numTeams > MAX_TEAMS)
+		return;
+
 	for (int allyTeamNum = 0; allyTeamNum < fileHeader.winningAllyTeamsSize; ++allyTeamNum) {
 		unsigned char winnerAllyTeam;
 		playbackDemo->Read((char*) &winnerAllyTeam, sizeof(unsigned char));


### PR DESCRIPTION
Adds runtime bounds checks for `numTeams`, `numPlayers`, and `winningAllyTeamsSize` 
in `CDemoReader::LoadStats()` before they are used as loop bounds and buffer sizes.

Previously these fields were only guarded by `assert()`, which compiles to nothing 
in release builds (`-DNDEBUG`). A crafted `.sdfz` demo file with `numTeams` exceeding 
`MAX_TEAMS` causes a write past the end of the stack-allocated `numStatsPerTeam` array 
(1020 bytes), overflowing into adjacent stack frames.

The fix early-returns from `LoadStats()` if any header field is negative or exceeds 
the protocol maximum, matching the existing pattern used for `demoStreamSize == 0`.

This enabled RCE via stack overflow on dev builds of the engine, caused crashes on prod builds. 