### PR TITLE
Fix missing cstdint include in ChatMessage

### DIFF
--- a/rts/Game/ChatMessage.h
+++ b/rts/Game/ChatMessage.h
@@ -4,6 +4,7 @@
 #define CHAT_MESSAGE_H
 
 #include <memory>
+#include <cstdint>
 #include <string>
 
 namespace netcode {


### PR DESCRIPTION
Later version of gccs is now considerably more strict regarding including  system header files.