### PR TITLE
Fix wantedHeight bug

### DIFF
--- a/rts/Sim/MoveTypes/HoverAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.cpp
@@ -760,8 +760,8 @@ void CHoverAirMoveType::UpdateVerticalSpeed(const float4& spd, float curRelHeigh
 		const float3 sdir = lastCollidee->speed - spd;
 
 		if (spd.dot(dir + sdir * 20.0f) < 0.0f) {
-			wh -= (30.0f * (lastCollidee->midPos.y >  owner->midpos.y));
-			wh += (50.0f * (lastCollidee->midPos.y <= owner->midpos.y));
+			wh -= (30.0f * (lastCollidee->midPos.y >  owner->midPos.y));
+			wh += (50.0f * (lastCollidee->midPos.y <= owner->midPos.y));
 		}
 	}
 


### PR DESCRIPTION
Fixes part of https://github.com/beyond-all-reason/RecoilEngine/issues/2786

BAR Dragons do not get stuck in the AIRCRAFT_TAKEOFF state anymore. However, two notes: 
A. This is a quick bug fix, a comprehensive assessment of air unit magic constants still needs to be done. 

B. ~~Two~~ One bug related to #2786 still exists:
~~1. While testing this fix with Luarules disabled, I noticed ALL builders (air and land) have an empty command queue when they are finished being constructed.  They don't inherit commands from their factory, 
they forget any commands you gave them 
and they don't receive the engine default "move out of the factory command"~~
Builders are fine, I had not run luaui disable and there was a BAR-side widget scewing with builders. 

~~2.~~ 1. In some cases, BAR armthund units when given a super close move command to the factory will pitch down and fly through the factory instead of taking off upwards. This will likely need to be fixed with a future comprehensive air physics/movement rework.