### PR TITLE
FIX: Update(dt) callin to prevent nil error

### DIFF
--- a/cont/LuaUI/fonts.lua
+++ b/cont/LuaUI/fonts.lua
@@ -492,7 +492,7 @@ local function FreeFonts()
 end
 
 
-local function Update(dt)
+function widget:Update(dt)
   timeStamp = timeStamp + dt
   if (timeStamp < (lastUpdate + 1.0)) then
     return  -- only update every 1.0 seconds
@@ -557,3 +557,4 @@ return FH
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
+


### PR DESCRIPTION
[84d3203](https://github.com/beyond-all-reason/RecoilEngine/commit/84d320374131da44f00151715d57979cd41b60cb) Changed Update(dt) to widget:Update(dt) so the engine passes dt correctly. Prevents runtime error in font cache cleanup.
<img width="957" height="81" alt="image" src="https://github.com/user-attachments/assets/c19d715f-33d7-4333-9045-473e4406bf96" />
