### PR TITLE
Draft: Show player in end game box

### DIFF
--- a/rts/Game/UI/EndGameBox.cpp
+++ b/rts/Game/UI/EndGameBox.cpp
@@ -454,6 +454,11 @@ void CEndGameBox::Draw()
 			{
 				const std::vector<float>& statValues = stats[stat1].values[teamNum];
 				addVertices(rbC, statValues, numPoints, scalex, scaley, team->color);
+				if (teamNum == gu->myTeam) {
+					float v1 = calcVertexY(statValues[numPoints - 1], statValues[numPoints - 2]);
+					font->SetTextColor(float(team->color[0])/255.0f, float(team->color[1])/255.0f, float(team->color[2])/255.0f, 1.0f);
+					font->glPrint(box.x2 - 0.028f, box.y1 + 0.08f + v1 * scaley, 0.7f, FONT_VCENTER | FONT_SCALE | FONT_NORM | FONT_BUFFERED, "You");
+				}
 			}
 
 			if (stat2 != -1) {
@@ -479,22 +484,27 @@ void CEndGameBox::addVertices(TypedRenderBuffer<VA_TYPE_C> &rbC, const std::vect
 {
 	float v0 = 0.0f;
 	for (size_t a = 0, n = numPoints - 1; a < n; ++a) {
-		float v1 = 0.0f;
-
-		if (dispMode == 1) {
-			v1 = statValues[a + 1];
-		} else {
-			// deltas
-			v1 = (statValues[a + 1] - statValues[a    ]) / TeamStatistics::statsPeriod;
-		}
-		if (logScale){
-			v1 = v1 <= 1.0f ? 1.0f : v1;
-			v1 = std::log(v1);
-		}
+		float v1 = calcVertexY(statValues[a + 1], statValues[a]);
 		rbC.AddVertex({{box.x1 + 0.15f + (a    ) * scalex, box.y1 + 0.08f + v0 * scaley, 0.0f}, color});
 		rbC.AddVertex({{box.x1 + 0.15f + (a + 1) * scalex, box.y1 + 0.08f + v1 * scaley, 0.0f}, color});
 		v0 = v1;
 	}
+}
+
+float CEndGameBox::calcVertexY(float val, float prevVal)
+{
+	float v = 0.0f;
+	if (dispMode == 1) {
+		v = val;
+	} else {
+		// deltas
+		v = (val - prevVal) / TeamStatistics::statsPeriod;
+	}
+	if (logScale){
+		v = v <= 1.0f ? 1.0f : v;
+		v = std::log(v);
+	}
+	return v;
 }
 
 std::string CEndGameBox::GetTooltip(int x, int y)

--- a/rts/Game/UI/EndGameBox.h
+++ b/rts/Game/UI/EndGameBox.h
@@ -31,6 +31,7 @@ protected:
 	static CEndGameBox* endGameBox;
 	void FillTeamStats();
 	void addVertices(TypedRenderBuffer<VA_TYPE_C> &rbC, const std::vector<float>& statValues, size_t numPoints, float scalex, float scaley, const uint8_t (&color)[4]);
+	float calcVertexY(float, float);
 
 	TRectangle<float> box;
 


### PR DESCRIPTION
When the game is over and my team lost, I sometimes forget what color I was playing. This means I can't find myself in the graphs at the end game screen, because I won't show up in the bottom right corner anymore, once my commander died. Thus I have implemented a little hint, which shows the player the color they were playing directly in the graphs:
<img width="2560" height="1440" alt="color_hint" src="https://github.com/user-attachments/assets/2405ff31-3c03-4ee6-8fe0-8ee8314e8ea2" />

I'm **considering this PR a draft** for now, because:
- Sometimes the hint would be displayed for my opponent instead of me. Is `teamNum == gu->myTeam` not reliable?
- I'm not sure if the hint should also be displayed for `stat2`, because I don't know what that is.