### PR TITLE
Add to LuaSyncedCtrl::SetUnitBlocking to enable gameside air collision toggling. 

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -3330,10 +3330,23 @@ int LuaSyncedCtrl::SetUnitNanoPieces(lua_State* L)
  * @param crushable boolean? Enable or disable crushable, or no change if `nil`.
  * @param blockEnemyPushing boolean? Enable or disable blocking enemy pushing, or no change if `nil`.
  * @param blockHeightChanges boolean? Enable or disable blocking height changes, or no change if `nil`.
+ * @param isAirCollide boolean? Enable or disable the collide bool that is used to run air collisions, or no change if `nil`.
  * @return boolean isBlocking
  */
 int LuaSyncedCtrl::SetUnitBlocking(lua_State* L)
 {
+	CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	// air unit collision is set at unit creation, by reading the unitdef, and is not affected by subsequent changes to the collision flags
+	// must change the collide var in the movetype directly
+	AAirMoveType* amt = dynamic_cast<AAirMoveType*>(unit->moveType);
+	if (amt != nullptr) {
+		amt->SetCollide(luaL_optboolean(L, 9, amt->collide));
+	}
+
 	return (SetSolidObjectBlocking(L, ParseUnit(L, __func__, 1)));
 }
 

--- a/rts/Sim/MoveTypes/AAirMoveType.h
+++ b/rts/Sim/MoveTypes/AAirMoveType.h
@@ -47,6 +47,7 @@ public:
 		wantedHeight = altitude;
 		orgWantedHeight = altitude;
 	}
+	void SetCollide(bool newCollide) { collide = newCollide; }
 
 	bool HaveLandingPos() const { return (reservedLandingPos.x != -1.0f); }
 


### PR DESCRIPTION
Partially addresses https://github.com/beyond-all-reason/RecoilEngine/issues/682
(Addresses air vs air collisions, allowing for games to adjust this property on the fly. This PR does not address the various bugs with aircraft incorrectly blocking terrain)

Enables gameside Lua to toggle air unit collisions. 

Previously, the variable that controlled this was set at unit creation from reading the unitdef, with no functions to change it.

LuaSyncedCtrl::SetUnitBlocking already controls a bunch of collision behavior, so this PR just adds one more optional bool to this function. 

https://github.com/user-attachments/assets/74fa1b7e-5561-4d31-9c4f-3b1eee039350

Example in BAR, using the below gadget
```
function gadget:GameFrame(nn)
	if nn%2000 == 1 then
		for _, unitID in ipairs(Spring.GetAllUnits()) do
			Spring.SetUnitBlocking(unitID,nil,nil,nil,nil,nil,nil,nil,true)
		end
		Spring.Echo("collision ON")
	end

	if nn%2000 == 1000 then
		for _, unitID in ipairs(Spring.GetAllUnits()) do
			Spring.SetUnitBlocking(unitID,nil,nil,nil,nil,nil,nil,nil,false)
		end
		Spring.Echo("collision OFF")
	end
end
```