### PR TITLE
Send Unit-Relative Headings and Pitch to AimWeaponX

### DIFF
--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -407,13 +407,20 @@ bool CWeapon::CallAimingScript(bool waitForAim)
 	lastRequestedDir = wantedDir;
 	lastAimedFrame = gs->frameNum;
 
-	const float heading = GetHeadingFromVectorF(wantedDir.x, wantedDir.z);
-	const float pitch = math::asin(std::clamp(wantedDir.dot(owner->updir), -1.0f, 1.0f));
+	// transform wantedDir into unit's local coordinate frame so that
+	// heading and pitch are relative to the unit's current orientation,
+	// correctly handling units on sloped terrain
+	const float localX = wantedDir.dot(owner->rightdir);
+	const float localY = wantedDir.dot(owner->updir);
+	const float localZ = wantedDir.dot(owner->frontdir);
+
+	const float heading = GetHeadingFromVectorF(localX, localZ);
+	const float pitch = math::asin(std::clamp(localY, -1.0f, 1.0f));
 
 	// for COB, this sets <angleGood> to AimWeapon's return value when finished
 	// for LUS, there exists a callout to set the <angleGood> member directly
 	// FIXME: convert CSolidObject::heading to radians too.
-	owner->script->AimWeapon(weaponNum, ClampRad(heading - owner->heading * TAANG2RAD), pitch);
+	owner->script->AimWeapon(weaponNum, ClampRad(-heading), pitch);
 	return true;
 }
 


### PR DESCRIPTION
Solves this issue raised on Discord
<img width="1090" height="432" alt="image" src="https://github.com/user-attachments/assets/883f4871-f74a-4b6c-b5b8-95e3fbd7bf5a" />

Old engine:
<img width="691" height="668" alt="image" src="https://github.com/user-attachments/assets/37801eca-f825-4713-8150-0ba2469a0625" />
<img width="595" height="471" alt="image" src="https://github.com/user-attachments/assets/f1d7d3c6-d3d3-4d1d-ae99-2ecb46edf73c" />

With this PR:
<img width="649" height="406" alt="image" src="https://github.com/user-attachments/assets/50543a98-e087-4ec2-b35d-8ec2e5fea265" />
<img width="656" height="387" alt="image" src="https://github.com/user-attachments/assets/d77f92ee-5431-4986-bc76-35ab7c9ba9f9" />

(AI disclosure, Claude Code Opus 4.6 helped figure out the geometry functions)