### PR TITLE
Fix docker images build CI `pull_request` flow

### DIFF
--- a/.github/workflows/docker-images-build.yml
+++ b/.github/workflows/docker-images-build.yml
@@ -27,21 +27,11 @@ jobs:
         system:
           - amd64-linux
           - amd64-windows
-    permissions:
-      packages: write
-      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        id: build
+      - name: Build
         uses: docker/build-push-action@v6
         with:
           # Disabling cache to make sure that operations like git clone are
@@ -49,57 +39,48 @@ jobs:
           # quite rarely so it's not an issue performance wise.
           no-cache: true
           context: docker-build-v2/${{ matrix.system }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ github.repository_owner }}/recoil-build-${{ matrix.system }}:latest
-      - name: Write new image digest to file
-        run: echo "${{ steps.build.outputs.digest }}" > ${{ matrix.system }}.txt
-      - name: Save digest in artifact
-        uses: actions/upload-artifact@v6
+          tags: recoil-build-${{ matrix.system }}:latest
+          outputs: type=docker,dest=${{ runner.temp }}/image.tar
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v7
         with:
-          name: image-digest-${{ matrix.system }}
-          path: ${{ matrix.system }}.txt
-  gather-digests:
-    name: Gather digests
-    runs-on: ubuntu-latest
-    needs: build-images
-    outputs:
-      images_versions: ${{ steps.merge.outputs.images_versions }}
-    steps:
-      - name: Fetch digests
-        uses: actions/download-artifact@v7
-        with:
-          path: .digests
-          pattern: image-digest-*
-          merge-multiple: true
-      - name: Merge digests
-        id: merge
-        run: |
-          echo "images_versions=$(
-            for digest in $(ls .digests); do
-              echo "${digest%.*}=$(cat .digests/$digest)"
-            done | jq -Rnc '[inputs] | map(. | split("=") | {key: .[0], value: .[1]}) | from_entries'
-          )" >> "$GITHUB_OUTPUT"
+          name: build-image-${{ matrix.system }}
+          path: ${{ runner.temp }}/image.tar
   test-build:
-    needs: gather-digests
+    needs: build-images
     uses: ./.github/workflows/engine-build.yml
     with:
-      image-versions: ${{ needs.gather-digests.outputs.images_versions }}
+      image-artifacts: true
     secrets: inherit
   publish:
-    name: Update digest branch
-    needs: [test-build, gather-digests]
-    if: github.event_name == 'workflow_dispatch' && inputs.update-digests == true || github.event_name == 'push'
+    name: Push images and update digests
     runs-on: ubuntu-latest
+    needs: test-build
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.update-digests == true
     permissions:
+      packages: write
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - name: Update digests
-        env:
-          images_versions: ${{ needs.gather-digests.outputs.images_versions }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download image artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: build-image-*
+          path: ${{ runner.temp }}/images
+      - name: Push images and update digests
         run: |
-          echo "$images_versions" | jq -r 'to_entries[] | "\(.key) \(.value)"' | while read -r platform digest; do
-            sed -i -r "s/(image_version\[$platform\]=)(.*)/\1$digest/" docker-build-v2/images_versions.sh
+          for system in amd64-linux amd64-windows; do
+            docker load --input ${{ runner.temp }}/images/build-image-$system/image.tar
+            docker tag recoil-build-$system:latest ghcr.io/${{ github.repository_owner }}/recoil-build-$system:latest
+            docker push ghcr.io/${{ github.repository_owner }}/recoil-build-$system:latest | tee ${{ runner.temp }}/push_output.txt
+            digest=$(tail -n 1 ${{ runner.temp }}/push_output.txt | cut -d' ' -f 3)
+            sed -i -r "s/(image_version\[$system\]=)(.*)/\1$digest/" docker-build-v2/images_versions.sh
           done
       - name: Commit and push
         uses: stefanzweifel/git-auto-commit-action@v7

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -42,10 +42,10 @@ on:
       package-suffix:
         description: 'Custom suffix for the package name'
         type: string
-      image-versions:
-        description: 'Allows override image-versions for this run'
-        type: string
-        default: '{}'
+      image-artifacts:
+        description: 'Use build-image-* docker image artifacts for build'
+        type: boolean
+        default: false
   pull_request:
     paths-ignore:
       - 'doc/**'
@@ -146,14 +146,26 @@ jobs:
           wait-on: |
             http-get://127.0.0.1:8085/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
           wait-for: 3m
+      - name: Download docker image artifact
+        if: inputs.image-artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-image-${{ matrix.system }}
+          path: ${{ runner.temp }}
       - name: Pull builder image
         id: resolve-image
         # Fetching image from GitHub can be *incredibly* slow, so cache layers also in the
         # namespace.so container registry.
         run: |
+          if [[ -f ${{ runner.temp }}/image.tar ]]; then
+            docker load --input ${{ runner.temp }}/image.tar
+            echo "image=recoil-build-${{ matrix.system }}:latest" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           source src/docker-build-v2/images_versions.sh
 
-          digest=${{ fromJson(inputs.image-versions || '{}')[matrix.system] || format('${{image_version[{0}]}}', matrix.system) }}
+          digest=${image_version[${{ matrix.system }}]}
           ghcr_image=ghcr.io/${{ github.repository_owner }}/recoil-build-${{ matrix.system }}
           nsc_image=${{ env.NSC_CONTAINER_REGISTRY }}/recoil-build-${{ matrix.system }}
 


### PR DESCRIPTION
#2711 tried to add testing of new images as part of `push` and `pull_request` but the `pull_request` flow is fundamentally broken because it's not allowed to push images to the registry in PR flow.

In this PR we rework that to instead of propagating digests of images pushed to registry, operate on images uploaded as artifacts that are only pushed once all testing is done and we are on branch.

#### Testing

- The `pull_request` flow, with both success and fail case was tested in #2834
- The `push` flow was tested in this run https://github.com/beyond-all-reason/RecoilEngine/actions/runs/22595100265 and it resulted with https://github.com/beyond-all-reason/RecoilEngine/commit/624d186cbaa57c8b6e34dc1406ab7a69b6deecca