### PR TITLE
fix: do not run atlas/iconhandler in headless

### DIFF
--- a/rts/Rendering/IconHandler.cpp
+++ b/rts/Rendering/IconHandler.cpp
@@ -279,6 +279,14 @@ void CIconHandler::Update()
 
 	defaultIconIdx = defIt->second;
 
+#ifdef HEADLESS
+	// Headless builds don't render icons; skip the atlas pipeline entirely.
+	// Clearing the bits makes the atlasNeedsUpdate.none() check above short-circuit
+	// all subsequent calls to Update().
+	atlasNeedsUpdate.reset();
+	return;
+#endif
+
 	for (size_t i = 0; i < atlasNeedsUpdate.size(); ++i) {
 		if (!atlasNeedsUpdate.test(i))
 			continue;


### PR DESCRIPTION
Fixes #2923

Turns out that the new sort() running every sim frame causes a 10x reduction in sim frame performance in headless 😅 

So not only is it spammy (as the issue mentions) but it's real bad in any benchmarks.

AI Disclosure: claude code + me :^)



Tested working by me.