### PR TITLE
fix(LuaHandle): null-check game pointer in Update callin

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2536,9 +2536,10 @@ void CLuaHandle::Update()
 	if (!cmdStr.GetGlobalFunc(L))
 		return;
 
-	// call the routine and pass dt (game is null during menu phase)
-	lua_pushnumber(L, game ? game->updateDeltaSeconds : 0.0f);
-	RunCallIn(L, cmdStr, 1, 0);
+	if (game) // null in LuaMenu
+		lua_pushnumber(L, game->updateDeltaSeconds);
+
+	RunCallIn(L, cmdStr, game ? 1 : 0, 0);
 }
 
 


### PR DESCRIPTION
71675a899b added `game->updateDeltaSeconds` as a `dt` argument to the `Update` callin, but `game` is nullptr during the LuaMenu phase (before any game is loaded). This causes a SIGSEGV on startup when the menu controller dispatches `Update` to its widget list.

Guard the dereference so `dt` is 0 when no game is active.

Fixes crash introduced by #2644.