### PR TITLE
fix: Restore lowercasing in FileSystem::GetExtension

### DIFF
--- a/rts/Game/UI/MouseCursor.cpp
+++ b/rts/Game/UI/MouseCursor.cpp
@@ -277,7 +277,7 @@ bool CMouseCursor::LoadCursorImage(const std::string& name, ImageData& image)
 	}
 
 	// hardcoded bmp transparency mask
-	if (FileSystem::GetExtension(name) == "bmp")
+	if (FileSystem::GetExtensionLowerCase(name) == "bmp")
 		b.SetTransparent(SColor(84, 84, 252));
 
 	if (hwCursor->NeedsYFlip()) {

--- a/rts/Lua/LuaIO.cpp
+++ b/rts/Lua/LuaIO.cpp
@@ -79,7 +79,7 @@ bool LuaIO::SafeWritePath(const std::string& path)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const std::array<std::string, 5> exeFiles = {"exe", "dll", "so", "bat", "com"};
-	const std::string ext = FileSystem::GetExtension(path);
+	const std::string ext = FileSystem::GetExtensionLowerCase(path);
 
 	if (std::find(std::begin(exeFiles), std::end(exeFiles), ext) != exeFiles.end())
 		return false;

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -778,7 +778,7 @@ int LuaUtils::PushModelName(lua_State* L, const SolidObjectDef* def)
 int LuaUtils::PushModelType(lua_State* L, const SolidObjectDef* def)
 {
 	const std::string& modelPath = modelLoader.FindModelPath(def->modelName);
-	const std::string& modelType = StringToLower(FileSystem::GetExtension(modelPath));
+	const std::string& modelType = StringToLower(FileSystem::GetExtensionLowerCase(modelPath));
 	lua_pushsstring(L, modelType);
 	return 1;
 }

--- a/rts/Map/MapParser.cpp
+++ b/rts/Map/MapParser.cpp
@@ -24,7 +24,7 @@ std::string MapParser::GetMapConfigName(const std::string& mapFileName)
 {
 	const std::string directory = FileSystem::GetDirectory(mapFileName);
 	const std::string filename  = FileSystem::GetBasename(mapFileName);
-	const std::string extension = FileSystem::GetExtension(mapFileName);
+	const std::string extension = FileSystem::GetExtensionLowerCase(mapFileName);
 
 	if (extension == "smf")
 		return directory + filename + ".smd";

--- a/rts/Map/ReadMap.cpp
+++ b/rts/Map/ReadMap.cpp
@@ -145,7 +145,7 @@ CReadMap* CReadMap::LoadMap(const std::string& mapName)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CReadMap* rm = nullptr;
 
-	if (FileSystem::GetExtension(mapName) == "sm3") {
+	if (FileSystem::GetExtensionLowerCase(mapName) == "sm3") {
 		throw content_error("[CReadMap::LoadMap] SM3 maps are no longer supported as of Spring 95.0");
 	} else {
 		// assume SMF format by default; calls ::Initialize

--- a/rts/Rendering/Env/Decals/GroundDecalHandler.cpp
+++ b/rts/Rendering/Env/Decals/GroundDecalHandler.cpp
@@ -163,7 +163,7 @@ namespace Impl {
 		RECOIL_DETAILED_TRACY_ZONE;
 		std::string fileName = StringToLower(name);
 
-		if (FileSystem::GetExtension(fileName).empty())
+		if (FileSystem::GetExtensionLowerCase(fileName).empty())
 			fileName += ".bmp";
 
 		std::string fullName = fileName;
@@ -182,7 +182,7 @@ namespace Impl {
 		if (!bm.Load(fullName))
 			return std::make_tuple(LoadResult::BITMAP_ERROR, CBitmap(), fullName);
 
-		if (convertDecalBitmap && FileSystem::GetExtension(fullName) == "bmp") {
+		if (convertDecalBitmap && FileSystem::GetExtensionLowerCase(fullName) == "bmp") {
 			// bitmaps don't have an alpha channel
 			// so use: red := brightness & green := alpha
 			auto* rmem = bm.GetRawMem();

--- a/rts/Rendering/Models/AssParser.cpp
+++ b/rts/Rendering/Models/AssParser.cpp
@@ -551,7 +551,7 @@ void CAssParser::Load(S3DModel& model, const std::string& modelFilePath)
 	}
 
 	if (modelTable.GetBool("nodenamesfromids", false)) {
-		assert(FileSystem::GetExtension(modelFilePath) == "dae");
+		assert(FileSystem::GetExtensionLowerCase(modelFilePath) == "dae");
 		PreProcessFileBuffer(fileBuf);
 	}
 

--- a/rts/Rendering/Models/IModelParser.cpp
+++ b/rts/Rendering/Models/IModelParser.cpp
@@ -205,7 +205,7 @@ std::string CModelLoader::FindModelPath(std::string name) const
 
 	const std::string vfsPath = "objects3d/";
 
-	if (const std::string& fileExt = FileSystem::GetExtension(name); fileExt.empty()) {
+	if (const std::string& fileExt = FileSystem::GetExtensionLowerCase(name); fileExt.empty()) {
 		for (const auto& [formatExt, parser] : parsers) {
 			if (CFileHandler::FileExists(name + "." + formatExt, SPRING_VFS_ZIP)) {
 				name.append("." + formatExt);
@@ -328,7 +328,7 @@ S3DModel* CModelLoader::GetCachedModel(std::string fullName)
 	}
 
 	auto keyName = std::pair<std::string, uint32_t>("", uint32_t(-1));
-	if (const auto ext = FileSystem::GetExtension(fullName); !ext.empty()) {
+	if (const auto ext = FileSystem::GetExtensionLowerCase(fullName); !ext.empty()) {
 		keyName.first = fullName.substr(0, fullName.size() - ext.size() - 1);
 		const auto ci = spring::BinarySearch(cache.begin(), cache.end(), keyName, CompPred);
 		if (ci != cache.end()) {
@@ -408,7 +408,7 @@ void CModelLoader::ParseModel(S3DModel& model, const std::string& name, const st
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	try {
-		auto* parser = GetFormatParser(FileSystem::GetExtension(path));
+		auto* parser = GetFormatParser(FileSystem::GetExtensionLowerCase(path));
 		if (parser == nullptr) {
 			LoadDummyModel(model);
 			throw content_error(fmt::sprintf("could not find a parser for model \"%s\" (unknown format?)", name));

--- a/rts/Rendering/Textures/Bitmap.cpp
+++ b/rts/Rendering/Textures/Bitmap.cpp
@@ -1230,7 +1230,7 @@ bool CBitmap::Load(std::string const& filename, float defaultAlpha, uint32_t req
 	// files ending in ".DDS" would appear upside-down if loaded by nv_dds
 	//
 	// const bool loadDDS = (filename.find(".dds") != std::string::npos || filename.find(".DDS") != std::string::npos);
-	const bool loadDDS = (FileSystem::GetExtension(filename) == "dds"); // always lower-case
+	const bool loadDDS = (FileSystem::GetExtensionLowerCase(filename) == "dds");
 	const bool flipDDS = (filename.find("unitpics") == std::string::npos); // keep buildpics as-is
 
 	const size_t curMemSize = GetMemSize();
@@ -1585,7 +1585,7 @@ bool CBitmap::Save(const std::string& filename, bool dontSaveAlpha, bool logged,
 		assert(ilGetError() == IL_NO_ERROR);
 	}
 
-	const std::string& fsImageExt = FileSystem::GetExtension(filename);
+	const std::string& fsImageExt = FileSystem::GetExtensionLowerCase(filename);
 	const std::string& fsFullPath = dataDirsAccess.LocateFile(filename, FileQueryFlags::WRITE);
 	const std::wstring& ilFullPath = std::wstring(fsFullPath.begin(), fsFullPath.end());
 
@@ -1702,7 +1702,7 @@ bool CBitmap::SaveFloat(std::string const& filename) const
 
 	ITexMemPool::texMemPool->FreeRaw(reinterpret_cast<uint8_t*>(ctb), channels * xsize * ysize * sizeof(ConvertType));
 
-	const std::string fsImageExt = FileSystem::GetExtension(filename);
+	const std::string fsImageExt = FileSystem::GetExtensionLowerCase(filename);
 	const std::string fsFullPath = dataDirsAccess.LocateFile(filename, FileQueryFlags::WRITE);
 	const std::wstring ilFullPath = std::wstring(fsFullPath.begin(), fsFullPath.end());
 

--- a/rts/Sim/Misc/CommonDefHandler.cpp
+++ b/rts/Sim/Misc/CommonDefHandler.cpp
@@ -59,7 +59,7 @@ int CommonDefHandler::LoadSoundFile(const std::string& fileName)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (!fileName.empty()) {
-		const std::string soundExt = FileSystem::GetExtension(fileName);
+		const std::string soundExt = FileSystem::GetExtensionLowerCase(fileName);
 
 		// unlike constructing a CFileHandler this does not read the data
 		// into memory; faster for large files and many small individually

--- a/rts/Sim/Units/Scripts/UnitScriptFactory.cpp
+++ b/rts/Sim/Units/Scripts/UnitScriptFactory.cpp
@@ -33,7 +33,7 @@ CUnitScript* CUnitScriptFactory::CreateScript(CUnit* unit, const UnitDef* udef)
 	// NOTE:
 	//   Lua scripts are not loaded here but deferred to LuaUnitScript::CreateScript
 	//   do not check extension in GetCobFile, prevents warning spam for .lua files
-	if (FileSystem::GetExtension(udef->scriptName) != "cob")
+	if (FileSystem::GetExtensionLowerCase(udef->scriptName) != "cob")
 		return script;
 
 	CCobFile* file = cobFileHandler->GetCobFile(udef->scriptName);

--- a/rts/System/FileSystem/ArchiveLoader.cpp
+++ b/rts/System/FileSystem/ArchiveLoader.cpp
@@ -47,7 +47,7 @@ const CArchiveLoader& CArchiveLoader::GetInstance()
 
 bool CArchiveLoader::IsArchiveFile(const std::string& fileName) const
 {
-	const std::string fileExt = FileSystem::GetExtension(fileName);
+	const std::string fileExt = FileSystem::GetExtensionLowerCase(fileName);
 
 	using P = decltype(archiveFactories)::value_type;
 
@@ -62,7 +62,7 @@ IArchive* CArchiveLoader::OpenArchive(const std::string& fileName, const std::st
 {
 	IArchive* ret = nullptr;
 
-	const std::string fileExt = type.empty() ? FileSystem::GetExtension(fileName) : type;
+	const std::string fileExt = type.empty() ? FileSystem::GetExtensionLowerCase(fileName) : type;
 	const std::string filePath = dataDirsAccess.LocateFile(fileName);
 
 	using P = decltype(archiveFactories)::value_type;

--- a/rts/System/FileSystem/ArchiveLoader.cpp
+++ b/rts/System/FileSystem/ArchiveLoader.cpp
@@ -12,8 +12,6 @@
 #include "Archives/SevenZipArchive.h"
 #include "Archives/VirtualArchive.h"
 
-#include "System/StringUtil.h"
-
 #include "FileSystem.h"
 #include "DataDirsAccess.h"
 #include "System/Log/ILog.h"
@@ -49,7 +47,7 @@ const CArchiveLoader& CArchiveLoader::GetInstance()
 
 bool CArchiveLoader::IsArchiveFile(const std::string& fileName) const
 {
-	const std::string fileExt = StringToLower(FileSystem::GetExtension(fileName));
+	const std::string fileExt = FileSystem::GetExtension(fileName);
 
 	using P = decltype(archiveFactories)::value_type;
 
@@ -64,7 +62,7 @@ IArchive* CArchiveLoader::OpenArchive(const std::string& fileName, const std::st
 {
 	IArchive* ret = nullptr;
 
-	const std::string fileExt = type.empty() ? StringToLower(FileSystem::GetExtension(fileName)) : type;
+	const std::string fileExt = type.empty() ? FileSystem::GetExtension(fileName) : type;
 	const std::string filePath = dataDirsAccess.LocateFile(fileName);
 
 	using P = decltype(archiveFactories)::value_type;

--- a/rts/System/FileSystem/ArchiveScanner.cpp
+++ b/rts/System/FileSystem/ArchiveScanner.cpp
@@ -605,7 +605,7 @@ std::string CArchiveScanner::SearchMapFile(const IArchive* ar, std::string& erro
 	// check for smf and if the uncompression of important files is too costy
 	for (uint32_t fid = 0; fid != ar->NumFiles(); ++fid) {
 		const auto& fn = ar->FileName(fid);
-		const std::string ext = FileSystem::GetExtension(StringToLower(fn));
+		const std::string ext = FileSystem::GetExtensionLowerCase(StringToLower(fn));
 
 		if (ext == "smf")
 			return fn;
@@ -832,7 +832,7 @@ bool CArchiveScanner::CheckCachedData(const std::string& fullName, uint32_t& mod
 {
 	// virtual archives do not exist on disk, and thus do not have a modification time
 	// they should still be scanned as normal archives so we only skip the cache-check
-	if (FileSystem::GetExtension(fullName) == "sva")
+	if (FileSystem::GetExtensionLowerCase(fullName) == "sva")
 		return false;
 
 	// if stat fails, assume the archive is not broken nor cached
@@ -1801,7 +1801,7 @@ CArchiveScanner::ArchiveData CArchiveScanner::GetArchiveDataByArchive(const std:
 int CArchiveScanner::GetMetaFileClass(const std::string& filePath)
 {
 	const std::string& lowerFilePath = StringToLower(filePath);
-	// const std::string& ext = FileSystem::GetExtension(lowerFilePath);
+	// const std::string& ext = FileSystem::GetExtensionLowerCase(lowerFilePath);
 	const auto it = metaFileClasses.find(lowerFilePath);
 
 	if (it != metaFileClasses.end())

--- a/rts/System/FileSystem/FileHandler.cpp
+++ b/rts/System/FileSystem/FileHandler.cpp
@@ -269,7 +269,7 @@ bool CFileHandler::LoadStringData(string& data)
 
 std::string CFileHandler::GetFileExt() const
 {
-	return FileSystem::GetExtension(fileName);
+	return FileSystem::GetExtensionLowerCase(fileName);
 }
 
 std::string CFileHandler::GetFileAbsolutePath(const std::string& filePath, const std::string& modes)

--- a/rts/System/FileSystem/FileSystem.cpp
+++ b/rts/System/FileSystem/FileSystem.cpp
@@ -895,7 +895,7 @@ std::string FileSystem::GetBasename(const std::string& pathStr)
 	return Impl::StorePathAsString(p.stem());
 }
 
-std::string FileSystem::GetExtension(const std::string& pathStr)
+std::string FileSystem::GetExtensionLowerCase(const std::string& pathStr)
 {
 	const auto p = Recoil::filesystem::u8path(pathStr);
 	auto ext = p.extension().generic_u8string();

--- a/rts/System/FileSystem/FileSystem.cpp
+++ b/rts/System/FileSystem/FileSystem.cpp
@@ -903,7 +903,7 @@ std::string FileSystem::GetExtension(const std::string& pathStr)
 		return "";
 
 	assert(ext[0] == u8'.');
-	return Impl::StorePathAsString(ext.substr(1, ext.length() - 1));
+	return StringToLower(Impl::StorePathAsString(ext.substr(1, ext.length() - 1)));
 }
 
 std::string FileSystem::GetNormalizedPath(const std::string& path) {

--- a/rts/System/FileSystem/FileSystem.h
+++ b/rts/System/FileSystem/FileSystem.h
@@ -172,7 +172,7 @@ public:
 	 * "/home/user/.spring/test.txt..." -> "txt"
 	 * "/home/user/.spring/test.txt. . ." -> "txt"
 	 */
-	static std::string GetExtension(const std::string& path);
+	static std::string GetExtensionLowerCase(const std::string& path);
 	/**
 	 * Converts the given path into a canonicalized one.
 	 * CAUTION: be careful where using this, as it easily allows to link to

--- a/rts/System/LoadSave/DemoReader.cpp
+++ b/rts/System/LoadSave/DemoReader.cpp
@@ -51,8 +51,8 @@ static bool CheckDemoHeader(const DemoFileHeader& fileHeader)
 
 CDemoReader::CDemoReader(const std::string& filename, float curTime): playbackDemo(new CGZFileHandler(filename, SPRING_VFS_PWD_ALL))
 {
-	if (FileSystem::GetExtension(filename) != "sdfz")
-		throw content_error("Unknown demo extension: " + FileSystem::GetExtension(filename));
+	if (FileSystem::GetExtensionLowerCase(filename) != "sdfz")
+		throw content_error("Unknown demo extension: " + FileSystem::GetExtensionLowerCase(filename));
 
 	// file not found -> exception
 	if (!playbackDemo->FileExists())

--- a/rts/System/LoadSave/LoadSaveHandler.cpp
+++ b/rts/System/LoadSave/LoadSaveHandler.cpp
@@ -12,7 +12,7 @@ SaveFileData globalSaveFileData;
 
 ILoadSaveHandler* ILoadSaveHandler::CreateHandler(const std::string& saveFile)
 {
-	const std::string& ext = FileSystem::GetExtension(saveFile);
+	const std::string& ext = FileSystem::GetExtensionLowerCase(saveFile);
 
 	if (ext == "ssf")
 		return (new CCregLoadSaveHandler());

--- a/rts/System/Platform/Linux/CrashHandler.cpp
+++ b/rts/System/Platform/Linux/CrashHandler.cpp
@@ -183,7 +183,7 @@ static std::string LocateSymbolFile(const std::string& binaryFile)
 
 	const std::string binPath = FileSystem::GetDirectory(binaryFile);
 	const std::string binFile = FileSystem::GetFilename(binaryFile);
-	// const std::string binExt  = FileSystem::GetExtension(binaryFile);
+	// const std::string binExt  = FileSystem::GetExtensionLowerCase(binaryFile);
 
 	if (FileSystem::IsReadableFile(symbolFile = binPath + binFile + ".dbg"))
 		return symbolFile;

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -689,7 +689,7 @@ void SpringApp::LoadSpringMenu()
 void SpringApp::Startup()
 {
 	// bash input
-	const std::string& extension = FileSystem::GetExtension(inputFile);
+	const std::string& extension = FileSystem::GetExtensionLowerCase(inputFile);
 
 	// note: avoid any .get() leaks between here and GameServer!
 	clientSetup.reset(new ClientSetup());

--- a/test/engine/System/FileSystem/TestFileSystem.cpp
+++ b/test/engine/System/FileSystem/TestFileSystem.cpp
@@ -133,6 +133,12 @@ TEST_CASE("GetDirectory")
 }
 
 
+TEST_CASE("GetExtensionLowerCase")
+{
+	CHECK(FileSystem::GetExtensionLowerCase("SCRIPT.COB") == "cob");
+}
+
+
 #define CHECK_NORM_PATH(path, normPath) \
 		CHECK(FileSystem::GetNormalizedPath(path) == normPath)
 

--- a/tools/unitsync/unitsync.cpp
+++ b/tools/unitsync/unitsync.cpp
@@ -604,7 +604,7 @@ static bool internal_GetMapInfo(const char* mapName, InternalMapInfo* outInfo)
 
 	// Retrieve the map header as well
 	if (err.empty()) {
-		const std::string extension = FileSystem::GetExtension(mapFile);
+		const std::string extension = FileSystem::GetExtensionLowerCase(mapFile);
 		if (extension == "smf") {
 			try {
 				const CSMFMapFile file(mapFile);
@@ -972,7 +972,7 @@ EXPORT(unsigned short*) GetMinimap(const char* mapName, int mipLevel)
 		ScopedMapLoader mapLoader(mapName, mapFile);
 
 		unsigned short* ret = nullptr;
-		const std::string extension = FileSystem::GetExtension(mapFile);
+		const std::string extension = FileSystem::GetExtensionLowerCase(mapFile);
 		if (extension == "smf") {
 			ret = GetMinimapSMF(mapFile, mipLevel);
 		} else if (extension == "sm3") {


### PR DESCRIPTION
### Restore lowercasing in `FileSystem::GetExtension`

Fixes #2935.

Restores lowercasing after PR #2235, (``StringToLower`` ), so uppercase extensions like `.COB` still match.

In BAR, unit defs that were using a script path with an uppercase extension (e.g. `script = "Units/CORKARG.COB"`)  would not animate or fire, with no error log.

Bisected to `c3b8b6397a`.

### Test plan

- [x] BAR `corkarg` with unit def script path: ``script = CORKARG.COB`` — animates and fires again.
- [x] `ctest` passes (28/28).

### AI / LLM usage statement:
Claude used to find the source of the script loading issue