### PR TITLE
Implement Custom Color Palette

### DIFF
--- a/cont/base/springcontent/shaders/GLSL/ModelFragProgGL4.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ModelFragProgGL4.glsl
@@ -39,7 +39,7 @@ layout(std140, binding = 1) uniform UniformParamsBuffer {
 	uint mouseUnused;
 	vec4 mouseWorldPos; //x,y,z; w=0 -- offmap. Ignores water, doesn't ignore units/features under the mouse cursor
 
-	vec4 teamColor[255]; //all team colors
+	vec4 teamColor[2048]; // [0..254] team colors, [255] reserved, [256..2047] custom palette
 };
 
 in Data {

--- a/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
@@ -10,7 +10,7 @@ layout (location = 5) in uvec3 bonesInfo; //boneIDsLow, boneWeights, boneIDsHigh
 layout (location = 6) in uvec4 instData;
 // u32 matOffset
 // u32 uniOffset
-// u32 {teamIdx, drawFlag, numPiecesH, numPiecesL}, note numPiecesH then numPiecesL
+// u32 {paletteIndex[0:10], reserved[11:15], numPieces[16:31]}
 // u32 bposeMatOffset
 
 layout(std140, binding = 0) uniform UniformMatrixBuffer {
@@ -80,7 +80,7 @@ layout(std140, binding = 1) uniform UniformParamsBuffer {
 	uint mouseUnused;
 	vec4 mouseWorldPos; //x,y,z; w=0 -- offmap. Ignores water, doesn't ignore units/features under the mouse cursor
 
-	vec4 teamColor[255]; //all team colors
+	vec4 teamColor[2048]; // [0..254] team colors, [255] reserved, [256..2047] custom palette
 };
 
 struct Transform {
@@ -353,8 +353,8 @@ void main(void)
 	gl_ClipDistance[1] = dot(modelPos, clipPlane1); //lower construction clip plane
 	gl_ClipDistance[2] = dot(worldPos, clipPlane2); //water clip plane
 
-	uint teamIndex = (instData.z & 0x000000FFu); //leftmost ubyte is teamIndex
-	teamCol = teamColor[teamIndex];
+	uint paletteIndex = instData.z & 0x07FFu; // mask 11 bits: 0..254 = team, 256..2047 = custom
+	teamCol = teamColor[paletteIndex];
 	teamCol.a = teamColorAlpha;
 
 	uvCoord = uv;

--- a/cont/base/springcontent/shaders/GLSL/ShadowGenVertProgGL4.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ShadowGenVertProgGL4.glsl
@@ -10,7 +10,7 @@ layout (location = 5) in uvec3 bonesInfo; //boneIDsLow, boneWeights, boneIDsHigh
 layout (location = 6) in uvec4 instData;
 // u32 matOffset
 // u32 uniOffset
-// u32 {teamIdx, drawFlag, numPiecesH, numPiecesL}, note numPiecesH then numPiecesL
+// u32 {paletteIndex[0:10], reserved[11:15], numPieces[16:31]}
 // u32 bposeMatOffset
 
 layout(std140, binding = 0) uniform UniformMatrixBuffer {
@@ -80,7 +80,7 @@ layout(std140, binding = 1) uniform UniformParamsBuffer {
 	uint mouseUnused;
 	vec4 mouseWorldPos; //x,y,z; w=0 -- offmap. Ignores water, doesn't ignore units/features under the mouse cursor
 
-	vec4 teamColor[255]; //all team colors
+	vec4 teamColor[2048]; // [0..254] team colors, [255] reserved, [256..2047] custom palette
 };
 
 struct Transform {

--- a/cont/examples/Widgets/gui_custom_unit_color.lua
+++ b/cont/examples/Widgets/gui_custom_unit_color.lua
@@ -1,0 +1,137 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+--
+--  file:    gui_custom_unit_color.lua
+--  brief:   Demonstrates custom unit color palette API
+--  author:  RecoilEngine
+--
+--  Copyright (C) 2026.
+--  Licensed under the terms of the GNU GPL, v2 or later.
+--
+--  Usage:
+--    Select a unit and press 'U' to cycle through custom colors
+--    Press Shift+U to reset to team color
+--
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function widget:GetInfo()
+  return {
+    name      = "CustomUnitColor",
+    desc      = "Demo widget for custom unit color palette API\n" ..
+                "Press U to cycle custom colors, Shift+U to reset",
+    author    = "RecoilEngine",
+    date      = "2026",
+    license   = "GNU GPL, v2 or later",
+    layer     = 0,
+    enabled   = true,
+  }
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+local spGetSelectedUnits      = Spring.GetSelectedUnits
+local spGetUnitPaletteIndex   = Spring.GetUnitPaletteIndex
+local spSetUnitPaletteIndex   = Spring.SetUnitPaletteIndex
+local spGetCustomPaletteColor = Spring.GetCustomPaletteColor
+local spSetCustomPaletteColor = Spring.SetCustomPaletteColor
+local spEcho                  = Spring.Echo
+local spGetKeyCode            = Spring.GetKeyCode
+
+local customColorBase = Spring.GetCustomPaletteColorPaletteBase()
+
+local currentCustomIndex = 0
+
+local keyU = spGetKeyCode("u")
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function widget:Initialize()
+  -- Initialize some custom colors for demonstration
+  -- These are stored at indices 0-7 in the custom palette
+  spSetCustomPaletteColor(0, 1.0, 0.0, 0.0, 1.0) -- Red
+  spSetCustomPaletteColor(1, 0.0, 1.0, 0.0, 1.0) -- Green
+  spSetCustomPaletteColor(2, 0.0, 0.0, 1.0, 1.0) -- Blue
+  spSetCustomPaletteColor(3, 1.0, 1.0, 0.0, 1.0) -- Yellow
+  spSetCustomPaletteColor(4, 1.0, 0.0, 1.0, 1.0) -- Magenta
+  spSetCustomPaletteColor(5, 0.0, 1.0, 1.0, 1.0) -- Cyan
+  spSetCustomPaletteColor(6, 1.0, 0.5, 0.0, 1.0) -- Orange
+  spSetCustomPaletteColor(7, 0.5, 0.0, 1.0, 1.0) -- Purple
+
+  spEcho("[CustomUnitColor] Demo widget loaded")
+  spEcho("[CustomUnitColor] Custom palette starts at index: " .. customColorBase)
+  spEcho("[CustomUnitColor] Select a unit and press U to cycle colors")
+end
+
+--------------------------------------------------------------------------------
+
+function widget:KeyPress(key)
+  local alt, ctrl, meta, shift = Spring.GetModKeyState()
+
+  if key == keyU then  -- 'U' key
+    local selUnits = spGetSelectedUnits()
+    if #selUnits == 0 then
+      spEcho("[CustomUnitColor] No unit selected")
+      return true
+    end
+
+    local unitID = selUnits[1]
+
+    if shift then
+      -- Reset to team color by passing nil
+      spSetUnitPaletteIndex(unitID, nil)
+      local teamID = Spring.GetUnitTeam(unitID)
+      spEcho("[CustomUnitColor] Reset unit " .. unitID .. " to team color (team " .. teamID .. ")")
+    else
+      -- Cycle through custom colors
+      currentCustomIndex = (currentCustomIndex + 1) % 8
+
+      -- Get the color we just set
+      local r, g, b, a = spGetCustomPaletteColor(currentCustomIndex)
+      
+      -- Apply custom color to unit (pass custom index directly)
+      spSetUnitPaletteIndex(unitID, currentCustomIndex)
+      
+      spEcho("[CustomUnitColor] Unit " .. unitID .. " now uses custom color " .. 
+             currentCustomIndex .. ": " ..
+             string.format("%.2f,%.2f,%.2f,%.2f", r, g, b, a))
+    end
+    return true
+  end
+
+  return false
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function widget:IsAbove(x, y)
+  local selUnits = spGetSelectedUnits()
+  if #selUnits == 0 then
+    return false
+  end
+  return true
+end
+
+function widget:GetTooltip(mx, my)
+  local selUnits = spGetSelectedUnits()
+  if #selUnits == 0 then
+    return nil
+  end
+
+  local unitID = selUnits[1]
+  local customIdx = spGetUnitPaletteIndex(unitID)
+  
+  if customIdx == nil then
+    return "Unit " .. unitID .. " uses team color"
+  else
+    local r, g, b, a = spGetCustomPaletteColor(customIdx)
+    return "Unit " .. unitID .. " uses custom color " .. customIdx .. 
+           "\nColor: " .. string.format("%.2f, %.2f, %.2f, %.2f", r, g, b, a)
+  end
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------

--- a/cont/examples/Widgets/gui_custom_unit_color.lua
+++ b/cont/examples/Widgets/gui_custom_unit_color.lua
@@ -39,8 +39,6 @@ local spSetCustomPaletteColor = Spring.SetCustomPaletteColor
 local spEcho                  = Spring.Echo
 local spGetKeyCode            = Spring.GetKeyCode
 
-local customColorBase = Spring.GetCustomPaletteColorPaletteBase()
-
 local currentCustomIndex = 0
 
 local keyU = spGetKeyCode("u")
@@ -61,7 +59,6 @@ function widget:Initialize()
   spSetCustomPaletteColor(7, 0.5, 0.0, 1.0) -- Purple
 
   spEcho("[CustomUnitColor] Demo widget loaded")
-  spEcho("[CustomUnitColor] Custom palette starts at index: " .. customColorBase)
   spEcho("[CustomUnitColor] Select a unit and press U to cycle colors")
 end
 

--- a/cont/examples/Widgets/gui_custom_unit_color.lua
+++ b/cont/examples/Widgets/gui_custom_unit_color.lua
@@ -49,6 +49,7 @@ local keyU = spGetKeyCode("u")
 function widget:Initialize()
   -- Initialize some custom colors for demonstration
   -- These are stored at indices 0-7 in the custom palette
+  assert(Engine.maxCustomPaletteID >= 7)
   spSetCustomPaletteColor(0, 1.0, 0.0, 0.0) -- Red
   spSetCustomPaletteColor(1, 0.0, 1.0, 0.0) -- Green
   spSetCustomPaletteColor(2, 0.0, 0.0, 1.0) -- Blue

--- a/cont/examples/Widgets/gui_custom_unit_color.lua
+++ b/cont/examples/Widgets/gui_custom_unit_color.lua
@@ -51,14 +51,14 @@ local keyU = spGetKeyCode("u")
 function widget:Initialize()
   -- Initialize some custom colors for demonstration
   -- These are stored at indices 0-7 in the custom palette
-  spSetCustomPaletteColor(0, 1.0, 0.0, 0.0, 1.0) -- Red
-  spSetCustomPaletteColor(1, 0.0, 1.0, 0.0, 1.0) -- Green
-  spSetCustomPaletteColor(2, 0.0, 0.0, 1.0, 1.0) -- Blue
-  spSetCustomPaletteColor(3, 1.0, 1.0, 0.0, 1.0) -- Yellow
-  spSetCustomPaletteColor(4, 1.0, 0.0, 1.0, 1.0) -- Magenta
-  spSetCustomPaletteColor(5, 0.0, 1.0, 1.0, 1.0) -- Cyan
-  spSetCustomPaletteColor(6, 1.0, 0.5, 0.0, 1.0) -- Orange
-  spSetCustomPaletteColor(7, 0.5, 0.0, 1.0, 1.0) -- Purple
+  spSetCustomPaletteColor(0, 1.0, 0.0, 0.0) -- Red
+  spSetCustomPaletteColor(1, 0.0, 1.0, 0.0) -- Green
+  spSetCustomPaletteColor(2, 0.0, 0.0, 1.0) -- Blue
+  spSetCustomPaletteColor(3, 1.0, 1.0, 0.0) -- Yellow
+  spSetCustomPaletteColor(4, 1.0, 0.0, 1.0) -- Magenta
+  spSetCustomPaletteColor(5, 0.0, 1.0, 1.0) -- Cyan
+  spSetCustomPaletteColor(6, 1.0, 0.5, 0.0) -- Orange
+  spSetCustomPaletteColor(7, 0.5, 0.0, 1.0) -- Purple
 
   spEcho("[CustomUnitColor] Demo widget loaded")
   spEcho("[CustomUnitColor] Custom palette starts at index: " .. customColorBase)
@@ -89,14 +89,14 @@ function widget:KeyPress(key)
       currentCustomIndex = (currentCustomIndex + 1) % 8
 
       -- Get the color we just set
-      local r, g, b, a = spGetCustomPaletteColor(currentCustomIndex)
+      local r, g, b = spGetCustomPaletteColor(currentCustomIndex)
       
       -- Apply custom color to unit (pass custom index directly)
       spSetUnitPaletteIndex(unitID, currentCustomIndex)
       
       spEcho("[CustomUnitColor] Unit " .. unitID .. " now uses custom color " .. 
              currentCustomIndex .. ": " ..
-             string.format("%.2f,%.2f,%.2f,%.2f", r, g, b, a))
+             string.format("%.2f,%.2f,%.2f", r, g, b))
     end
     return true
   end
@@ -127,9 +127,9 @@ function widget:GetTooltip(mx, my)
   if customIdx == nil then
     return "Unit " .. unitID .. " uses team color"
   else
-    local r, g, b, a = spGetCustomPaletteColor(customIdx)
+    local r, g, b = spGetCustomPaletteColor(customIdx)
     return "Unit " .. unitID .. " uses custom color " .. customIdx .. 
-           "\nColor: " .. string.format("%.2f, %.2f, %.2f, %.2f", r, g, b, a)
+           "\nColor: " .. string.format("%.2f, %.2f, %.2f", r, g, b)
   end
 end
 

--- a/rts/Lua/LuaConstEngine.cpp
+++ b/rts/Lua/LuaConstEngine.cpp
@@ -4,10 +4,9 @@
 #include "LuaHandle.h"
 #include "LuaUtils.h"
 #include "Game/GameVersion.h"
-#include "System/Config/ConfigHandler.h"
 #include "System/Platform/Misc.h"
 #include "Rendering/Fonts/glFont.h"
-#include "Rendering/Fonts/FontHandler.h"
+#include "Sim/Misc/CustomColorPalette.h"
 
 /******************************************************************************
  * Engine constants
@@ -64,6 +63,7 @@ bool LuaConstEngine::PushEntries(lua_State* L)
 		LuaPushNamedBool(L, "isHeadless", SpringVersion::IsHeadless());
 
 	LuaPushNamedNumber(L, "gameSpeed", GAME_SPEED);
+	LuaPushNamedNumber(L, "maxCustomPaletteID", MAX_CUSTOM_COLORS - 1);
 
 	/* If possible, entries should be bools that resolve to false in the "old" version
 	 * and to true in the "new" version; this is because any version beforehand has it

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -3033,7 +3033,7 @@ int LuaUnsyncedCtrl::SetUnitPaletteIndex(lua_State* L)
 	if (customIndex < 0 || customIndex >= MAX_CUSTOM_COLORS)
 		return 0;
 
-	unit->paletteIndex = static_cast<uint16_t>(CUSTOM_COLOR_PALETTE_BASE + customIndex);
+	unit->paletteIndex = CCustomColorPalette::EncodePaletteIndex(static_cast<uint16_t>(customIndex));
 	return 0;
 }
 
@@ -3062,7 +3062,7 @@ int LuaUnsyncedCtrl::SetFeaturePaletteIndex(lua_State* L)
 	if (customIndex < 0 || customIndex >= MAX_CUSTOM_COLORS)
 		return 0;
 
-	feature->paletteIndex = static_cast<uint16_t>(CUSTOM_COLOR_PALETTE_BASE + customIndex);
+	feature->paletteIndex = CCustomColorPalette::EncodePaletteIndex(static_cast<uint16_t>(customIndex));
 	return 0;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -66,6 +66,8 @@
 #include "Sim/Features/FeatureDefHandler.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "Sim/Misc/TeamHandler.h"
+#include "Sim/Misc/GlobalConstants.h"
+#include "Sim/Misc/CustomColorPalette.h"
 #include "Sim/Projectiles/Projectile.h"
 #include "Sim/Projectiles/ProjectileHandler.h"
 #include "Sim/Units/Unit.h"
@@ -174,6 +176,10 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(DrawUnitCommands);
 
 	REGISTER_LUA_CFUNC(SetTeamColor);
+
+	REGISTER_LUA_CFUNC(SetCustomPaletteColor);
+	REGISTER_LUA_CFUNC(SetUnitPaletteIndex);
+	REGISTER_LUA_CFUNC(SetFeaturePaletteIndex);
 
 	REGISTER_LUA_CFUNC(AssignMouseCursor);
 	REGISTER_LUA_CFUNC(ReplaceMouseCursor);
@@ -2975,6 +2981,88 @@ int LuaUnsyncedCtrl::SetTeamColor(lua_State* L)
 	team->color[1] = (unsigned char)(std::clamp(luaL_checkfloat(L, 3      ), 0.0f, 1.0f) * 255.0f);
 	team->color[2] = (unsigned char)(std::clamp(luaL_checkfloat(L, 4      ), 0.0f, 1.0f) * 255.0f);
 	team->color[3] = (unsigned char)(std::clamp(luaL_optfloat  (L, 5, 1.0f), 0.0f, 1.0f) * 255.0f);
+	return 0;
+}
+
+
+/***
+ *
+ * @function Spring.SetCustomPaletteColor
+ * @param index integer 0-based index into custom palette (0..1791, maps to palette slots 256..2047)
+ * @param r number
+ * @param g number
+ * @param b number
+ * @return nil
+ */
+int LuaUnsyncedCtrl::SetCustomPaletteColor(lua_State* L)
+{
+	const int index = luaL_checkint(L, 1);
+	if (index < 0 || index >= MAX_CUSTOM_COLORS)
+		return 0;
+
+	const float r = std::clamp(luaL_checkfloat(L, 2), 0.0f, 1.0f);
+	const float g = std::clamp(luaL_checkfloat(L, 3), 0.0f, 1.0f);
+	const float b = std::clamp(luaL_checkfloat(L, 4), 0.0f, 1.0f);
+
+	customColorPalette.SetColor(static_cast<uint16_t>(index), r, g, b);
+	return 0;
+}
+
+
+/***
+ * Sets a custom color for a unit from the palette. Custom assignments are permanent
+ * until explicitly reset by passing nil, and are NOT affected by team changes.
+ * @function Spring.SetUnitPaletteIndex
+ * @param unitID integer
+ * @param customIndex integer? [0..MAX_CUSTOM_COLORS) index into custom palette, or nil to reset to team color
+ * @return nil
+ */
+int LuaUnsyncedCtrl::SetUnitPaletteIndex(lua_State* L)
+{
+	const int unitID = luaL_checkint(L, 1);
+	CUnit* unit = unitHandler.GetUnit(unitID);
+	if (unit == nullptr)
+		return 0;
+
+	if (lua_isnoneornil(L, 2)) {
+		unit->paletteIndex = static_cast<uint16_t>(unit->team);
+		return 0;
+	}
+
+	const int customIndex = luaL_checkint(L, 2);
+	if (customIndex < 0 || customIndex >= MAX_CUSTOM_COLORS)
+		return 0;
+
+	unit->paletteIndex = static_cast<uint16_t>(CUSTOM_COLOR_PALETTE_BASE + customIndex);
+	return 0;
+}
+
+
+/***
+ * Sets a custom color for a feature from the palette. Custom assignments are permanent
+ * until explicitly reset by passing nil, and are NOT affected by team changes.
+ * @function Spring.SetFeaturePaletteIndex
+ * @param featureID integer
+ * @param customIndex integer? [0..MAX_CUSTOM_COLORS) index into custom palette, or nil to reset to team color
+ * @return nil
+ */
+int LuaUnsyncedCtrl::SetFeaturePaletteIndex(lua_State* L)
+{
+	const int featureID = luaL_checkint(L, 1);
+	CFeature* feature = featureHandler.GetFeature(featureID);
+	if (feature == nullptr)
+		return 0;
+
+	if (lua_isnoneornil(L, 2)) {
+		feature->paletteIndex = static_cast<uint16_t>(feature->team);
+		return 0;
+	}
+
+	const int customIndex = luaL_checkint(L, 2);
+	if (customIndex < 0 || customIndex >= MAX_CUSTOM_COLORS)
+		return 0;
+
+	feature->paletteIndex = static_cast<uint16_t>(CUSTOM_COLOR_PALETTE_BASE + customIndex);
 	return 0;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2996,15 +2996,13 @@ int LuaUnsyncedCtrl::SetTeamColor(lua_State* L)
  */
 int LuaUnsyncedCtrl::SetCustomPaletteColor(lua_State* L)
 {
-	const auto index = static_cast<uint16_t>(luaL_checkint(L, 1));
-	if (!CCustomColorPalette::IsValidIndex(index))
-		luaL_error(L, "[%s] paletteID has to be [0; %d)\n", __func__, MAX_CUSTOM_COLORS);
+	const auto customIndex = LuaUtils::ParsePalette(L, 1);
 
 	const float r = std::clamp(luaL_checkfloat(L, 2), 0.0f, 1.0f);
 	const float g = std::clamp(luaL_checkfloat(L, 3), 0.0f, 1.0f);
 	const float b = std::clamp(luaL_checkfloat(L, 4), 0.0f, 1.0f);
 
-	customColorPalette.SetColor(index, r, g, b);
+	customColorPalette.SetColor(customIndex, r, g, b);
 	return 0;
 }
 
@@ -3029,11 +3027,8 @@ int LuaUnsyncedCtrl::SetUnitPaletteIndex(lua_State* L)
 		return 0;
 	}
 
-	const int customIndex = luaL_checkint(L, 2);
-	if (customIndex < 0 || customIndex >= MAX_CUSTOM_COLORS)
-		return 0;
-
-	unit->paletteIndex = CCustomColorPalette::EncodePaletteIndex(static_cast<uint16_t>(customIndex));
+	const auto customIndex = LuaUtils::ParsePalette(L, 2);
+	unit->paletteIndex = CCustomColorPalette::EncodePaletteIndex(customIndex);
 	return 0;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2996,15 +2996,15 @@ int LuaUnsyncedCtrl::SetTeamColor(lua_State* L)
  */
 int LuaUnsyncedCtrl::SetCustomPaletteColor(lua_State* L)
 {
-	const int index = luaL_checkint(L, 1);
-	if (index < 0 || index >= MAX_CUSTOM_COLORS)
-		return 0;
+	const auto index = static_cast<uint16_t>(luaL_checkint(L, 1));
+	if (!CCustomColorPalette::IsValidIndex(index))
+		luaL_error(L, "[%s] paletteID has to be [0; %d)\n", __func__, MAX_CUSTOM_COLORS);
 
 	const float r = std::clamp(luaL_checkfloat(L, 2), 0.0f, 1.0f);
 	const float g = std::clamp(luaL_checkfloat(L, 3), 0.0f, 1.0f);
 	const float b = std::clamp(luaL_checkfloat(L, 4), 0.0f, 1.0f);
 
-	customColorPalette.SetColor(static_cast<uint16_t>(index), r, g, b);
+	customColorPalette.SetColor(index, r, g, b);
 	return 0;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -68,6 +68,10 @@ class LuaUnsyncedCtrl {
 
 		static int SetTeamColor(lua_State* L);
 
+		static int SetCustomPaletteColor(lua_State* L);
+		static int SetUnitPaletteIndex(lua_State* L);
+		static int SetFeaturePaletteIndex(lua_State* L);
+
 		static int AssignMouseCursor(lua_State* L);
 		static int ReplaceMouseCursor(lua_State* L);
 

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3327,11 +3327,11 @@ int LuaUnsyncedRead::GetTeamOrigColor(lua_State* L)
  */
 int LuaUnsyncedRead::GetCustomPaletteColor(lua_State* L)
 {
-	const int index = luaL_checkint(L, 1);
-	if (index < 0 || index >= MAX_CUSTOM_COLORS)
+	const auto index = static_cast<uint16_t>(luaL_checkint(L, 1));
+	if (!CCustomColorPalette::IsValidIndex(index))
 		return 0;
 
-	const float4 color = customColorPalette.GetColor(static_cast<uint16_t>(index));
+	const float4 color = customColorPalette.GetColor(index);
 	lua_pushnumber(L, color.x);
 	lua_pushnumber(L, color.y);
 	lua_pushnumber(L, color.z);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -182,8 +182,6 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetCustomPaletteColor);
 	REGISTER_LUA_CFUNC(GetUnitPaletteIndex);
 	REGISTER_LUA_CFUNC(GetFeaturePaletteIndex);
-	REGISTER_LUA_CFUNC(GetCustomPaletteColorPaletteBase);
-
 	REGISTER_LUA_CFUNC(GetLocalPlayerID);
 	REGISTER_LUA_CFUNC(GetLocalTeamID);
 	REGISTER_LUA_CFUNC(GetLocalAllyTeamID);
@@ -3379,21 +3377,6 @@ int LuaUnsyncedRead::GetFeaturePaletteIndex(lua_State* L)
 	} else {
 		lua_pushnil(L);
 	}
-	return 1;
-}
-
-
-/***
- * Returns the starting palette index for custom colors (256).
- * Primarily useful for GL4 shaders that need to compute the UBO offset
- * into the teamColor array for custom palette entries.
- *
- * @function Spring.GetCustomPaletteColorPaletteBase
- * @return integer paletteBase The starting index for custom colors (256)
- */
-int LuaUnsyncedRead::GetCustomPaletteColorPaletteBase(lua_State* L)
-{
-	lua_pushnumber(L, CUSTOM_COLOR_PALETTE_BASE);
 	return 1;
 }
 

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3325,11 +3325,9 @@ int LuaUnsyncedRead::GetTeamOrigColor(lua_State* L)
  */
 int LuaUnsyncedRead::GetCustomPaletteColor(lua_State* L)
 {
-	const auto index = static_cast<uint16_t>(luaL_checkint(L, 1));
-	if (!CCustomColorPalette::IsValidIndex(index))
-		return 0;
+	const auto customIndex = LuaUtils::ParsePalette(L, 1);
+	const float4 color = customColorPalette.GetColor(customIndex);
 
-	const float4 color = customColorPalette.GetColor(index);
 	lua_pushnumber(L, color.x);
 	lua_pushnumber(L, color.y);
 	lua_pushnumber(L, color.z);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3350,8 +3350,8 @@ int LuaUnsyncedRead::GetUnitPaletteIndex(lua_State* L)
 	if (unit == nullptr)
 		return 0;
 
-	if (unit->paletteIndex >= CUSTOM_COLOR_PALETTE_BASE) {
-		lua_pushnumber(L, unit->paletteIndex - CUSTOM_COLOR_PALETTE_BASE);
+	if (CCustomColorPalette::IsCustomPaletteIndex(unit->paletteIndex)) {
+		lua_pushnumber(L, CCustomColorPalette::DecodePaletteIndex(unit->paletteIndex));
 	} else {
 		lua_pushnil(L);
 	}
@@ -3372,8 +3372,8 @@ int LuaUnsyncedRead::GetFeaturePaletteIndex(lua_State* L)
 	if (feature == nullptr)
 		return 0;
 
-	if (feature->paletteIndex >= CUSTOM_COLOR_PALETTE_BASE) {
-		lua_pushnumber(L, feature->paletteIndex - CUSTOM_COLOR_PALETTE_BASE);
+	if (CCustomColorPalette::IsCustomPaletteIndex(feature->paletteIndex)) {
+		lua_pushnumber(L, CCustomColorPalette::DecodePaletteIndex(feature->paletteIndex));
 	} else {
 		lua_pushnil(L);
 	}

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -52,6 +52,8 @@
 #include "Sim/Misc/LosHandler.h"
 #include "Sim/Misc/ModInfo.h"
 #include "Sim/Misc/TeamHandler.h"
+#include "Sim/Misc/GlobalConstants.h"
+#include "Sim/Misc/CustomColorPalette.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Projectiles/Projectile.h"
 #include "Sim/Units/Unit.h"
@@ -176,6 +178,11 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(GetTeamColor);
 	REGISTER_LUA_CFUNC(GetTeamOrigColor);
+
+	REGISTER_LUA_CFUNC(GetCustomPaletteColor);
+	REGISTER_LUA_CFUNC(GetUnitPaletteIndex);
+	REGISTER_LUA_CFUNC(GetFeaturePaletteIndex);
+	REGISTER_LUA_CFUNC(GetCustomPaletteColorPaletteBase);
 
 	REGISTER_LUA_CFUNC(GetLocalPlayerID);
 	REGISTER_LUA_CFUNC(GetLocalTeamID);
@@ -3307,6 +3314,87 @@ int LuaUnsyncedRead::GetTeamOrigColor(lua_State* L)
 	lua_pushnumber(L, team->origColor[2] / 255.0f);
 	lua_pushnumber(L, team->origColor[3] / 255.0f);
 	return 4;
+}
+
+
+/***
+ *
+ * @function Spring.GetCustomPaletteColor
+ * @param index integer 0-based index into custom palette
+ * @return number? r factor from 0 to 1
+ * @return number? g factor from 0 to 1
+ * @return number? b factor from 0 to 1
+ */
+int LuaUnsyncedRead::GetCustomPaletteColor(lua_State* L)
+{
+	const int index = luaL_checkint(L, 1);
+	if (index < 0 || index >= MAX_CUSTOM_COLORS)
+		return 0;
+
+	const float4 color = customColorPalette.GetColor(static_cast<uint16_t>(index));
+	lua_pushnumber(L, color.x);
+	lua_pushnumber(L, color.y);
+	lua_pushnumber(L, color.z);
+	return 3;
+}
+
+
+/***
+ * Returns the custom palette index for a unit, or nil if using team color.
+ * @function Spring.GetUnitPaletteIndex
+ * @param unitID integer
+ * @return integer? customIndex [0..MAX_CUSTOM_COLORS) if unit uses a custom color, nil if using team color
+ */
+int LuaUnsyncedRead::GetUnitPaletteIndex(lua_State* L)
+{
+	const int unitID = luaL_checkint(L, 1);
+	const CUnit* unit = unitHandler.GetUnit(unitID);
+	if (unit == nullptr)
+		return 0;
+
+	if (unit->paletteIndex >= CUSTOM_COLOR_PALETTE_BASE) {
+		lua_pushnumber(L, unit->paletteIndex - CUSTOM_COLOR_PALETTE_BASE);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+
+/***
+ * Returns the custom palette index for a feature, or nil if using team color.
+ * @function Spring.GetFeaturePaletteIndex
+ * @param featureID integer
+ * @return integer? customIndex [0..MAX_CUSTOM_COLORS) if feature uses a custom color, nil if using team color
+ */
+int LuaUnsyncedRead::GetFeaturePaletteIndex(lua_State* L)
+{
+	const int featureID = luaL_checkint(L, 1);
+	const CFeature* feature = featureHandler.GetFeature(featureID);
+	if (feature == nullptr)
+		return 0;
+
+	if (feature->paletteIndex >= CUSTOM_COLOR_PALETTE_BASE) {
+		lua_pushnumber(L, feature->paletteIndex - CUSTOM_COLOR_PALETTE_BASE);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+
+/***
+ * Returns the starting palette index for custom colors (256).
+ * Primarily useful for GL4 shaders that need to compute the UBO offset
+ * into the teamColor array for custom palette entries.
+ *
+ * @function Spring.GetCustomPaletteColorPaletteBase
+ * @return integer paletteBase The starting index for custom colors (256)
+ */
+int LuaUnsyncedRead::GetCustomPaletteColorPaletteBase(lua_State* L)
+{
+	lua_pushnumber(L, CUSTOM_COLOR_PALETTE_BASE);
+	return 1;
 }
 
 

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -95,6 +95,11 @@ class LuaUnsyncedRead {
 		static int GetTeamColor(lua_State* L);
 		static int GetTeamOrigColor(lua_State* L);
 
+		static int GetCustomPaletteColor(lua_State* L);
+		static int GetUnitPaletteIndex(lua_State* L);
+		static int GetFeaturePaletteIndex(lua_State* L);
+		static int GetCustomPaletteColorPaletteBase(lua_State* L);
+
 		static int GetLocalPlayerID(lua_State* L);
 		static int GetLocalTeamID(lua_State* L);
 		static int GetLocalAllyTeamID(lua_State* L);

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -98,8 +98,6 @@ class LuaUnsyncedRead {
 		static int GetCustomPaletteColor(lua_State* L);
 		static int GetUnitPaletteIndex(lua_State* L);
 		static int GetFeaturePaletteIndex(lua_State* L);
-		static int GetCustomPaletteColorPaletteBase(lua_State* L);
-
 		static int GetLocalPlayerID(lua_State* L);
 		static int GetLocalTeamID(lua_State* L);
 		static int GetLocalAllyTeamID(lua_State* L);

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -18,6 +18,7 @@
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/CommandAI/CommandDescription.h"
+#include "Sim/Misc/CustomColorPalette.h"
 #include "Sim/Misc/LosHandler.h"
 #include "System/FileSystem/FileSystem.h"
 #include "System/Log/ILog.h"
@@ -2011,4 +2012,13 @@ void LuaUtils::TracyRemoveAlsoExtras(char* script)
 			script += 18;
 	}
 #endif
+}
+
+uint16_t LuaUtils::ParsePalette(lua_State* L, int index)
+{
+	const int paletteID = static_cast<uint16_t>(luaL_checkint(L, index));
+	if (!CCustomColorPalette::IsValidIndex(paletteID))
+		luaL_error(L, "[%s] paletteID has to be [0; %d)\n", __func__, MAX_CUSTOM_COLORS);
+
+	return paletteID;
 }

--- a/rts/Lua/LuaUtils.h
+++ b/rts/Lua/LuaUtils.h
@@ -3,6 +3,7 @@
 #ifndef LUA_UTILS_H
 #define LUA_UTILS_H
 
+#include <cstdint>
 #include <string>
 
 #include <fmt/printf.h>
@@ -150,6 +151,7 @@ class LuaUtils {
 		// (implementation copied from lua/src/lib/lbaselib.c)
 		static int Echo(lua_State* L);
 		static int ParseLogLevel(lua_State* L, int index);
+		static uint16_t ParsePalette(lua_State* L, int index);
 		static int Log(lua_State* L);
 		static bool PushLogEntries(lua_State* L);
 

--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -1006,9 +1006,9 @@ size_t LuaVBOImpl::MatrixDataFromProjectileIDsImpl(const Iterable& ids, int attr
 }
 
 template<typename TObj>
-SInstanceData LuaVBOImpl::InstanceDataFromGetData(int id, int attrID, uint8_t defTeamID)
+SInstanceData LuaVBOImpl::InstanceDataFromGetData(int id, int attrID, uint16_t defPaletteIndex)
 {
-	uint32_t teamID = defTeamID;
+	uint16_t paletteIndex = defPaletteIndex;
 
 	const TObj* obj = LuaUtils::SolIdToObject<TObj>(id, __func__);
 	const uint32_t traOffset = static_cast<uint32_t>(transformsUploader.GetElemOffset(obj));
@@ -1018,10 +1018,8 @@ SInstanceData LuaVBOImpl::InstanceDataFromGetData(int id, int attrID, uint8_t de
 		LuaUtils::SolLuaError("[LuaVBOImpl::%s] Invalid data supplied. See infolog for details", __func__);
 	}
 
-	uint8_t drawFlags = 0u;
 	if constexpr (std::is_same_v<TObj, CUnit> || std::is_same_v<TObj, CFeature>) {
-		teamID = obj->team;
-		drawFlags = obj->drawFlag;
+		paletteIndex = obj->paletteIndex;
 	}
 
 	uint16_t numPieces = 0;
@@ -1035,16 +1033,16 @@ SInstanceData LuaVBOImpl::InstanceDataFromGetData(int id, int attrID, uint8_t de
 		bposeIndex = transformsUploader.GetElemOffset(obj->model);
 	}
 
-	return SInstanceData(traOffset, teamID, drawFlags, numPieces, uniIndex, bposeIndex);
+	return SInstanceData(traOffset, paletteIndex, numPieces, uniIndex, bposeIndex);
 }
 
 template<typename TObj>
-size_t LuaVBOImpl::InstanceDataFromImpl(int id, int attrID, uint8_t defTeamID, const sol::optional<int>& elemOffsetOpt)
+size_t LuaVBOImpl::InstanceDataFromImpl(int id, int attrID, uint16_t defPaletteIndex, const sol::optional<int>& elemOffsetOpt)
 {
 	InstanceBufferCheckAndFormatCheck(attrID, __func__);
 
 	const uint32_t elemOffset = elemOffsetOpt.value_or(0u);
-	const SInstanceData instanceData = InstanceDataFromGetData<TObj>(id, attrID, defTeamID);
+	const SInstanceData instanceData = InstanceDataFromGetData<TObj>(id, attrID, defPaletteIndex);
 
 	if (elemOffset + 1 > elementsCount || elemOffset < 0)
 		LuaUtils::SolLuaError("[LuaVBOImpl::%s] Element offset (%u) is too big or negative", __func__, elemOffset);
@@ -1057,7 +1055,7 @@ size_t LuaVBOImpl::InstanceDataFromImpl(int id, int attrID, uint8_t defTeamID, c
 }
 
 template<typename TObj>
-size_t LuaVBOImpl::InstanceDataFromImpl(const sol::stack_table& ids, int attrID, uint8_t defTeamID, const sol::optional<int>& elemOffsetOpt)
+size_t LuaVBOImpl::InstanceDataFromImpl(const sol::stack_table& ids, int attrID, uint16_t defPaletteIndex, const sol::optional<int>& elemOffsetOpt)
 {
 	InstanceBufferCheckAndFormatCheck(attrID, __func__);
 
@@ -1078,7 +1076,7 @@ size_t LuaVBOImpl::InstanceDataFromImpl(const sol::stack_table& ids, int attrID,
 	for (std::size_t i = 0u; i < idsSize; ++i) {
 		lua_Number idLua = ids.raw_get_or<lua_Number>(i + 1, defaultValue);
 		int id = spring::SafeCast<int, lua_Number>(idLua);
-		const SInstanceData instanceData = InstanceDataFromGetData<TObj>(id, attrID, defTeamID);
+		const SInstanceData instanceData = InstanceDataFromGetData<TObj>(id, attrID, defPaletteIndex);
 		memcpy(&instanceDataVec[4 * i], &instanceData, sizeof(SInstanceData));
 	}
 
@@ -1198,14 +1196,14 @@ size_t LuaVBOImpl::ModelsVBO()
  * The instance data in that attribute will contain the offset to bind position
  * matrix in global matrices SSBO and offset to uniform buffer structure in
  * global per unit/feature uniform SSBO (unused for Unit/FeatureDefs), as
- * well as some auxiliary data ushc as draw flags and team index.
+ * well as some auxiliary data such as palette index and number of pieces.
  * 
  * Data Layout:
  * ```
  * SInstanceData:
  *    , traOffset{ matOffset_ }            // updated during the following draw frames
  *    , uniOffset{ uniOffset_ }            // updated during the following draw frames
- *    , info{ teamIndex, drawFlags, 0, 0 } // not updated during the following draw frames
+ *    , info{ paletteIndex, numPieces } // not updated during the following draw frames
  *    , aux1 { 0u }
  * ```
  *
@@ -1219,14 +1217,14 @@ size_t LuaVBOImpl::ModelsVBO()
  */
 size_t LuaVBOImpl::InstanceDataFromUnitDefIDs(int id, int attrID, sol::optional<int> teamIdOpt, sol::optional<int> elemOffsetOpt)
 {
-	uint8_t defTeamID = teamIdOpt.value_or(gu->myTeam);
-	return InstanceDataFromImpl<UnitDef>(id, attrID, defTeamID, elemOffsetOpt);
+	uint16_t defPaletteIndex = static_cast<uint16_t>(teamIdOpt.value_or(gu->myTeam));
+	return InstanceDataFromImpl<UnitDef>(id, attrID, defPaletteIndex, elemOffsetOpt);
 }
 
 size_t LuaVBOImpl::InstanceDataFromUnitDefIDs(const sol::stack_table& ids, int attrID, sol::optional<int> teamIdOpt, sol::optional<int> elemOffsetOpt)
 {
-	uint8_t defTeamID = teamIdOpt.value_or(gu->myTeam);
-	return InstanceDataFromImpl<UnitDef>(ids, attrID, defTeamID, elemOffsetOpt);
+	uint16_t defPaletteIndex = static_cast<uint16_t>(teamIdOpt.value_or(gu->myTeam));
+	return InstanceDataFromImpl<UnitDef>(ids, attrID, defPaletteIndex, elemOffsetOpt);
 }
 
 
@@ -1237,14 +1235,14 @@ size_t LuaVBOImpl::InstanceDataFromUnitDefIDs(const sol::stack_table& ids, int a
  * The instance data in that attribute will contain the offset to bind position
  * matrix in global matrices SSBO and offset to uniform buffer structure in
  * global per unit/feature uniform SSBO (unused for Unit/FeatureDefs), as
- * well as some auxiliary data ushc as draw flags and team index.
+ * well as some auxiliary data such as palette index and number of pieces.
  * 
  * Data Layout
  * ```
  * SInstanceData:
  *    , traOffset{ matOffset_ }            // updated during the following draw frames
  *    , uniOffset{ uniOffset_ }            // updated during the following draw frames
- *    , info{ teamIndex, drawFlags, 0, 0 } // not updated during the following draw frames
+ *    , info{ paletteIndex, numPieces } // not updated during the following draw frames
  *    , aux1 { 0u }
  * ```
  *
@@ -1258,14 +1256,14 @@ size_t LuaVBOImpl::InstanceDataFromUnitDefIDs(const sol::stack_table& ids, int a
  */
 size_t LuaVBOImpl::InstanceDataFromFeatureDefIDs(int id, int attrID, sol::optional<int> teamIdOpt, sol::optional<int> elemOffsetOpt)
 {
-	uint8_t defTeamID = teamIdOpt.value_or(gu->myTeam);
-	return InstanceDataFromImpl<FeatureDef>(id, attrID, defTeamID, elemOffsetOpt);
+	uint16_t defPaletteIndex = static_cast<uint16_t>(teamIdOpt.value_or(gu->myTeam));
+	return InstanceDataFromImpl<FeatureDef>(id, attrID, defPaletteIndex, elemOffsetOpt);
 }
 
 size_t LuaVBOImpl::InstanceDataFromFeatureDefIDs(const sol::stack_table& ids, int attrID, sol::optional<int> teamIdOpt, sol::optional<int> elemOffsetOpt)
 {
-	uint8_t defTeamID = teamIdOpt.value_or(gu->myTeam);
-	return InstanceDataFromImpl<FeatureDef>(ids, attrID, defTeamID, elemOffsetOpt);
+	uint16_t defPaletteIndex = static_cast<uint16_t>(teamIdOpt.value_or(gu->myTeam));
+	return InstanceDataFromImpl<FeatureDef>(ids, attrID, defPaletteIndex, elemOffsetOpt);
 }
 
 
@@ -1276,7 +1274,7 @@ size_t LuaVBOImpl::InstanceDataFromFeatureDefIDs(const sol::stack_table& ids, in
  * The instance data in that attribute will contain the offset to bind position
  * matrix in global matrices SSBO and offset to uniform buffer structure in
  * global per unit/feature uniform SSBO (unused for Unit/FeatureDefs), as
- * well as some auxiliary data ushc as draw flags and team index.
+ * well as some auxiliary data such as palette index and number of pieces.
  * 
  * Data Layout
  *
@@ -1284,7 +1282,7 @@ size_t LuaVBOImpl::InstanceDataFromFeatureDefIDs(const sol::stack_table& ids, in
  * SInstanceData:
  *    , traOffset{ matOffset_ }            // updated during the following draw frames
  *    , uniOffset{ uniOffset_ }            // updated during the following draw frames
- *    , info{ teamIndex, drawFlags, 0, 0 } // not updated during the following draw frames
+ *    , info{ paletteIndex, numPieces } // not updated during the following draw frames
  *    , aux1 { 0u }
  * ```
  *
@@ -1314,7 +1312,7 @@ size_t LuaVBOImpl::InstanceDataFromUnitIDs(const sol::stack_table& ids, int attr
  * The instance data in that attribute will contain the offset to bind position
  * matrix in global matrices SSBO and offset to uniform buffer structure in
  * global per unit/feature uniform SSBO (unused for Unit/FeatureDefs), as
- * well as some auxiliary data ushc as draw flags and team index.
+ * well as some auxiliary data such as palette index and number of pieces.
  *
  * @param featureIDs number|number[]
  * @param attrID integer

--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -1201,8 +1201,8 @@ size_t LuaVBOImpl::ModelsVBO()
  * Data Layout:
  * ```
  * SInstanceData:
- *    , traOffset{ matOffset_ }            // updated during the following draw frames
- *    , uniOffset{ uniOffset_ }            // updated during the following draw frames
+ *    , traOffset{ matOffset_ }         // updated during the following draw frames
+ *    , uniOffset{ uniOffset_ }         // updated during the following draw frames
  *    , info{ paletteIndex, numPieces } // not updated during the following draw frames
  *    , aux1 { 0u }
  * ```
@@ -1240,8 +1240,8 @@ size_t LuaVBOImpl::InstanceDataFromUnitDefIDs(const sol::stack_table& ids, int a
  * Data Layout
  * ```
  * SInstanceData:
- *    , traOffset{ matOffset_ }            // updated during the following draw frames
- *    , uniOffset{ uniOffset_ }            // updated during the following draw frames
+ *    , traOffset{ matOffset_ }         // updated during the following draw frames
+ *    , uniOffset{ uniOffset_ }         // updated during the following draw frames
  *    , info{ paletteIndex, numPieces } // not updated during the following draw frames
  *    , aux1 { 0u }
  * ```
@@ -1280,8 +1280,8 @@ size_t LuaVBOImpl::InstanceDataFromFeatureDefIDs(const sol::stack_table& ids, in
  *
  * ```
  * SInstanceData:
- *    , traOffset{ matOffset_ }            // updated during the following draw frames
- *    , uniOffset{ uniOffset_ }            // updated during the following draw frames
+ *    , traOffset{ matOffset_ }         // updated during the following draw frames
+ *    , uniOffset{ uniOffset_ }         // updated during the following draw frames
  *    , info{ paletteIndex, numPieces } // not updated during the following draw frames
  *    , aux1 { 0u }
  * ```

--- a/rts/Lua/LuaVBOImpl.h
+++ b/rts/Lua/LuaVBOImpl.h
@@ -81,13 +81,13 @@ private:
 	inline void InstanceBufferCheckAndFormatCheck(int attrID, const char* func);
 
 	template<typename TObj>
-	static SInstanceData InstanceDataFromGetData(int id, int attrID, uint8_t defTeamID);
+	static SInstanceData InstanceDataFromGetData(int id, int attrID, uint16_t defPaletteIndex);
 
 	template<typename TObj>
-	size_t InstanceDataFromImpl(int id, int attrID, uint8_t defTeamID, const sol::optional<int>& elemOffsetOpt);
+	size_t InstanceDataFromImpl(int id, int attrID, uint16_t defPaletteIndex, const sol::optional<int>& elemOffsetOpt);
 
 	template<typename TObj>
-	size_t InstanceDataFromImpl(const sol::stack_table& ids, int attrID, uint8_t defTeamID, const sol::optional<int>& elemOffsetOpt);
+	size_t InstanceDataFromImpl(const sol::stack_table& ids, int attrID, uint16_t defPaletteIndex, const sol::optional<int>& elemOffsetOpt);
 
 	template<typename Iterable>
 	size_t MatrixDataFromProjectileIDsImpl(const Iterable& ids, int attrID, sol::optional<int> elemOffsetOpt, const char* func);

--- a/rts/Rendering/Common/ModelDrawerData.h
+++ b/rts/Rendering/Common/ModelDrawerData.h
@@ -208,6 +208,7 @@ inline void CModelDrawerDataBase<T>::UpdateObjectUniforms(const T* o)
 
 	if (gu->spectatingFullView || o->IsInLosForAllyTeam(gu->myAllyTeam)) {
 		uni.id = o->id;
+		uni.teamID = o->team;
 		// TODO remove drawPos, replace with pos
 		uni.drawPos = float4{ o->drawPos, o->heading * math::PI / SPRING_MAX_HEADING };
 		uni.speed = o->speed;

--- a/rts/Rendering/GL/myGL.h
+++ b/rts/Rendering/GL/myGL.h
@@ -143,18 +143,16 @@ struct SDrawElementsIndirectCommand {
 
 struct SInstanceData {
 	SInstanceData() = default;
-	SInstanceData(uint32_t matOffset_, uint8_t teamIndex, uint8_t drawFlags, uint16_t numPieces, uint32_t uniOffset_, uint32_t bposeMatOffset_)
-		: matOffset{ matOffset_ }                         // updated during the following draw frames
-		, uniOffset{ uniOffset_ }                         // updated during the following draw frames
-		, info{ teamIndex, drawFlags                      // not updated during the following draw frames
-			, static_cast<uint8_t>((numPieces >> 8) & 0xFF)
-			, static_cast<uint8_t>((numPieces     ) & 0xFF) }
-		, bposeMatOffset { bposeMatOffset_ }              // updated during the following draw frames
+	SInstanceData(uint32_t matOffset_, uint16_t auxInfo_, uint16_t numPieces_, uint32_t uniOffset_, uint32_t bposeMatOffset_)
+		: matOffset{ matOffset_ }            // updated during the following draw frames
+		, uniOffset{ uniOffset_ }            // updated during the following draw frames
+		, info{ auxInfo_, numPieces_ }       // not updated during the following draw frames
+		, bposeMatOffset { bposeMatOffset_ } // updated during the following draw frames
 	{}
 
 	uint32_t matOffset;
 	uint32_t uniOffset;
-	std::array<uint8_t, 4> info;
+	std::array<uint16_t, 2> info; // u32 {paletteIndex[0:10], reserved[11:15], numPieces[16:31]}
 	uint32_t bposeMatOffset;
 };
 

--- a/rts/Rendering/Models/3DModelVAO.cpp
+++ b/rts/Rendering/Models/3DModelVAO.cpp
@@ -287,7 +287,7 @@ void S3DModelVAO::DrawElements(GLenum prim, uint32_t vboIndxStart, uint32_t vboI
 }
 
 template<typename TObj>
-bool S3DModelVAO::AddToSubmissionImpl(const TObj* obj, uint32_t indexStart, uint32_t indexCount, uint8_t teamID, uint8_t drawFlags)
+bool S3DModelVAO::AddToSubmissionImpl(const TObj* obj, uint32_t indexStart, uint32_t indexCount, uint16_t paletteIndex)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const auto traIndex = transformsUploader.GetElemOffset(obj);
@@ -313,8 +313,7 @@ bool S3DModelVAO::AddToSubmissionImpl(const TObj* obj, uint32_t indexStart, uint
 	auto& modelInstanceData = modelDataToInstance[SIndexAndCount{ indexStart, indexCount }];
 	modelInstanceData.emplace_back(SInstanceData(
 		static_cast<uint32_t>(traIndex),
-		teamID,
-		drawFlags,
+		paletteIndex,
 		numPieces,
 		static_cast<uint32_t>(uniIndex),
 		static_cast<uint32_t>(bposeIndex)
@@ -323,12 +322,12 @@ bool S3DModelVAO::AddToSubmissionImpl(const TObj* obj, uint32_t indexStart, uint
 	return true;
 }
 
-bool S3DModelVAO::AddToSubmission(const S3DModel* model, uint8_t teamID, uint8_t drawFlags)
+bool S3DModelVAO::AddToSubmission(const S3DModel* model, uint16_t paletteIndex)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	assert(model);
 
-	return AddToSubmissionImpl(model, model->indxStart, model->indxCount, teamID, drawFlags);
+	return AddToSubmissionImpl(model, model->indxStart, model->indxCount, paletteIndex);
 }
 
 bool S3DModelVAO::AddToSubmission(const CUnit* unit)
@@ -339,7 +338,7 @@ bool S3DModelVAO::AddToSubmission(const CUnit* unit)
 	const S3DModel* model = unit->model;
 	assert(model);
 
-	return AddToSubmissionImpl(unit, model->indxStart, model->indxCount, unit->team, unit->drawFlag);
+	return AddToSubmissionImpl(unit, model->indxStart, model->indxCount, unit->paletteIndex);
 }
 
 bool S3DModelVAO::AddToSubmission(const CFeature* feature)
@@ -350,10 +349,10 @@ bool S3DModelVAO::AddToSubmission(const CFeature* feature)
 	const S3DModel* model = feature->model;
 	assert(model);
 
-	return AddToSubmissionImpl(feature, model->indxStart, model->indxCount, feature->team, feature->drawFlag);
+	return AddToSubmissionImpl(feature, model->indxStart, model->indxCount, feature->paletteIndex);
 }
 
-bool S3DModelVAO::AddToSubmission(const UnitDef* unitDef, uint8_t teamID)
+bool S3DModelVAO::AddToSubmission(const UnitDef* unitDef, uint16_t paletteIndex)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	assert(unitDef);
@@ -361,7 +360,7 @@ bool S3DModelVAO::AddToSubmission(const UnitDef* unitDef, uint8_t teamID)
 	const S3DModel* model = unitDef->model;
 	assert(model);
 
-	return AddToSubmissionImpl(unitDef, model->indxStart, model->indxCount, teamID, 0);
+	return AddToSubmissionImpl(unitDef, model->indxStart, model->indxCount, paletteIndex);
 }
 
 
@@ -414,7 +413,7 @@ void S3DModelVAO::Submit(GLenum mode, bool bindUnbind)
 }
 
 template<typename TObj>
-bool S3DModelVAO::SubmitImmediatelyImpl(const TObj* obj, uint32_t indexStart, uint32_t indexCount, uint8_t teamID, uint8_t drawFlags, GLenum mode, bool bindUnbind)
+bool S3DModelVAO::SubmitImmediatelyImpl(const TObj* obj, uint32_t indexStart, uint32_t indexCount, uint16_t paletteIndex, GLenum mode, bool bindUnbind)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	std::size_t traIndex = transformsUploader.GetElemOffset(obj);
@@ -434,7 +433,7 @@ bool S3DModelVAO::SubmitImmediatelyImpl(const TObj* obj, uint32_t indexStart, ui
 		bposeIndex = transformsUploader.GetElemOffset(obj->model);
 	}
 
-	SInstanceData instanceData(static_cast<uint32_t>(traIndex), teamID, drawFlags, numPieces, uniIndex, bposeIndex);
+	SInstanceData instanceData(static_cast<uint32_t>(traIndex), paletteIndex, numPieces, uniIndex, bposeIndex);
 	const uint32_t immediateBaseInstanceAbs = INSTANCE_BUFFER_NUM_BATCHED + immediateBaseInstance;
 
 	static SDrawElementsIndirectCommand scmd;
@@ -469,11 +468,11 @@ bool S3DModelVAO::SubmitImmediatelyImpl(const TObj* obj, uint32_t indexStart, ui
 	return true;
 }
 
-bool S3DModelVAO::SubmitImmediately(const S3DModel* model, uint8_t teamID, uint8_t drawFlags, GLenum mode, bool bindUnbind)
+bool S3DModelVAO::SubmitImmediately(const S3DModel* model, uint16_t paletteIndex, GLenum mode, bool bindUnbind)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	assert(model);
-	return SubmitImmediatelyImpl(model, model->indxStart, model->indxCount, teamID, drawFlags, mode, bindUnbind);
+	return SubmitImmediatelyImpl(model, model->indxStart, model->indxCount, paletteIndex, mode, bindUnbind);
 }
 
 bool S3DModelVAO::SubmitImmediately(const CUnit* unit, const GLenum mode, bool bindUnbind)
@@ -484,7 +483,7 @@ bool S3DModelVAO::SubmitImmediately(const CUnit* unit, const GLenum mode, bool b
 	const S3DModel* model = unit->model;
 	assert(model);
 
-	return SubmitImmediatelyImpl(unit, model->indxStart, model->indxCount, unit->team, unit->drawFlag, mode, bindUnbind);
+	return SubmitImmediatelyImpl(unit, model->indxStart, model->indxCount, unit->paletteIndex, mode, bindUnbind);
 }
 
 bool S3DModelVAO::SubmitImmediately(const CFeature* feature, GLenum mode, bool bindUnbind)
@@ -495,7 +494,7 @@ bool S3DModelVAO::SubmitImmediately(const CFeature* feature, GLenum mode, bool b
 	const S3DModel* model = feature->model;
 	assert(model);
 
-	return SubmitImmediatelyImpl(feature, model->indxStart, model->indxCount, feature->team, feature->drawFlag, mode, bindUnbind);
+	return SubmitImmediatelyImpl(feature, model->indxStart, model->indxCount, feature->paletteIndex, mode, bindUnbind);
 }
 
 bool S3DModelVAO::SubmitImmediately(const UnitDef* unitDef, int teamID, GLenum mode, bool bindUnbind)
@@ -506,5 +505,5 @@ bool S3DModelVAO::SubmitImmediately(const UnitDef* unitDef, int teamID, GLenum m
 	const S3DModel* model = unitDef->model;
 	assert(model);
 
-	return SubmitImmediatelyImpl(unitDef, model->indxStart, model->indxCount, teamID, 0, mode, bindUnbind);
+	return SubmitImmediatelyImpl(unitDef, model->indxStart, model->indxCount, static_cast<uint16_t>(teamID), mode, bindUnbind);
 }

--- a/rts/Rendering/Models/3DModelVAO.hpp
+++ b/rts/Rendering/Models/3DModelVAO.hpp
@@ -65,15 +65,15 @@ public:
 
 	void DrawElements(GLenum prim, uint32_t vboIndxStart, uint32_t vboIndxCount) const;
 
-	bool AddToSubmission(const S3DModel* model, uint8_t teamID, uint8_t drawFlags);
+	bool AddToSubmission(const S3DModel* model, uint16_t paletteIndex);
 
 	bool AddToSubmission(const CUnit* unit);
 	bool AddToSubmission(const CFeature* feature);
 
-	bool AddToSubmission(const UnitDef* unitDef, uint8_t teamID);
+	bool AddToSubmission(const UnitDef* unitDef, uint16_t paletteIndex);
 	void Submit(GLenum mode = GL_TRIANGLES, bool bindUnbind = false);
 
-	bool SubmitImmediately(const S3DModel* model, uint8_t teamID, uint8_t drawFlags, GLenum mode = GL_TRIANGLES, bool bindUnbind = false);
+	bool SubmitImmediately(const S3DModel* model, uint16_t paletteIndex, GLenum mode = GL_TRIANGLES, bool bindUnbind = false);
 	bool SubmitImmediately(const CUnit* unit, GLenum mode = GL_TRIANGLES, bool bindUnbind = false);
 	bool SubmitImmediately(const CFeature* feature, GLenum mode = GL_TRIANGLES, bool bindUnbind = false);
 	bool SubmitImmediately(const UnitDef* unitDef, int teamID, GLenum mode = GL_TRIANGLES, bool bindUnbind = false);
@@ -91,8 +91,7 @@ private:
 		const TObj* obj,
 		uint32_t indexStart,
 		uint32_t indexCount,
-		uint8_t teamID,
-		uint8_t drawFlags,
+		uint16_t paletteIndex,
 		GLenum mode = GL_TRIANGLES,
 		bool bindUnbind = false
 	);
@@ -101,8 +100,7 @@ private:
 		const TObj* obj,
 		uint32_t indexStart,
 		uint32_t indexCount,
-		uint8_t teamID,
-		uint8_t drawFlags
+		uint16_t paletteIndex
 	);
 	void EnableAttribs(bool inst) const;
 	void DisableAttribs() const;

--- a/rts/Rendering/Models/ModelsMemStorageDefs.cpp
+++ b/rts/Rendering/Models/ModelsMemStorageDefs.cpp
@@ -12,15 +12,14 @@
 CR_BIND(ModelUniformData, )
 CR_REG_METADATA(ModelUniformData, (
 	CR_MEMBER_BEGINFLAG(CM_NoSerialize),
-
-		CR_MEMBER(composite),
-		CR_MEMBER(unused2),
-		CR_MEMBER(unused3),
+		CR_MEMBER(composite1),
+		CR_MEMBER(composite2),
 		CR_MEMBER(unused4),
+		CR_MEMBER(unused5),
 		CR_MEMBER(maxHealth),
 		CR_MEMBER(health),
-		CR_MEMBER(unused5),
 		CR_MEMBER(unused6),
+		CR_MEMBER(unused7),
 		CR_MEMBER(drawPos),
 		CR_MEMBER(speed),
 		CR_MEMBER(userDefined),

--- a/rts/Rendering/Models/ModelsMemStorageDefs.h
+++ b/rts/Rendering/Models/ModelsMemStorageDefs.h
@@ -9,7 +9,7 @@ public:
 	static constexpr int MAX_MODEL_UD_UNIFORMS = 16;
 
 	union {
-		uint32_t composite;
+		uint32_t composite1;
 		struct {
 			uint8_t drawFlag;
 			uint8_t unused1;
@@ -17,14 +17,22 @@ public:
 		};
 	};
 
-	uint32_t unused2;
-	uint32_t unused3;
+	union {
+		uint32_t composite2;
+		struct {
+			uint8_t teamID;
+			uint8_t unused2;
+			uint16_t unused3;
+		};
+	};
+
 	uint32_t unused4;
+	uint32_t unused5;
 
 	float maxHealth;
 	float health;
-	float unused5;
 	float unused6;
+	float unused7;
 
 	float4 drawPos;
 	float4 speed;

--- a/rts/Rendering/UniformConstants.cpp
+++ b/rts/Rendering/UniformConstants.cpp
@@ -301,7 +301,7 @@ void UniformConstants::UpdateParamsImpl(UniformParamsBuffer* updateBuffer)
 	}
 
 	for (int i = 0; i < MAX_CUSTOM_COLORS; ++i) {
-		updateBuffer->teamColor[CUSTOM_COLOR_PALETTE_BASE + i] = customColorPalette.GetColor(i);
+		updateBuffer->teamColor[CCustomColorPalette::EncodePaletteIndex(i)] = customColorPalette.GetColor(i);
 	}
 }
 

--- a/rts/Rendering/UniformConstants.cpp
+++ b/rts/Rendering/UniformConstants.cpp
@@ -18,6 +18,7 @@
 #include "Sim/Features/Feature.h"
 #include "Sim/Misc/GlobalConstants.h"
 #include "Sim/Misc/GlobalSynced.h"
+#include "Sim/Misc/CustomColorPalette.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Misc/Wind.h"
 #include "Map/ReadMap.h"
@@ -297,6 +298,10 @@ void UniformConstants::UpdateParamsImpl(UniformParamsBuffer* updateBuffer)
 			continue;
 
 		updateBuffer->teamColor[teamID] = float4{team->color[0] / 255.0f, team->color[1] / 255.0f, team->color[2] / 255.0f, team->color[3] / 255.0f};
+	}
+
+	for (int i = 0; i < MAX_CUSTOM_COLORS; ++i) {
+		updateBuffer->teamColor[CUSTOM_COLOR_PALETTE_BASE + i] = customColorPalette.GetColor(i);
 	}
 }
 

--- a/rts/Rendering/UniformConstants.h
+++ b/rts/Rendering/UniformConstants.h
@@ -12,6 +12,7 @@
 #include "System/SpringMath.h"
 #include "System/creg/creg.h"
 #include "Sim/Misc/GlobalConstants.h"
+#include "Sim/Misc/CustomColorPalette.h"
 #include "Rendering/GL/myGL.h"
 #include "Rendering/GL/StreamBuffer.h"
 

--- a/rts/Rendering/UniformConstants.h
+++ b/rts/Rendering/UniformConstants.h
@@ -11,6 +11,7 @@
 #include "System/Matrix44f.h"
 #include "System/SpringMath.h"
 #include "System/creg/creg.h"
+#include "Sim/Misc/GlobalConstants.h"
 #include "Rendering/GL/myGL.h"
 #include "Rendering/GL/StreamBuffer.h"
 
@@ -87,7 +88,7 @@ struct UniformParamsBuffer {
 	uint32_t mouseUnused;
 	float4 mouseWorldPos; //x,y,z; w=0 -- offmap. Ignores water, doesn't ignore units/features under the mouse cursor
 
-	float4 teamColor[MAX_TEAMS]; //all team colors
+	float4 teamColor[MAX_PALETTE_COLORS]; // [0..254] = team, [255] = reserved, [256..2047] = custom
 };
 
 class UniformConstants {

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -1598,7 +1598,7 @@ void CUnitDrawerGL4::DrawBuildIcons(const std::vector<CCursorIcons::BuildIcon>& 
 			CModelDrawerHelper::BindModelTypeTexture(model->type, model->textureType); //inefficient rendering, but w/e
 		}
 
-		smv.SubmitImmediately(model, buildIcon.team, DrawFlags::SO_ALPHAF_FLAG);
+		smv.SubmitImmediately(model, static_cast<uint16_t>(buildIcon.team));
 	}
 
 	if (prevModelType != -1)
@@ -1769,7 +1769,7 @@ void CUnitDrawerGL4::DrawAlphaObjects(int modelType, bool drawReflection, bool d
 			}
 
 			modelDrawerState->SetStaticModelMatrix(staticWorldMat);
-			smv.SubmitImmediately(dgb->GetModel(), dgb->team, DrawFlags::SO_ALPHAF_FLAG); //need to submit immediately every model because of static per-model matrix
+			smv.SubmitImmediately(dgb->GetModel(), static_cast<uint16_t>(dgb->team)); //need to submit immediately every model because of static per-model matrix
 		}
 	}
 
@@ -1823,7 +1823,7 @@ void CUnitDrawerGL4::DrawAlphaObjects(int modelType, bool drawReflection, bool d
 			}
 
 			modelDrawerState->SetStaticModelMatrix(staticWorldMat);
-			smv.SubmitImmediately(model, lgb->team, DrawFlags::SO_ALPHAF_FLAG); //need to submit immediately every model because of static per-model matrix
+			smv.SubmitImmediately(model, static_cast<uint16_t>(lgb->team)); //need to submit immediately every model because of static per-model matrix
 		}
 	}
 
@@ -1876,7 +1876,7 @@ void CUnitDrawerGL4::DrawAlphaAIUnit(const CUnitDrawerData::TempDrawUnit& unit) 
 	SetTeamColor(unit.team, IModelDrawerState::alphaValues.x);
 	modelDrawerState->SetStaticModelMatrix(staticWorldMat);
 
-	smv.SubmitImmediately(mdl, unit.team, DrawFlags::SO_ALPHAF_FLAG);
+	smv.SubmitImmediately(mdl, static_cast<uint16_t>(unit.team));
 }
 
 void CUnitDrawerGL4::DrawOpaqueObjectsAux(int modelType) const
@@ -1923,7 +1923,7 @@ void CUnitDrawerGL4::DrawOpaqueAIUnit(const CUnitDrawerData::TempDrawUnit& unit)
 	SetTeamColor(unit.team);
 	modelDrawerState->SetStaticModelMatrix(staticWorldMat);
 
-	smv.SubmitImmediately(mdl, unit.team, DrawFlags::SO_OPAQUE_FLAG);
+	smv.SubmitImmediately(mdl, static_cast<uint16_t>(unit.team));
 }
 
 void CUnitDrawerGL4::DrawUnitModelBeingBuiltShadow(const CUnit* unit, bool noLuaCall) const

--- a/rts/Sim/CMakeLists.txt
+++ b/rts/Sim/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(engineSim STATIC
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/CollisionHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/CollisionVolume.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/CommonDefHandler.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/CustomColorPalette.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/DamageArray.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/DamageArrayHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/DefinitionTag.cpp"

--- a/rts/Sim/Features/Feature.cpp
+++ b/rts/Sim/Features/Feature.cpp
@@ -161,6 +161,7 @@ void CFeature::Initialize(const FeatureLoadParams& params)
 	id = params.featureID;
 
 	team = params.teamID;
+	paletteIndex = static_cast<uint16_t>(team);
 	allyteam = params.allyTeamID;
 
 	heading = params.heading;

--- a/rts/Sim/Misc/CustomColorPalette.cpp
+++ b/rts/Sim/Misc/CustomColorPalette.cpp
@@ -1,0 +1,49 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "CustomColorPalette.h"
+
+#include <algorithm>
+
+CCustomColorPalette customColorPalette;
+
+void CCustomColorPalette::Init()
+{
+	if (initialized)
+		return;
+
+	for (auto& c : colors)
+		c = float4{1.0f, 1.0f, 1.0f, 1.0f};
+
+	initialized = true;
+}
+
+void CCustomColorPalette::Kill()
+{
+	initialized = false;
+}
+
+void CCustomColorPalette::SetColor(uint16_t index, float r, float g, float b)
+{
+	if (!IsValidIndex(index))
+		return;
+
+	colors[index] = float4{
+		std::clamp(r, 0.0f, 1.0f),
+		std::clamp(g, 0.0f, 1.0f),
+		std::clamp(b, 0.0f, 1.0f),
+		1.0f
+	};
+}
+
+float4 CCustomColorPalette::GetColor(uint16_t index) const
+{
+	if (!IsValidIndex(index))
+		return {1.0f, 1.0f, 1.0f, 1.0f};
+
+	return colors[index];
+}
+
+bool CCustomColorPalette::IsValidIndex(uint16_t index) const
+{
+	return index < MAX_CUSTOM_COLORS;
+}

--- a/rts/Sim/Misc/CustomColorPalette.cpp
+++ b/rts/Sim/Misc/CustomColorPalette.cpp
@@ -43,7 +43,7 @@ float4 CCustomColorPalette::GetColor(uint16_t index) const
 	return colors[index];
 }
 
-bool CCustomColorPalette::IsValidIndex(uint16_t index) const
+bool CCustomColorPalette::IsValidIndex(uint16_t index)
 {
 	return index < MAX_CUSTOM_COLORS;
 }

--- a/rts/Sim/Misc/CustomColorPalette.cpp
+++ b/rts/Sim/Misc/CustomColorPalette.cpp
@@ -43,7 +43,3 @@ float4 CCustomColorPalette::GetColor(uint16_t index) const
 	return colors[index];
 }
 
-bool CCustomColorPalette::IsValidIndex(uint16_t index)
-{
-	return index < MAX_CUSTOM_COLORS;
-}

--- a/rts/Sim/Misc/CustomColorPalette.h
+++ b/rts/Sim/Misc/CustomColorPalette.h
@@ -1,0 +1,29 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "Sim/Misc/GlobalConstants.h"
+#include "System/float4.h"
+
+class CCustomColorPalette {
+public:
+	void Init();
+	void Kill();
+
+	void SetColor(uint16_t index, float r, float g, float b);
+	float4 GetColor(uint16_t index) const;
+	bool IsValidIndex(uint16_t index) const;
+
+	static CCustomColorPalette& GetInstance() {
+		static CCustomColorPalette instance;
+		return instance;
+	}
+
+private:
+	std::array<float4, MAX_CUSTOM_COLORS> colors{};
+	bool initialized = false;
+};
+
+extern CCustomColorPalette customColorPalette;

--- a/rts/Sim/Misc/CustomColorPalette.h
+++ b/rts/Sim/Misc/CustomColorPalette.h
@@ -14,7 +14,7 @@ public:
 
 	void SetColor(uint16_t index, float r, float g, float b);
 	float4 GetColor(uint16_t index) const;
-	bool IsValidIndex(uint16_t index) const;
+	static bool IsValidIndex(uint16_t index);
 
 	static CCustomColorPalette& GetInstance() {
 		static CCustomColorPalette instance;

--- a/rts/Sim/Misc/CustomColorPalette.h
+++ b/rts/Sim/Misc/CustomColorPalette.h
@@ -16,6 +16,18 @@ public:
 	float4 GetColor(uint16_t index) const;
 	static bool IsValidIndex(uint16_t index);
 
+	static uint16_t EncodePaletteIndex(uint16_t customIndex) {
+		return CUSTOM_COLOR_PALETTE_BASE + customIndex;
+	}
+
+	static uint16_t DecodePaletteIndex(uint16_t paletteIndex) {
+		return paletteIndex - CUSTOM_COLOR_PALETTE_BASE;
+	}
+
+	static bool IsCustomPaletteIndex(uint16_t paletteIndex) {
+		return paletteIndex >= CUSTOM_COLOR_PALETTE_BASE;
+	}
+
 	static CCustomColorPalette& GetInstance() {
 		static CCustomColorPalette instance;
 		return instance;

--- a/rts/Sim/Misc/CustomColorPalette.h
+++ b/rts/Sim/Misc/CustomColorPalette.h
@@ -4,8 +4,11 @@
 #include <array>
 #include <cstdint>
 
-#include "Sim/Misc/GlobalConstants.h"
 #include "System/float4.h"
+
+static constexpr int MAX_PALETTE_COLORS = 2048;
+static constexpr int CUSTOM_COLOR_PALETTE_BASE = 256; // first custom color index (power of 2 aligned)
+static constexpr int MAX_CUSTOM_COLORS  = MAX_PALETTE_COLORS - CUSTOM_COLOR_PALETTE_BASE; // 1792
 
 class CCustomColorPalette {
 public:
@@ -14,7 +17,7 @@ public:
 
 	void SetColor(uint16_t index, float r, float g, float b);
 	float4 GetColor(uint16_t index) const;
-	static bool IsValidIndex(uint16_t index);
+	static bool IsValidIndex(uint16_t index) { return index < MAX_CUSTOM_COLORS; }
 
 	static uint16_t EncodePaletteIndex(uint16_t customIndex) {
 		return CUSTOM_COLOR_PALETTE_BASE + customIndex;

--- a/rts/Sim/Misc/GlobalConstants.h
+++ b/rts/Sim/Misc/GlobalConstants.h
@@ -76,6 +76,10 @@ static constexpr int TEAM_SLOWUPDATE_RATE = 30;
  */
 static constexpr int MAX_TEAMS = 255;
 
+static constexpr int MAX_PALETTE_COLORS = 2048;
+static constexpr int CUSTOM_COLOR_PALETTE_BASE = 256; // first custom color index (power of 2 aligned)
+static constexpr int MAX_CUSTOM_COLORS  = MAX_PALETTE_COLORS - CUSTOM_COLOR_PALETTE_BASE; // 1792
+
 /**
  * @brief max players
  *

--- a/rts/Sim/Misc/GlobalConstants.h
+++ b/rts/Sim/Misc/GlobalConstants.h
@@ -76,9 +76,6 @@ static constexpr int TEAM_SLOWUPDATE_RATE = 30;
  */
 static constexpr int MAX_TEAMS = 255;
 
-static constexpr int MAX_PALETTE_COLORS = 2048;
-static constexpr int CUSTOM_COLOR_PALETTE_BASE = 256; // first custom color index (power of 2 aligned)
-static constexpr int MAX_CUSTOM_COLORS  = MAX_PALETTE_COLORS - CUSTOM_COLOR_PALETTE_BASE; // 1792
 
 /**
  * @brief max players

--- a/rts/Sim/Objects/SolidObject.h
+++ b/rts/Sim/Objects/SolidObject.h
@@ -388,6 +388,10 @@ public:
 	///< allyteam that this->team is part of
 	int allyteam = 0;
 
+	///< Palette index for color lookup in the teamColor UBO (0..254 = team color, 256..2047 = custom).
+	///< Custom values are permanent until explicitly reset via Lua, and are NOT affected by team changes.
+	uint16_t paletteIndex = 0;
+
 	// useful to track the objects that just got created
 	int creationFrame = -1;
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -221,6 +221,7 @@ void CUnit::PreInit(const UnitLoadParams& params)
 	}
 
 	team = params.teamID;
+	paletteIndex = static_cast<uint16_t>(team);
 	allyteam = teamHandler.AllyTeam(team);
 
 	buildFacing = std::abs(params.facing) % NUM_FACINGS;
@@ -1561,6 +1562,8 @@ bool CUnit::ChangeTeam(int newteam, ChangeType type)
 
 
 	team = newteam;
+	if (paletteIndex == static_cast<uint16_t>(oldteam))
+		paletteIndex = static_cast<uint16_t>(newteam);
 	allyteam = teamHandler.AllyTeam(newteam);
 	neutral = false;
 


### PR DESCRIPTION
## Description
This PR implements a custom color palette system for the engine, allowing for unit-specific color overrides independently of team colors.

### Key Changes
- Introduced `CustomColorPalette` class to manage 1792 custom color slots (256-2047).
- Added `paletteIndex` to `CSolidObject` (units and features), defaulting to team ID.
- Updated GL4 model shaders (`ModelVertProgGL4.glsl`, etc.) to use an 11-bit palette index for color lookups in the `teamColor` UBO.
- Expanded `teamColor` UBO array size to 2048 in both engine and shaders.
- Added Lua APIs:
  - `Spring.SetCustomPaletteColor(index, r, g, b)`
  - `Spring.GetCustomPaletteColor(index)`
  - `Spring.SetUnitPaletteIndex(unitID, customIndex)`
  - `Spring.GetUnitPaletteIndex(unitID)`
  - `Spring.SetFeaturePaletteIndex(featureID, customIndex)`
  - `Spring.GetFeaturePaletteIndex(featureID)`
- Updated `SInstanceData` to pack `paletteIndex` and `numPieces` into the 32-bit `info` field.
- Added an example widget `gui_custom_unit_color.lua` to demonstrate the functionality.

### Testing
- Verified shader compilation and rendering.
- Tested Lua API functionality with the example widget.
- Ensured team colors still work as default.