### PR TITLE
Fix negative upkeep GUI regression

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -958,6 +958,21 @@ void CUnit::SetStunned(bool stun) {
 	eventHandler.UnitStunned(this, stun);
 }
 
+// e.g. [+1, -9, -8, +4] -> { [1, 0, 0, 4], [0, 9, 8, 0] }
+// hopefully a temporary hack, see call site for rationale
+static auto SplitResourcePackIntoPositiveNegative (const SResourcePack &pack)
+{
+	SResourcePack positive {0.0f}, negative {0.0f};
+
+	for (auto [resourceID, value] : std::views::enumerate (pack)) {
+		if (value < 0.0f)
+			negative[resourceID] = -value;
+		else
+			positive[resourceID] = value;
+	}
+
+	return std::make_pair (positive, negative);
+}
 
 void CUnit::SlowUpdate()
 {
@@ -1056,7 +1071,15 @@ void CUnit::SlowUpdate()
 	AddResources(unitDef->resourceMake * 0.5f);
 
 	if (activated) {
-		if (UseResources(unitDef->upkeep * 0.5f)) {
+
+		/* Due to legacy API limitations, games often define conditional resourcing via negative upkeep.
+		 * Handle this separately via Add; this doesn't change the resulting resource totals, but makes it
+		 * show up the expected way in GUI tooltips and endgame stats. Encourage games to eventually use
+		 * `makesResources` instead, once that becomes available. */
+		const auto [positiveUpkeep, negativeUpkeep] = SplitResourcePackIntoPositiveNegative(unitDef->upkeep);
+		AddResources(negativeUpkeep * 0.5f);
+
+		if (UseResources(positiveUpkeep * 0.5f)) {
 			AddResources(unitDef->makesResources * 0.5f);
 
 			if (unitDef->extractsMetal > 0.0f)


### PR DESCRIPTION
Fixes a regression introduced with #2639. Some games use negative upkeep values for conditional income (solars that only work when open), which now shows up as such in `master` as a double negative:
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/7f654abc-79cd-4b55-bc99-7cef9f890249" />

Previously this worked because Add and Use for individual resources redirected to each other for negative values, but I think long-term it's good to mandate positive values everywhere (because Add and Use have slightly different semantics) so I would rather handle upkeep exceptionally for now rather than add this kind of redirection AddResources to limit it to this existing case. Later on there will be a proper unitdef tag for this kind of resourcing that games will be able to migrate to.

After:
<img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/6631b7c3-b0eb-4bdd-a268-6291c7e50c16" />
