### PR TITLE
Mount main repo .git directory for worktree builds

### DIFF
--- a/docker-build-v2/build.sh
+++ b/docker-build-v2/build.sh
@@ -135,11 +135,22 @@ else
   P="/"
 fi
 
+# Handle git worktrees: the container needs access to the shared .git directory
+# for version generation. In a worktree, --absolute-git-dir returns the
+# worktree-specific dir while --git-common-dir returns the shared .git root.
+WORKTREE_MOUNTS=""
+GIT_DIR=$(git rev-parse --absolute-git-dir)
+GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+if [[ "$GIT_DIR" != "$GIT_COMMON_DIR" ]]; then
+  WORKTREE_MOUNTS="-v $GIT_COMMON_DIR:$GIT_COMMON_DIR:ro"
+fi
+
 $RUNTIME run -it --rm \
     -v "$CWD${P}":/build/src:z,ro \
     -v "$CWD${P}.cache${P}ccache-$OS":/build/cache:z,rw \
     -v "$CWD${P}build-$OS":/build/out:z,rw \
     $UID_FLAGS \
+    $WORKTREE_MOUNTS \
     -e CONFIGURE \
     -e COMPILE \
     -e CMAKE_BUILD_PARALLEL_LEVEL \


### PR DESCRIPTION
When building from a git worktree, .git is a file pointing to the main repo's .git/worktrees/<name> directory. The container only mounts the worktree source tree, so git operations (version detection, git describe) fail because the target of the pointer isn't available. Mount the main repo's .git directory read-only so the indirection resolves.