### PR TITLE
fix: memory barrier bitfield now pulls from correct parameter

### DIFF
--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -2929,7 +2929,7 @@ int LuaOpenGL::DispatchCompute(lua_State* L)
 
 	glDispatchCompute(numGroupX, numGroupY, numGroupZ);
 
-	GLbitfield barriers = (GLbitfield)luaL_optint(L, 1, 4);
+	GLbitfield barriers = (GLbitfield)luaL_optint(L, 4, 0);
 	//skip checking the correctness of values :)
 
 	if (barriers > 0u)

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -2904,7 +2904,7 @@ int LuaOpenGL::TexRect(lua_State* L)
  * @param numGroupX integer
  * @param numGroupY integer
  * @param numGroupZ integer
- * @param barriers integer? (Default: `4`)
+ * @param barriers integer? (Default: `0`)
  */
 int LuaOpenGL::DispatchCompute(lua_State* L)
 {


### PR DESCRIPTION
## Purpose
Looks like the original code was:

```
int LuaOpenGL::MemoryBarrier(lua_State* L)
{
	GLbitfield barriers = (GLbitfield)luaL_optint(L, 1, 0);
	//skip checking the correctness of values :)

	if (barriers > 0u)
		glMemoryBarrier(barriers);

	return 0;
}
```

and when it was merged here, the `default` parameter  was changed to a 4 instead of the `idx` parameter.

## Discussion

The old code before had the benefit of extra correctness when the param was not passed. We were calling `glMemoryBarrier(0x00000004)` which is the `GL_UNIFORM_BARRIER_BIT`. I'm not familiar enough with the underlying code to know:
1. if removing this default barrier could have some effects where devs forgot to memory barrier
2. if there was any significant performance difference for having this as a memory barrier

## AI Disclosure
A Codex review of related code found this bug :)