### PR TITLE
Enable IO, OS and debug libraries for unsynced gadgets

### DIFF
--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -88,11 +88,7 @@ bool CUnsyncedLuaHandle::Init(std::string code, const std::string& file)
 	watchExplosionDefs.resize(weaponDefHandler->NumWeaponDefs(), false);
 
 	// load the standard libraries
-	LuaLibs::OpenSynced(L, false);
-	//LUA_OPEN_LIB(L, luaopen_io);
-	//LUA_OPEN_LIB(L, luaopen_os);
-	//LUA_OPEN_LIB(L, luaopen_package);
-	LUA_OPEN_LIB(L, luaopen_debug);
+	LuaLibs::OpenUnsynced(L);
 
 	// delete some dangerous functions
 	lua_pushnil(L); lua_setglobal(L, "dofile");

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -92,8 +92,7 @@ bool CUnsyncedLuaHandle::Init(std::string code, const std::string& file)
 	//LUA_OPEN_LIB(L, luaopen_io);
 	//LUA_OPEN_LIB(L, luaopen_os);
 	//LUA_OPEN_LIB(L, luaopen_package);
-	//LUA_OPEN_LIB(L, luaopen_debug);
-	EnactDevMode();
+	LUA_OPEN_LIB(L, luaopen_debug);
 
 	// delete some dangerous functions
 	lua_pushnil(L); lua_setglobal(L, "dofile");
@@ -164,13 +163,6 @@ bool CUnsyncedLuaHandle::Init(std::string code, const std::string& file)
 	eventHandler.AddClient(this);
 	return true;
 }
-
-
-void CUnsyncedLuaHandle::EnactDevMode() const
-{
-	SwapEnableModule(L, devMode, LUA_DBLIBNAME, luaopen_debug);
-}
-
 
 /***
  * @class UnsyncedCallins

--- a/rts/Lua/LuaHandleSynced.h
+++ b/rts/Lua/LuaHandleSynced.h
@@ -35,8 +35,6 @@ class CUnsyncedLuaHandle : public CLuaHandle
 
 		bool Init(std::string code, const std::string& file);
 
-		void EnactDevMode() const override;
-
 		static CUnsyncedLuaHandle* GetUnsyncedHandle(lua_State* L) {
 			assert(dynamic_cast<CUnsyncedLuaHandle*>(CLuaHandle::GetHandle(L)) != nullptr);
 			return static_cast<CUnsyncedLuaHandle*>(CLuaHandle::GetHandle(L));


### PR DESCRIPTION
Split off from https://github.com/beyond-all-reason/RecoilEngine/pull/2795 .

Looking at the other lua environments like LuaUI widgets, LuaMenu and now a use case for needing to write from a unsynced gadgets it would be good to enable these libraries. Note that (although probably not perfect) the IO library is already sandboxed to "safe paths" (meaning `data` folder or deeper).

Note for reviewer that even though this file is called _sync_ there is actually a section in this file for _unsynced_ code.